### PR TITLE
fix: set initial tmux dimensions before TUI starts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/sys v0.36.0 // indirect
+	golang.org/x/sys v0.39.0 // indirect
+	golang.org/x/term v0.38.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,10 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
 golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
+golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/term v0.38.0 h1:PQ5pkm/rLO6HnxFR7N2lJHOZX6Kez5Y1gDSJla6jo7Q=
+golang.org/x/term v0.38.0/go.mod h1:bSEAKrOT1W+VSu9TSCMtoGEOUcKxOKgl3LE5QEF/xVg=
 golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=
 golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Iron-Ham/claudio/internal/orchestrator"
 	"github.com/Iron-Ham/claudio/internal/tui"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var startCmd = &cobra.Command{
@@ -43,6 +44,15 @@ func runStart(cmd *cobra.Command, args []string) error {
 	session, err := orch.StartSession(sessionName)
 	if err != nil {
 		return fmt.Errorf("failed to start session: %w", err)
+	}
+
+	// Get terminal dimensions and set them on the orchestrator before launching TUI
+	// This ensures that any instances started from the TUI have the correct initial size
+	if termWidth, termHeight, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+		contentWidth, contentHeight := tui.CalculateContentDimensions(termWidth, termHeight)
+		if contentWidth > 0 && contentHeight > 0 {
+			orch.SetDisplayDimensions(contentWidth, contentHeight)
+		}
 	}
 
 	// Launch TUI

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -368,6 +368,16 @@ func (o *Orchestrator) GetConflictDetector() *conflict.Detector {
 	return o.conflictDetector
 }
 
+// SetDisplayDimensions sets the initial display dimensions for new instances
+// This should be called before the TUI starts to ensure instances are created
+// with the correct size from the beginning
+func (o *Orchestrator) SetDisplayDimensions(width, height int) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.displayWidth = width
+	o.displayHeight = height
+}
+
 // ResizeAllInstances resizes all running tmux sessions to the given dimensions
 // and stores the dimensions for new instances
 func (o *Orchestrator) ResizeAllInstances(width, height int) {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -44,9 +44,25 @@ func (a *App) Run() error {
 
 // Layout constants
 const (
-	sidebarWidth    = 30 // Fixed sidebar width
-	sidebarMinWidth = 20 // Minimum sidebar width
+	SidebarWidth    = 30 // Fixed sidebar width
+	SidebarMinWidth = 20 // Minimum sidebar width
+
+	// Layout offsets for content area calculation
+	ContentWidthOffset  = 5 // sidebar gap (3) + border chars (2)
+	ContentHeightOffset = 6 // header + help bar + margins
 )
+
+// CalculateContentDimensions returns the effective content area dimensions
+// given the terminal width and height. This accounts for the sidebar and other UI elements.
+func CalculateContentDimensions(termWidth, termHeight int) (contentWidth, contentHeight int) {
+	effectiveSidebarWidth := SidebarWidth
+	if termWidth < 80 {
+		effectiveSidebarWidth = SidebarMinWidth
+	}
+	contentWidth = termWidth - effectiveSidebarWidth - ContentWidthOffset
+	contentHeight = termHeight - ContentHeightOffset
+	return contentWidth, contentHeight
+}
 
 // Messages
 
@@ -85,18 +101,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 		m.ready = true
 
-		// Calculate the content area width for tmux sessions
-		// This accounts for the sidebar taking up space
-		effectiveSidebarWidth := sidebarWidth
-		if m.width < 80 {
-			effectiveSidebarWidth = sidebarMinWidth
-		}
-		// Content width minus borders/padding (2 for border chars)
-		contentWidth := m.width - effectiveSidebarWidth - 3 - 2
-		// Content height minus header, help bar, and margins
-		contentHeight := m.height - 6
-
-		// Resize all running tmux sessions to match the content area
+		// Calculate the content area dimensions and resize tmux sessions
+		contentWidth, contentHeight := CalculateContentDimensions(m.width, m.height)
 		if m.orchestrator != nil && contentWidth > 0 && contentHeight > 0 {
 			m.orchestrator.ResizeAllInstances(contentWidth, contentHeight)
 		}
@@ -544,9 +550,9 @@ func (m Model) View() string {
 	b.WriteString("\n")
 
 	// Calculate widths for sidebar and main content
-	effectiveSidebarWidth := sidebarWidth
+	effectiveSidebarWidth := SidebarWidth
 	if m.width < 80 {
-		effectiveSidebarWidth = sidebarMinWidth
+		effectiveSidebarWidth = SidebarMinWidth
 	}
 	mainContentWidth := m.width - effectiveSidebarWidth - 3 // 3 for gap between panels
 


### PR DESCRIPTION
## Summary
- Fix Claude tmux instances not seeing correct width within their tmux panel
- Query terminal dimensions at startup and pre-configure orchestrator before launching TUI
- Ensures instances are created with correct content area size from the beginning

## Problem
Claude CLI caches terminal dimensions at startup. Previously, tmux sessions were created with default 200x50 dimensions, then resized after the TUI started. By then, Claude had already cached the wrong dimensions and didn't respond to resize signals.

## Solution
- Add `SetDisplayDimensions()` method to orchestrator for pre-setting dimensions
- Query terminal size in start command before launching TUI using `term.GetSize()`
- Export layout constants and add `CalculateContentDimensions()` helper to avoid duplication

## Test plan
- [ ] Start claudio with `claudio start`
- [ ] Add a new instance and verify Claude's UI renders at the correct width (matching the content area)
- [ ] Resize terminal and verify instances resize correctly