### PR TITLE
feat: add Claude-powered PR creation with smart rebase

### DIFF
--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -1,0 +1,245 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Iron-Ham/claudio/internal/config"
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/pr"
+	"github.com/Iron-Ham/claudio/internal/worktree"
+	"github.com/spf13/cobra"
+)
+
+var prCmd = &cobra.Command{
+	Use:   "pr [instance-id]",
+	Short: "Create a pull request for a Claudio instance",
+	Long: `Create a GitHub pull request for a Claudio instance using Claude to generate
+a meaningful title and description based on the task, code changes, and commit history.
+
+If no instance ID is provided and there's only one instance, it will be used automatically.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runPR,
+}
+
+var (
+	prDraft      bool
+	prNoPush     bool
+	prNoAI       bool
+	prNoRebase   bool
+	prTitle      string
+	prBody       string
+)
+
+func init() {
+	rootCmd.AddCommand(prCmd)
+	prCmd.Flags().BoolVarP(&prDraft, "draft", "d", false, "Create as a draft PR")
+	prCmd.Flags().BoolVar(&prNoPush, "no-push", false, "Don't push the branch before creating the PR")
+	prCmd.Flags().BoolVar(&prNoAI, "no-ai", false, "Skip AI generation, use simple defaults")
+	prCmd.Flags().BoolVar(&prNoRebase, "no-rebase", false, "Skip rebasing on main before creating PR")
+	prCmd.Flags().StringVarP(&prTitle, "title", "t", "", "Override the PR title")
+	prCmd.Flags().StringVarP(&prBody, "body", "b", "", "Override the PR body")
+}
+
+func runPR(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	// Load config for defaults
+	cfg := config.Get()
+
+	// Apply config defaults, then allow flags to override
+	// Note: flags override config when explicitly set
+	useDraft := cfg.PR.Draft
+	if cmd.Flags().Changed("draft") {
+		useDraft = prDraft
+	}
+	useRebase := cfg.PR.AutoRebase
+	if cmd.Flags().Changed("no-rebase") {
+		useRebase = !prNoRebase
+	}
+	useAI := cfg.PR.UseAI
+	if cmd.Flags().Changed("no-ai") {
+		useAI = !prNoAI
+	}
+
+	// Create orchestrator and load session
+	orch, err := orchestrator.New(cwd)
+	if err != nil {
+		return fmt.Errorf("failed to create orchestrator: %w", err)
+	}
+
+	session, err := orch.LoadSession()
+	if err != nil {
+		return fmt.Errorf("no active session found: %w", err)
+	}
+
+	// Find the instance
+	var inst *orchestrator.Instance
+	if len(args) > 0 {
+		inst = session.GetInstance(args[0])
+		if inst == nil {
+			return fmt.Errorf("instance %s not found", args[0])
+		}
+	} else {
+		// If no instance specified, use the only one or error
+		if len(session.Instances) == 0 {
+			return fmt.Errorf("no instances in session")
+		}
+		if len(session.Instances) > 1 {
+			return fmt.Errorf("multiple instances exist, please specify an instance ID")
+		}
+		inst = session.Instances[0]
+	}
+
+	fmt.Printf("Creating PR for instance %s...\n", inst.ID)
+	fmt.Printf("Task: %s\n", inst.Task)
+	fmt.Printf("Branch: %s\n\n", inst.Branch)
+
+	// Create worktree manager
+	wt, err := worktree.New(cwd)
+	if err != nil {
+		return fmt.Errorf("failed to create worktree manager: %w", err)
+	}
+
+	// Check for uncommitted changes
+	hasChanges, err := wt.HasUncommittedChanges(inst.WorktreePath)
+	if err != nil {
+		return fmt.Errorf("failed to check for uncommitted changes: %w", err)
+	}
+	if hasChanges {
+		return fmt.Errorf("instance has uncommitted changes. Please commit or stash them first")
+	}
+
+	// Get changed files
+	changedFiles, err := wt.GetChangedFiles(inst.WorktreePath)
+	if err != nil {
+		return fmt.Errorf("failed to get changed files: %w", err)
+	}
+	if len(changedFiles) == 0 {
+		return fmt.Errorf("no changes to create PR for")
+	}
+
+	fmt.Printf("Changed files: %d\n", len(changedFiles))
+
+	// Check for rebase conflicts and rebase if needed
+	if useRebase {
+		behindCount, err := wt.GetBehindCount(inst.WorktreePath)
+		if err != nil {
+			fmt.Printf("Warning: could not check if branch is behind main: %v\n", err)
+		} else if behindCount > 0 {
+			fmt.Printf("Branch is %d commit(s) behind main, checking for conflicts...\n", behindCount)
+
+			hasConflicts, err := wt.HasRebaseConflicts(inst.WorktreePath)
+			if err != nil {
+				fmt.Printf("Warning: could not check for conflicts: %v\n", err)
+			} else if hasConflicts {
+				return fmt.Errorf("rebasing would cause conflicts. Please resolve manually:\n  cd %s\n  git rebase origin/main\n  # resolve conflicts\n  git rebase --continue", inst.WorktreePath)
+			}
+
+			fmt.Println("Rebasing on main...")
+			if err := wt.RebaseOnMain(inst.WorktreePath); err != nil {
+				return fmt.Errorf("failed to rebase: %w", err)
+			}
+			fmt.Println("Rebase successful!")
+		} else {
+			fmt.Println("Branch is up to date with main.")
+		}
+	}
+
+	// Push branch if needed
+	if !prNoPush {
+		fmt.Println("Pushing branch to remote...")
+		// Force push after rebase (with lease for safety)
+		forceNeeded := useRebase
+		if err := wt.Push(inst.WorktreePath, forceNeeded); err != nil {
+			return fmt.Errorf("failed to push branch: %w", err)
+		}
+	}
+
+	// Generate or use provided PR content
+	var title, body string
+
+	if prTitle != "" && prBody != "" {
+		// User provided both title and body
+		title = prTitle
+		body = prBody
+	} else if !useAI {
+		// Simple defaults without AI
+		title = fmt.Sprintf("feat: %s", truncateString(inst.Task, 60))
+		body = fmt.Sprintf("## Task\n%s\n\n## Changed Files\n", inst.Task)
+		for _, f := range changedFiles {
+			body += fmt.Sprintf("- %s\n", f)
+		}
+	} else {
+		// Use Claude to generate PR content
+		fmt.Println("Generating PR content with Claude...")
+
+		diff, err := wt.GetDiffAgainstMain(inst.WorktreePath)
+		if err != nil {
+			fmt.Printf("Warning: failed to get diff: %v\n", err)
+			diff = ""
+		}
+
+		commitLog, err := wt.GetCommitLog(inst.WorktreePath)
+		if err != nil {
+			fmt.Printf("Warning: failed to get commit log: %v\n", err)
+			commitLog = ""
+		}
+
+		gen := pr.New()
+		content, err := gen.Generate(pr.Context{
+			Task:         inst.Task,
+			Branch:       inst.Branch,
+			Diff:         diff,
+			CommitLog:    commitLog,
+			ChangedFiles: changedFiles,
+			InstanceID:   inst.ID,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to generate PR content: %w", err)
+		}
+
+		title = content.Title
+		body = content.Body
+
+		// Allow overrides
+		if prTitle != "" {
+			title = prTitle
+		}
+		if prBody != "" {
+			body = prBody
+		}
+	}
+
+	fmt.Printf("\nTitle: %s\n", title)
+	fmt.Println("\nBody:")
+	fmt.Println(strings.Repeat("-", 40))
+	fmt.Println(body)
+	fmt.Println(strings.Repeat("-", 40))
+
+	// Create the PR
+	fmt.Println("\nCreating pull request...")
+	var prURL string
+	if useDraft {
+		prURL, err = pr.CreatePRDraft(title, body, inst.Branch)
+	} else {
+		prURL, err = pr.CreatePR(title, body, inst.Branch)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to create PR: %w", err)
+	}
+
+	fmt.Printf("\nPull request created: %s\n", prURL)
+	return nil
+}
+
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	TUI        TUIConfig        `mapstructure:"tui"`
 	Session    SessionConfig    `mapstructure:"session"`
 	Instance   InstanceConfig   `mapstructure:"instance"`
+	PR         PRConfig         `mapstructure:"pr"`
 }
 
 // CompletionConfig controls what happens when an instance completes
@@ -49,6 +50,16 @@ type InstanceConfig struct {
 	TmuxHeight int `mapstructure:"tmux_height"`
 }
 
+// PRConfig controls pull request creation behavior
+type PRConfig struct {
+	// Draft creates PRs as drafts by default
+	Draft bool `mapstructure:"draft"`
+	// AutoRebase rebases on main before creating PR (default: true)
+	AutoRebase bool `mapstructure:"auto_rebase"`
+	// UseAI uses Claude to generate PR title and description (default: true)
+	UseAI bool `mapstructure:"use_ai"`
+}
+
 // Default returns a Config with sensible default values
 func Default() *Config {
 	return &Config{
@@ -67,6 +78,11 @@ func Default() *Config {
 			CaptureIntervalMs: 100,
 			TmuxWidth:         200,
 			TmuxHeight:        50,
+		},
+		PR: PRConfig{
+			Draft:      false,
+			AutoRebase: true,
+			UseAI:      true,
 		},
 	}
 }
@@ -95,6 +111,11 @@ func SetDefaults() {
 	viper.SetDefault("instance.capture_interval_ms", defaults.Instance.CaptureIntervalMs)
 	viper.SetDefault("instance.tmux_width", defaults.Instance.TmuxWidth)
 	viper.SetDefault("instance.tmux_height", defaults.Instance.TmuxHeight)
+
+	// PR defaults
+	viper.SetDefault("pr.draft", defaults.PR.Draft)
+	viper.SetDefault("pr.auto_rebase", defaults.PR.AutoRebase)
+	viper.SetDefault("pr.use_ai", defaults.PR.UseAI)
 }
 
 // Load reads the configuration from viper into a Config struct

--- a/internal/pr/pr.go
+++ b/internal/pr/pr.go
@@ -1,0 +1,167 @@
+package pr
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"text/template"
+)
+
+// PRContent holds the generated PR title and body
+type PRContent struct {
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+// Context holds all the information needed to generate PR content
+type Context struct {
+	Task          string
+	Branch        string
+	Diff          string
+	CommitLog     string
+	ChangedFiles  []string
+	InstanceID    string
+}
+
+// Generator creates PR content using Claude
+type Generator struct{}
+
+// New creates a new PR generator
+func New() *Generator {
+	return &Generator{}
+}
+
+// promptTemplate is the prompt sent to Claude for generating PR content
+const promptTemplate = `You are helping create a pull request. Based on the following information, generate a concise and meaningful PR title and description.
+
+## Task Description
+{{.Task}}
+
+## Branch Name
+{{.Branch}}
+
+## Changed Files
+{{range .ChangedFiles}}- {{.}}
+{{end}}
+
+## Commit History
+{{.CommitLog}}
+
+## Code Diff (truncated if large)
+{{.Diff}}
+
+---
+
+Generate a PR with:
+1. A concise title following conventional commit format (e.g., "feat: add user authentication", "fix: resolve memory leak")
+2. A body that includes:
+   - A brief summary (2-3 sentences max)
+   - Key changes as bullet points
+   - Any important notes for reviewers
+
+Respond ONLY with valid JSON in this exact format:
+{"title": "your title here", "body": "your body here\n\nwith proper newlines"}
+
+Important:
+- Keep the title under 72 characters
+- Use lowercase for the conventional commit prefix
+- Be concise but informative
+- Do not include any text outside the JSON object`
+
+// Generate uses Claude to create PR content from the provided context
+func (g *Generator) Generate(ctx Context) (*PRContent, error) {
+	// Build the prompt
+	tmpl, err := template.New("prompt").Parse(promptTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	// Truncate diff if too large (Claude has context limits)
+	diff := ctx.Diff
+	const maxDiffSize = 50000
+	if len(diff) > maxDiffSize {
+		diff = diff[:maxDiffSize] + "\n\n... (diff truncated due to size)"
+	}
+	ctx.Diff = diff
+
+	var promptBuf bytes.Buffer
+	if err := tmpl.Execute(&promptBuf, ctx); err != nil {
+		return nil, fmt.Errorf("failed to execute template: %w", err)
+	}
+
+	// Call Claude CLI in one-shot mode
+	cmd := exec.Command("claude", "--print", promptBuf.String())
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("claude command failed: %w\nstderr: %s", err, string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("failed to run claude: %w", err)
+	}
+
+	// Parse the JSON response
+	// Claude might include markdown code blocks, so we need to extract the JSON
+	responseStr := strings.TrimSpace(string(output))
+	responseStr = extractJSON(responseStr)
+
+	var content PRContent
+	if err := json.Unmarshal([]byte(responseStr), &content); err != nil {
+		return nil, fmt.Errorf("failed to parse claude response as JSON: %w\nresponse: %s", err, responseStr)
+	}
+
+	return &content, nil
+}
+
+// extractJSON extracts JSON from a response that might be wrapped in markdown code blocks
+func extractJSON(s string) string {
+	// Remove markdown code blocks if present
+	s = strings.TrimPrefix(s, "```json")
+	s = strings.TrimPrefix(s, "```")
+	s = strings.TrimSuffix(s, "```")
+	s = strings.TrimSpace(s)
+
+	// Try to find JSON object boundaries
+	start := strings.Index(s, "{")
+	end := strings.LastIndex(s, "}")
+	if start != -1 && end != -1 && end > start {
+		return s[start : end+1]
+	}
+
+	return s
+}
+
+// CreatePR creates a GitHub PR using the gh CLI
+func CreatePR(title, body, branch string) (string, error) {
+	cmd := exec.Command("gh", "pr", "create",
+		"--title", title,
+		"--body", body,
+		"--head", branch,
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to create PR: %w\n%s", err, string(output))
+	}
+
+	// gh pr create outputs the PR URL
+	return strings.TrimSpace(string(output)), nil
+}
+
+// CreatePRDraft creates a draft GitHub PR using the gh CLI
+func CreatePRDraft(title, body, branch string) (string, error) {
+	cmd := exec.Command("gh", "pr", "create",
+		"--title", title,
+		"--body", body,
+		"--head", branch,
+		"--draft",
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to create draft PR: %w\n%s", err, string(output))
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -141,3 +141,186 @@ func (m *Manager) CommitAll(path, message string) error {
 
 	return nil
 }
+
+// GetDiffAgainstMain returns the diff of the branch against main/master
+func (m *Manager) GetDiffAgainstMain(path string) (string, error) {
+	// Try to find the main branch name (could be main or master)
+	mainBranch := m.findMainBranch()
+
+	cmd := exec.Command("git", "diff", mainBranch+"...HEAD")
+	cmd.Dir = path
+
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get diff: %w", err)
+	}
+
+	return string(output), nil
+}
+
+// GetCommitLog returns the commit log for the current branch since it diverged from main
+func (m *Manager) GetCommitLog(path string) (string, error) {
+	mainBranch := m.findMainBranch()
+
+	cmd := exec.Command("git", "log", mainBranch+"..HEAD", "--pretty=format:%s%n%b---")
+	cmd.Dir = path
+
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get commit log: %w", err)
+	}
+
+	return string(output), nil
+}
+
+// GetChangedFiles returns a list of files changed compared to main
+func (m *Manager) GetChangedFiles(path string) ([]string, error) {
+	mainBranch := m.findMainBranch()
+
+	cmd := exec.Command("git", "diff", "--name-only", mainBranch+"...HEAD")
+	cmd.Dir = path
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get changed files: %w", err)
+	}
+
+	files := strings.Split(strings.TrimSpace(string(output)), "\n")
+	if len(files) == 1 && files[0] == "" {
+		return []string{}, nil
+	}
+
+	return files, nil
+}
+
+// Push pushes the current branch to the remote
+func (m *Manager) Push(path string, force bool) error {
+	args := []string{"push", "-u", "origin", "HEAD"}
+	if force {
+		args = append(args, "--force-with-lease")
+	}
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = path
+
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to push: %w\n%s", err, string(output))
+	}
+
+	return nil
+}
+
+// RebaseOnMain rebases the current branch on main/master
+func (m *Manager) RebaseOnMain(path string) error {
+	mainBranch := m.findMainBranch()
+
+	// First fetch the latest from origin
+	fetchCmd := exec.Command("git", "fetch", "origin", mainBranch)
+	fetchCmd.Dir = path
+	if output, err := fetchCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to fetch origin/%s: %w\n%s", mainBranch, err, string(output))
+	}
+
+	// Rebase on origin/main
+	rebaseCmd := exec.Command("git", "rebase", "origin/"+mainBranch)
+	rebaseCmd.Dir = path
+	if output, err := rebaseCmd.CombinedOutput(); err != nil {
+		// Check if there are conflicts
+		if strings.Contains(string(output), "CONFLICT") || strings.Contains(string(output), "could not apply") {
+			// Abort the rebase so we don't leave things in a bad state
+			abortCmd := exec.Command("git", "rebase", "--abort")
+			abortCmd.Dir = path
+			abortCmd.Run()
+			return fmt.Errorf("rebase conflicts detected - manual resolution required:\n%s", string(output))
+		}
+		return fmt.Errorf("failed to rebase: %w\n%s", err, string(output))
+	}
+
+	return nil
+}
+
+// HasRebaseConflicts checks if rebasing on main would cause conflicts
+// Returns true if conflicts would occur, false if rebase would be clean
+func (m *Manager) HasRebaseConflicts(path string) (bool, error) {
+	mainBranch := m.findMainBranch()
+
+	// Fetch first
+	fetchCmd := exec.Command("git", "fetch", "origin", mainBranch)
+	fetchCmd.Dir = path
+	if err := fetchCmd.Run(); err != nil {
+		return false, fmt.Errorf("failed to fetch: %w", err)
+	}
+
+	// Check if we're already up to date
+	behindCmd := exec.Command("git", "rev-list", "--count", "HEAD..origin/"+mainBranch)
+	behindCmd.Dir = path
+	behindOutput, err := behindCmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("failed to check commits behind: %w", err)
+	}
+
+	behindCount := strings.TrimSpace(string(behindOutput))
+	if behindCount == "0" {
+		// Already up to date, no rebase needed
+		return false, nil
+	}
+
+	// Check for potential conflicts using merge-tree (dry run)
+	// Get the merge base
+	mergeBaseCmd := exec.Command("git", "merge-base", "HEAD", "origin/"+mainBranch)
+	mergeBaseCmd.Dir = path
+	mergeBaseOutput, err := mergeBaseCmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("failed to get merge base: %w", err)
+	}
+	mergeBase := strings.TrimSpace(string(mergeBaseOutput))
+
+	// Use merge-tree to check for conflicts
+	mergeTreeCmd := exec.Command("git", "merge-tree", mergeBase, "HEAD", "origin/"+mainBranch)
+	mergeTreeCmd.Dir = path
+	mergeTreeOutput, err := mergeTreeCmd.Output()
+	if err != nil {
+		// merge-tree doesn't return error on conflicts, just outputs them
+		return false, fmt.Errorf("failed to run merge-tree: %w", err)
+	}
+
+	// If output contains conflict markers, there would be conflicts
+	output := string(mergeTreeOutput)
+	hasConflicts := strings.Contains(output, "<<<<<<<") || strings.Contains(output, ">>>>>>>")
+
+	return hasConflicts, nil
+}
+
+// GetBehindCount returns how many commits the branch is behind origin/main
+func (m *Manager) GetBehindCount(path string) (int, error) {
+	mainBranch := m.findMainBranch()
+
+	// Fetch first
+	fetchCmd := exec.Command("git", "fetch", "origin", mainBranch)
+	fetchCmd.Dir = path
+	fetchCmd.Run() // Ignore error, might be offline
+
+	behindCmd := exec.Command("git", "rev-list", "--count", "HEAD..origin/"+mainBranch)
+	behindCmd.Dir = path
+	output, err := behindCmd.Output()
+	if err != nil {
+		return 0, fmt.Errorf("failed to check commits behind: %w", err)
+	}
+
+	count := 0
+	fmt.Sscanf(strings.TrimSpace(string(output)), "%d", &count)
+	return count, nil
+}
+
+// findMainBranch returns the name of the main branch (main or master)
+func (m *Manager) findMainBranch() string {
+	// Check if 'main' exists
+	cmd := exec.Command("git", "rev-parse", "--verify", "main")
+	cmd.Dir = m.repoDir
+	if err := cmd.Run(); err == nil {
+		return "main"
+	}
+
+	// Fall back to 'master'
+	return "master"
+}


### PR DESCRIPTION
- Add `claudio pr` command that uses Claude to generate meaningful PR titles and descriptions based on task, diff, and commit history
- Automatically rebase on main and detect conflicts before pushing
- Add PR configuration options (draft, auto_rebase, use_ai)
- Wire up completion.default_action: "auto_pr" in TUI
- Add [r] keybinding to show PR command for active instance
- Show PR suggestion when stopping instances with [x]