### PR TITLE
feat: add keyboard shortcut 'd' to show diff preview panel

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -534,3 +534,8 @@ func (o *Orchestrator) GetInstance(id string) *Instance {
 	}
 	return nil
 }
+
+// GetInstanceDiff returns the git diff for an instance against main
+func (o *Orchestrator) GetInstanceDiff(worktreePath string) (string, error) {
+	return o.wt.GetDiffAgainstMain(worktreePath)
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -35,6 +35,11 @@ type Model struct {
 
 	// Instance outputs (instance ID -> output string)
 	outputs map[string]string
+
+	// Diff preview state
+	showDiff    bool   // Whether the diff panel is visible
+	diffContent string // Cached diff content for the active instance
+	diffScroll  int    // Scroll offset for navigating the diff
 }
 
 // NewModel creates a new TUI model

--- a/internal/tui/styles/styles.go
+++ b/internal/tui/styles/styles.go
@@ -179,6 +179,23 @@ var (
 
 	DropdownName = lipgloss.NewStyle().
 			Foreground(MutedColor)
+
+	// Diff syntax highlighting styles
+	DiffAdd = lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#22C55E")) // Green for additions
+
+	DiffRemove = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#EF4444")) // Red for removals
+
+	DiffHeader = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#60A5FA")). // Blue for diff headers
+			Bold(true)
+
+	DiffHunk = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#A78BFA")) // Purple for @@ hunk markers
+
+	DiffContext = lipgloss.NewStyle().
+			Foreground(MutedColor) // Gray for context lines
 )
 
 // StatusColor returns the color for a given status


### PR DESCRIPTION
## Summary

Adds a new keyboard shortcut `d` to display a scrollable diff preview panel showing changes for the active instance against main.

**Features:**
- Press `d` to toggle diff preview for the current instance
- Vim-style navigation: `j/k` to scroll, `g/G` for top/bottom
- Syntax highlighting for additions (green), removals (red), headers (blue), hunks (purple)
- Dedicated help bar when in diff view mode
- Press `d` or `Esc` to close the panel

## Test plan

- [ ] Start claudio with an instance that has changes
- [ ] Press `d` to open diff preview - verify it shows git diff with syntax highlighting
- [ ] Use `j/k` to scroll through the diff
- [ ] Press `g` to jump to top, `G` to jump to bottom
- [ ] Press `d` or `Esc` to close the panel
- [ ] Press `d` on an instance with no changes - verify "No changes to show" message
- [ ] Verify `?` help panel shows new `d` shortcut
- [ ] Verify bottom help bar shows `[d] diff`