### PR TITLE
feat: add PR template support and reviewer auto-assignment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,22 +3,24 @@ module github.com/Iron-Ham/claudio
 go 1.25.5
 
 require (
+	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/fsnotify/fsnotify v1.9.0
+	github.com/gobwas/glob v0.2.3
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
+	golang.org/x/term v0.38.0
 )
 
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/bubbles v0.21.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
@@ -39,6 +41,5 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sys v0.39.0 // indirect
-	golang.org/x/term v0.38.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -86,8 +88,6 @@ golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZ
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
-golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.38.0 h1:PQ5pkm/rLO6HnxFR7N2lJHOZX6Kez5Y1gDSJla6jo7Q=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,20 @@ type PRConfig struct {
 	AutoRebase bool `mapstructure:"auto_rebase"`
 	// UseAI uses Claude to generate PR title and description (default: true)
 	UseAI bool `mapstructure:"use_ai"`
+	// Template is a custom PR body template using Go text/template syntax
+	Template string `mapstructure:"template"`
+	// Reviewers configuration for automatic reviewer assignment
+	Reviewers ReviewerConfig `mapstructure:"reviewers"`
+	// Labels to add to all PRs by default
+	Labels []string `mapstructure:"labels"`
+}
+
+// ReviewerConfig controls automatic reviewer assignment
+type ReviewerConfig struct {
+	// Default reviewers to always assign
+	Default []string `mapstructure:"default"`
+	// ByPath maps file path patterns to reviewers (glob patterns supported)
+	ByPath map[string][]string `mapstructure:"by_path"`
 }
 
 // Default returns a Config with sensible default values
@@ -80,6 +94,12 @@ func Default() *Config {
 			Draft:      false,
 			AutoRebase: true,
 			UseAI:      true,
+			Template:   "",
+			Reviewers: ReviewerConfig{
+				Default: []string{},
+				ByPath:  map[string][]string{},
+			},
+			Labels: []string{},
 		},
 	}
 }
@@ -112,6 +132,10 @@ func SetDefaults() {
 	viper.SetDefault("pr.draft", defaults.PR.Draft)
 	viper.SetDefault("pr.auto_rebase", defaults.PR.AutoRebase)
 	viper.SetDefault("pr.use_ai", defaults.PR.UseAI)
+	viper.SetDefault("pr.template", defaults.PR.Template)
+	viper.SetDefault("pr.reviewers.default", defaults.PR.Reviewers.Default)
+	viper.SetDefault("pr.reviewers.by_path", defaults.PR.Reviewers.ByPath)
+	viper.SetDefault("pr.labels", defaults.PR.Labels)
 }
 
 // Load reads the configuration from viper into a Config struct

