### PR TITLE
feat: add sidebar pagination for unlimited instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ claudio config
 
 # Set individual values
 claudio config set completion.default_action auto_pr
-claudio config set session.max_instances 5
+claudio config set tui.auto_focus_on_input false
 ```
 
 ### Configuration Options
@@ -189,11 +189,6 @@ tui:
   auto_focus_on_input: true
   # Maximum number of output lines to display per instance
   max_output_lines: 1000
-
-# Session settings
-session:
-  # Maximum number of instances that can run simultaneously
-  max_instances: 10
 
 # Instance settings (advanced)
 instance:

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -50,7 +50,6 @@ Valid keys:
                                 Options: prompt, keep_branch, merge_staging, merge_main, auto_pr
   tui.auto_focus_on_input     - Auto-focus new instances (true/false)
   tui.max_output_lines        - Max output lines to display
-  session.max_instances       - Max simultaneous instances
   instance.output_buffer_size - Output buffer size in bytes
   instance.capture_interval_ms - Output capture interval in milliseconds
   instance.tmux_width         - tmux pane width
@@ -137,10 +136,6 @@ func runConfigShow(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  auto_focus_on_input: %v\n", cfg.TUI.AutoFocusOnInput)
 	fmt.Printf("  max_output_lines: %d\n", cfg.TUI.MaxOutputLines)
 
-	// Session settings
-	fmt.Println("session:")
-	fmt.Printf("  max_instances: %d\n", cfg.Session.MaxInstances)
-
 	// Instance settings
 	fmt.Println("instance:")
 	fmt.Printf("  output_buffer_size: %d\n", cfg.Instance.OutputBufferSize)
@@ -166,7 +161,6 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 		"completion.default_action":    "string",
 		"tui.auto_focus_on_input":      "bool",
 		"tui.max_output_lines":         "int",
-		"session.max_instances":        "int",
 		"instance.output_buffer_size":  "int",
 		"instance.capture_interval_ms": "int",
 		"instance.tmux_width":          "int",
@@ -256,11 +250,6 @@ tui:
   auto_focus_on_input: true
   # Maximum number of output lines to display per instance
   max_output_lines: 1000
-
-# Session settings
-session:
-  # Maximum number of instances that can run simultaneously
-  max_instances: 10
 
 # Instance settings (advanced)
 instance:
@@ -362,7 +351,6 @@ func runConfigReset(cmd *cobra.Command, args []string) error {
 		"completion.default_action":    defaults.Completion.DefaultAction,
 		"tui.auto_focus_on_input":      defaults.TUI.AutoFocusOnInput,
 		"tui.max_output_lines":         defaults.TUI.MaxOutputLines,
-		"session.max_instances":        defaults.Session.MaxInstances,
 		"instance.output_buffer_size":  defaults.Instance.OutputBufferSize,
 		"instance.capture_interval_ms": defaults.Instance.CaptureIntervalMs,
 		"instance.tmux_width":          defaults.Instance.TmuxWidth,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,8 +34,7 @@ type TUIConfig struct {
 
 // SessionConfig controls session behavior
 type SessionConfig struct {
-	// MaxInstances limits how many instances can run simultaneously
-	MaxInstances int `mapstructure:"max_instances"`
+	// Placeholder for future session settings
 }
 
 // InstanceConfig controls instance behavior
@@ -70,9 +69,7 @@ func Default() *Config {
 			AutoFocusOnInput: true,
 			MaxOutputLines:   1000,
 		},
-		Session: SessionConfig{
-			MaxInstances: 10,
-		},
+		Session: SessionConfig{},
 		Instance: InstanceConfig{
 			OutputBufferSize:  100000, // 100KB
 			CaptureIntervalMs: 100,
@@ -103,8 +100,7 @@ func SetDefaults() {
 	viper.SetDefault("tui.auto_focus_on_input", defaults.TUI.AutoFocusOnInput)
 	viper.SetDefault("tui.max_output_lines", defaults.TUI.MaxOutputLines)
 
-	// Session defaults
-	viper.SetDefault("session.max_instances", defaults.Session.MaxInstances)
+	// Session defaults (currently empty)
 
 	// Instance defaults
 	viper.SetDefault("instance.output_buffer_size", defaults.Instance.OutputBufferSize)

--- a/internal/tui/config/config.go
+++ b/internal/tui/config/config.go
@@ -87,18 +87,6 @@ func New() Model {
 			},
 		},
 		{
-			Name: "Session",
-			Items: []ConfigItem{
-				{
-					Key:         "session.max_instances",
-					Label:       "Max Instances",
-					Description: "Maximum simultaneous instances allowed",
-					Type:        "int",
-					Category:    "session",
-				},
-			},
-		},
-		{
 			Name: "Instance",
 			Items: []ConfigItem{
 				{
@@ -570,7 +558,6 @@ func (m *Model) resetCurrentToDefault() {
 		"completion.default_action":    defaults.Completion.DefaultAction,
 		"tui.auto_focus_on_input":      defaults.TUI.AutoFocusOnInput,
 		"tui.max_output_lines":         defaults.TUI.MaxOutputLines,
-		"session.max_instances":        defaults.Session.MaxInstances,
 		"instance.output_buffer_size":  defaults.Instance.OutputBufferSize,
 		"instance.capture_interval_ms": defaults.Instance.CaptureIntervalMs,
 		"instance.tmux_width":          defaults.Instance.TmuxWidth,


### PR DESCRIPTION
## Summary

- Remove the `max_instances` config option (it was never actually enforced)
- Add virtual scrolling to the sidebar that dynamically calculates visible slots based on terminal height
- Show scroll indicators (`▲ N more above` / `▼ N more below`) when instances are hidden
- Add arrow key (↑↓) and vim-style (j/k) navigation for instances
- Auto-scroll to keep the selected instance visible when navigating

## Test plan

- [ ] Verify the TUI builds and runs correctly
- [ ] Create more instances than fit in the sidebar and verify pagination works
- [ ] Test arrow key and j/k navigation scrolls the view appropriately
- [ ] Verify scroll indicators appear/disappear correctly
- [ ] Check that `claudio config` no longer shows `max_instances`