### PR TITLE
Add a 'claudio remove <id>' CLI command to stop and remove a specific instance and its worktree

### DIFF
--- a/internal/cmd/remove.go
+++ b/internal/cmd/remove.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/spf13/cobra"
+)
+
+var removeCmd = &cobra.Command{
+	Use:   "remove <id>",
+	Short: "Remove a specific instance and its worktree",
+	Long: `Remove a specific Claude instance, stopping it if running and cleaning up
+its worktree and branch. Use --force to remove even if there are uncommitted changes.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRemove,
+}
+
+var forceRemove bool
+
+func init() {
+	rootCmd.AddCommand(removeCmd)
+	removeCmd.Flags().BoolVarP(&forceRemove, "force", "f", false, "Force removal even with uncommitted changes")
+}
+
+func runRemove(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	instanceID := args[0]
+
+	// Create orchestrator
+	orch, err := orchestrator.New(cwd)
+	if err != nil {
+		return fmt.Errorf("failed to create orchestrator: %w", err)
+	}
+
+	// Load current session
+	session, err := orch.LoadSession()
+	if err != nil {
+		return fmt.Errorf("no active session found: %w", err)
+	}
+
+	// Remove instance
+	if err := orch.RemoveInstance(session, instanceID, forceRemove); err != nil {
+		return fmt.Errorf("failed to remove instance: %w", err)
+	}
+
+	fmt.Printf("Removed instance %s\n", instanceID)
+	return nil
+}


### PR DESCRIPTION
## Summary

Completed by Claudio instance.

## Branch
`claudio/0419f480-add-a-claudio-remove-id-cli-co`