### PR TITLE
feat: add interactive conflict detail view with 'c' keyboard shortcut

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -18,6 +18,7 @@ type Model struct {
 	ready          bool
 	quitting       bool
 	showHelp       bool
+	showConflicts  bool // When true, show detailed conflict view
 	addingTask     bool
 	taskInput      string
 	errorMessage   string


### PR DESCRIPTION
## Summary
- Add `showConflicts` toggle to Model for detailed conflict view
- Press `c` to open a panel showing all conflicting files and which instances modified them
- Update conflict warning banner to hint "(press [c] for details)"
- Add dynamic `[c] conflicts` shortcut to help bar when conflicts exist

## Test plan
- [ ] Run multiple instances that modify the same file
- [ ] Verify conflict warning banner appears with "(press [c] for details)" hint
- [ ] Press `c` to open detailed conflict view
- [ ] Verify panel shows file paths and instance numbers/tasks
- [ ] Press `c` again to close the panel
- [ ] Verify `[c] conflicts` appears in help bar only when conflicts exist