--- a/internal/pr/template.go
+++ b/internal/pr/template.go
@@ -1,0 +1,122 @@
+package pr
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"github.com/gobwas/glob"
+)
+
+// TemplateData contains all data available to PR templates
+type TemplateData struct {
+	// AISummary is the AI-generated summary (if available)
+	AISummary string
+	// Task is the original task description
+	Task string
+	// Branch is the branch name
+	Branch string
+	// ChangedFiles is a list of modified file paths
+	ChangedFiles []string
+	// CommitLog is the git commit history
+	CommitLog string
+	// LinkedIssue is any detected issue reference (e.g., "#42")
+	LinkedIssue string
+	// InstanceID is the Claudio instance identifier
+	InstanceID string
+}
+
+// RenderTemplate renders a custom PR body template with the given data
+func RenderTemplate(tmplStr string, data TemplateData) (string, error) {
+	tmpl, err := template.New("pr-template").Parse(tmplStr)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+// ExtractIssueReference extracts issue references from text
+// Supports formats: #123, fixes #123, closes #123, resolves #123
+func ExtractIssueReference(text string) string {
+	// Pattern matches various issue reference formats
+	patterns := []string{
+		`(?i)(?:fixes|fix|closes|close|resolves|resolve)\s*#(\d+)`,
+		`(?i)\((?:fixes|fix|closes|close|resolves|resolve)\s*#(\d+)\)`,
+		`#(\d+)`,
+	}
+
+	for _, pattern := range patterns {
+		re := regexp.MustCompile(pattern)
+		matches := re.FindStringSubmatch(text)
+		if len(matches) >= 2 {
+			return "#" + matches[1]
+		}
+	}
+
+	return ""
+}
+
+// ResolveReviewers determines reviewers based on changed files and config
+func ResolveReviewers(changedFiles []string, defaultReviewers []string, byPath map[string][]string) []string {
+	reviewerSet := make(map[string]bool)
+
+	// Add default reviewers
+	for _, r := range defaultReviewers {
+		reviewerSet[normalizeReviewer(r)] = true
+	}
+
+	// Check path-based rules
+	for pattern, reviewers := range byPath {
+		g, err := glob.Compile(pattern)
+		if err != nil {
+			continue
+		}
+
+		for _, file := range changedFiles {
+			if g.Match(file) {
+				for _, r := range reviewers {
+					reviewerSet[normalizeReviewer(r)] = true
+				}
+				break
+			}
+		}
+	}
+
+	// Convert set to slice
+	result := make([]string, 0, len(reviewerSet))
+	for r := range reviewerSet {
+		result = append(result, r)
+	}
+
+	return result
+}
+
+// normalizeReviewer removes @ prefix from reviewer handles
+func normalizeReviewer(reviewer string) string {
+	return strings.TrimPrefix(reviewer, "@")
+}
+
+// FormatClosesClause formats issue references for PR body
+func FormatClosesClause(issues []string) string {
+	if len(issues) == 0 {
+		return ""
+	}
+
+	var clauses []string
+	for _, issue := range issues {
+		// Ensure issue has # prefix
+		if !strings.HasPrefix(issue, "#") {
+			issue = "#" + issue
+		}
+		clauses = append(clauses, "Closes "+issue)
+	}
+
+	return strings.Join(clauses, "\n")
+}

--- a/internal/pr/template_test.go
+++ b/internal/pr/template_test.go
@@ -1,0 +1,264 @@
+package pr
+
+import (
+	"testing"
+)
+
+func TestExtractIssueReference(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		expected string
+	}{
+		{
+			name:     "simple hash reference",
+			text:     "Fix the login bug #42",
+			expected: "#42",
+		},
+		{
+			name:     "fixes keyword",
+			text:     "Fix the login bug (fixes #123)",
+			expected: "#123",
+		},
+		{
+			name:     "closes keyword",
+			text:     "Add new feature closes #456",
+			expected: "#456",
+		},
+		{
+			name:     "resolves keyword",
+			text:     "resolves #789 - memory leak",
+			expected: "#789",
+		},
+		{
+			name:     "case insensitive",
+			text:     "FIXES #100",
+			expected: "#100",
+		},
+		{
+			name:     "no issue reference",
+			text:     "Just a regular task description",
+			expected: "",
+		},
+		{
+			name:     "multiple references returns first match",
+			text:     "Fix #1 and closes #2",
+			expected: "#1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractIssueReference(tt.text)
+			if result != tt.expected {
+				t.Errorf("ExtractIssueReference(%q) = %q, want %q", tt.text, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestResolveReviewers(t *testing.T) {
+	tests := []struct {
+		name             string
+		changedFiles     []string
+		defaultReviewers []string
+		byPath           map[string][]string
+		expectedCount    int
+		mustContain      []string
+	}{
+		{
+			name:             "default reviewers only",
+			changedFiles:     []string{"main.go"},
+			defaultReviewers: []string{"alice", "bob"},
+			byPath:           map[string][]string{},
+			expectedCount:    2,
+			mustContain:      []string{"alice", "bob"},
+		},
+		{
+			name:             "path-based reviewer matching",
+			changedFiles:     []string{"internal/tui/view.go"},
+			defaultReviewers: []string{},
+			byPath: map[string][]string{
+				"internal/tui/**": {"ui-team"},
+			},
+			expectedCount: 1,
+			mustContain:   []string{"ui-team"},
+		},
+		{
+			name:             "combined default and path-based",
+			changedFiles:     []string{"internal/tui/view.go", "README.md"},
+			defaultReviewers: []string{"alice"},
+			byPath: map[string][]string{
+				"internal/tui/**": {"ui-team"},
+			},
+			expectedCount: 2,
+			mustContain:   []string{"alice", "ui-team"},
+		},
+		{
+			name:             "removes @ prefix",
+			changedFiles:     []string{"main.go"},
+			defaultReviewers: []string{"@alice", "@bob"},
+			byPath:           map[string][]string{},
+			expectedCount:    2,
+			mustContain:      []string{"alice", "bob"},
+		},
+		{
+			name:             "no duplicates",
+			changedFiles:     []string{"internal/tui/view.go"},
+			defaultReviewers: []string{"alice"},
+			byPath: map[string][]string{
+				"internal/tui/**": {"alice", "bob"},
+			},
+			expectedCount: 2,
+			mustContain:   []string{"alice", "bob"},
+		},
+		{
+			name:             "empty inputs",
+			changedFiles:     []string{},
+			defaultReviewers: []string{},
+			byPath:           map[string][]string{},
+			expectedCount:    0,
+			mustContain:      []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ResolveReviewers(tt.changedFiles, tt.defaultReviewers, tt.byPath)
+
+			if len(result) != tt.expectedCount {
+				t.Errorf("ResolveReviewers() returned %d reviewers, want %d", len(result), tt.expectedCount)
+			}
+
+			for _, expected := range tt.mustContain {
+				found := false
+				for _, r := range result {
+					if r == expected {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("ResolveReviewers() result missing expected reviewer %q", expected)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderTemplate(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		data     TemplateData
+		contains []string
+		wantErr  bool
+	}{
+		{
+			name:     "basic template",
+			template: "## Summary\n{{ .AISummary }}\n\n## Task\n{{ .Task }}",
+			data: TemplateData{
+				AISummary: "This is the AI summary",
+				Task:      "Fix the bug",
+			},
+			contains: []string{"## Summary", "This is the AI summary", "## Task", "Fix the bug"},
+			wantErr:  false,
+		},
+		{
+			name:     "template with changed files",
+			template: "## Changed Files\n{{range .ChangedFiles}}- {{.}}\n{{end}}",
+			data: TemplateData{
+				ChangedFiles: []string{"file1.go", "file2.go"},
+			},
+			contains: []string{"- file1.go", "- file2.go"},
+			wantErr:  false,
+		},
+		{
+			name:     "template with linked issue",
+			template: "Closes {{ .LinkedIssue }}",
+			data: TemplateData{
+				LinkedIssue: "#42",
+			},
+			contains: []string{"Closes #42"},
+			wantErr:  false,
+		},
+		{
+			name:     "invalid template",
+			template: "{{ .Invalid }}",
+			data:     TemplateData{},
+			contains: []string{},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := RenderTemplate(tt.template, tt.data)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RenderTemplate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				for _, expected := range tt.contains {
+					if !containsString(result, expected) {
+						t.Errorf("RenderTemplate() result missing expected string %q", expected)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestFormatClosesClause(t *testing.T) {
+	tests := []struct {
+		name     string
+		issues   []string
+		expected string
+	}{
+		{
+			name:     "single issue",
+			issues:   []string{"42"},
+			expected: "Closes #42",
+		},
+		{
+			name:     "single issue with hash",
+			issues:   []string{"#42"},
+			expected: "Closes #42",
+		},
+		{
+			name:     "multiple issues",
+			issues:   []string{"42", "43"},
+			expected: "Closes #42\nCloses #43",
+		},
+		{
+			name:     "empty issues",
+			issues:   []string{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatClosesClause(tt.issues)
+			if result != tt.expected {
+				t.Errorf("FormatClosesClause(%v) = %q, want %q", tt.issues, result, tt.expected)
+			}
+		})
+	}
+}
+
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Add custom PR body template support using Go text/template syntax
- Implement automatic reviewer assignment based on config and path rules
- Add issue linking detection from task descriptions
- Add new CLI flags for reviewers, labels, and issue linking

## Changes

- **`internal/config/config.go`**: Extended `PRConfig` with `Template`, `Reviewers`, and `Labels` fields
- **`internal/pr/pr.go`**: Added unified `Create()` function with full options support
- **`internal/pr/template.go`**: New file with template rendering, issue extraction, and reviewer resolution
- **`internal/pr/template_test.go`**: Comprehensive tests for new functionality
- **`internal/cmd/pr.go`**: Added `--reviewer`, `--label`, `--closes` flags and integration logic

## Configuration Example

```yaml
pr:
  template: |
    ## Summary
    {{ .AISummary }}
    
    ## Changes
    {{range .ChangedFiles}}- {{.}}
    {{end}}
  reviewers:
    default: ["@teamlead"]
    by_path:
      "internal/tui/**": ["@ui-team"]
  labels: ["needs-review"]
```

## CLI Usage

```bash
claudio pr abc123 --reviewer @alice --closes 42 --label bug
```

## Test plan

- [x] All existing tests pass
- [x] New template tests pass
- [x] `go vet` passes
- [x] Code compiles successfully

Closes #19