### PR TITLE
fix: resize tmux panes dynamically to match sidebar-adjusted content area

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -84,6 +84,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.ready = true
+
+		// Calculate the content area width for tmux sessions
+		// This accounts for the sidebar taking up space
+		effectiveSidebarWidth := sidebarWidth
+		if m.width < 80 {
+			effectiveSidebarWidth = sidebarMinWidth
+		}
+		// Content width minus borders/padding (2 for border chars)
+		contentWidth := m.width - effectiveSidebarWidth - 3 - 2
+		// Content height minus header, help bar, and margins
+		contentHeight := m.height - 6
+
+		// Resize all running tmux sessions to match the content area
+		if m.orchestrator != nil && contentWidth > 0 && contentHeight > 0 {
+			m.orchestrator.ResizeAllInstances(contentWidth, contentHeight)
+		}
+
 		return m, nil
 
 	case tickMsg:


### PR DESCRIPTION
## Summary
- Fixes Claude output rendering incorrectly after sidebar introduction
- Adds dynamic tmux pane resizing when terminal window changes size
- New instances now use current display dimensions instead of fixed 200-char width

## Test plan
- [ ] Run Claudio with existing instances and resize terminal window
- [ ] Verify Claude output wraps correctly within content area
- [ ] Create new instance after resize and verify it uses correct dimensions
- [ ] Test with narrow terminal (< 80 chars) to verify minimum sidebar width handling

Closes #13