### PR TITLE
feat: add option to clear completed instances

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -399,6 +399,26 @@ func (m Model) handleKeypress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		return m, nil
+
+	case "C":
+		// Clear all completed instances
+		removed, err := m.orchestrator.ClearCompletedInstances(m.session)
+		if err != nil {
+			m.errorMessage = err.Error()
+		} else if removed == 0 {
+			m.infoMessage = "No completed instances to clear"
+		} else {
+			m.infoMessage = fmt.Sprintf("Cleared %d completed instance(s)", removed)
+			// Adjust active tab if needed
+			if m.activeTab >= m.instanceCount() {
+				m.activeTab = m.instanceCount() - 1
+				if m.activeTab < 0 {
+					m.activeTab = 0
+				}
+			}
+		}
+		m.errorMessage = "" // Clear any error
+		return m, nil
 	}
 
 	return m, nil
@@ -978,6 +998,7 @@ Instance Control:
   s          Start selected instance
   p          Pause/resume instance
   x          Stop instance
+  C          Clear completed instances
   r          Show PR creation command
   d          Show diff preview
 
@@ -1221,6 +1242,7 @@ func (m Model) renderHelp() string {
 		styles.HelpKey.Render("[i]") + " input",
 		styles.HelpKey.Render("[p]") + " pause",
 		styles.HelpKey.Render("[x]") + " stop",
+		styles.HelpKey.Render("[C]") + " clear",
 		styles.HelpKey.Render("[d]") + " diff",
 		styles.HelpKey.Render("[r]") + " pr",
 		styles.HelpKey.Render("[?]") + " help",


### PR DESCRIPTION
## Summary
- Add `ClearCompletedInstances` method to orchestrator that removes all completed instances
- Add keybinding `[c]` in TUI to trigger the clear action
- Update help panel and help bar to document the new keybinding

## Test plan
- [ ] Start claudio and create multiple instances
- [ ] Complete some instances (let them finish or stop them with `x`)
- [ ] Press `c` to clear completed instances
- [ ] Verify completed instances are removed from sidebar
- [ ] Verify worktrees and branches are cleaned up
- [ ] Verify "No completed instances to clear" message when none exist