### PR TITLE
feat: add session persistence and recovery across restarts

### DIFF
--- a/internal/cmd/sessions.go
+++ b/internal/cmd/sessions.go
@@ -1,0 +1,251 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/instance"
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/tui"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+var sessionsCmd = &cobra.Command{
+	Use:   "sessions",
+	Short: "Manage Claudio sessions",
+	Long:  `Commands for listing, recovering, and cleaning up Claudio sessions.`,
+}
+
+var sessionsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List recoverable sessions and orphaned tmux sessions",
+	Long: `List all Claudio sessions that can be recovered, including:
+- Existing session files with their instances
+- Orphaned tmux sessions (claudio-* sessions without a session file)`,
+	RunE: runSessionsList,
+}
+
+var sessionsRecoverCmd = &cobra.Command{
+	Use:   "recover",
+	Short: "Recover a previous session",
+	Long: `Recover a previous Claudio session by reconnecting to any
+still-running tmux sessions and launching the TUI.
+
+This command will:
+1. Load the session state from .claudio/session.json
+2. Attempt to reconnect to any tmux sessions that are still running
+3. Mark instances with missing tmux sessions as paused
+4. Launch the TUI to continue working`,
+	RunE: runSessionsRecover,
+}
+
+var sessionsCleanCmd = &cobra.Command{
+	Use:   "clean",
+	Short: "Clean up stale session data",
+	Long: `Clean up orphaned tmux sessions and optionally remove session files.
+
+This command will:
+1. Kill any orphaned claudio-* tmux sessions
+2. Optionally remove the session file (with --all flag)`,
+	RunE: runSessionsClean,
+}
+
+var (
+	cleanAll bool
+)
+
+func init() {
+	rootCmd.AddCommand(sessionsCmd)
+	sessionsCmd.AddCommand(sessionsListCmd)
+	sessionsCmd.AddCommand(sessionsRecoverCmd)
+	sessionsCmd.AddCommand(sessionsCleanCmd)
+
+	sessionsCleanCmd.Flags().BoolVar(&cleanAll, "all", false, "Also remove session file")
+}
+
+func runSessionsList(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	orch, err := orchestrator.New(cwd)
+	if err != nil {
+		return fmt.Errorf("failed to create orchestrator: %w", err)
+	}
+
+	// Check for existing session file
+	hasSession := orch.HasExistingSession()
+
+	// List orphaned tmux sessions
+	tmuxSessions, err := instance.ListClaudioTmuxSessions()
+	if err != nil {
+		return fmt.Errorf("failed to list tmux sessions: %w", err)
+	}
+
+	fmt.Println(strings.Repeat("─", 60))
+	fmt.Println("Claudio Session Status")
+	fmt.Println(strings.Repeat("─", 60))
+
+	if hasSession {
+		session, err := orch.LoadSession()
+		if err != nil {
+			fmt.Printf("\nSession file exists but failed to load: %v\n", err)
+		} else {
+			fmt.Printf("\nSession: %s (ID: %s)\n", session.Name, session.ID)
+			fmt.Printf("Created: %s\n", session.Created.Format(time.RFC822))
+			fmt.Printf("Instances: %d\n\n", len(session.Instances))
+
+			if len(session.Instances) > 0 {
+				fmt.Println("Instances:")
+				for _, inst := range session.Instances {
+					sessionName := fmt.Sprintf("claudio-%s", inst.ID)
+					tmuxStatus := "stopped"
+
+					// Check if tmux session exists
+					for _, ts := range tmuxSessions {
+						if ts == sessionName {
+							tmuxStatus = "running"
+							break
+						}
+					}
+
+					fmt.Printf("  [%s] %s - %s\n", inst.Status, inst.ID, truncateTask(inst.Task, 40))
+					fmt.Printf("       Branch: %s\n", inst.Branch)
+					fmt.Printf("       Tmux: %s\n", tmuxStatus)
+				}
+			}
+		}
+	} else {
+		fmt.Println("\nNo session file found.")
+	}
+
+	// Show orphaned tmux sessions
+	orphaned, _ := orch.GetOrphanedTmuxSessions()
+	if len(orphaned) > 0 {
+		fmt.Printf("\nOrphaned tmux sessions (%d):\n", len(orphaned))
+		for _, sess := range orphaned {
+			instanceID := instance.ExtractInstanceIDFromSession(sess)
+			fmt.Printf("  - %s (instance: %s)\n", sess, instanceID)
+		}
+		fmt.Println("\nRun 'claudio sessions clean' to remove orphaned sessions.")
+	} else if len(tmuxSessions) == 0 {
+		fmt.Println("\nNo claudio tmux sessions running.")
+	}
+
+	fmt.Println(strings.Repeat("─", 60))
+
+	if hasSession {
+		fmt.Println("\nTo recover this session: claudio sessions recover")
+		fmt.Println("To start fresh: claudio sessions clean --all && claudio start")
+	}
+
+	return nil
+}
+
+func runSessionsRecover(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	orch, err := orchestrator.New(cwd)
+	if err != nil {
+		return fmt.Errorf("failed to create orchestrator: %w", err)
+	}
+
+	if !orch.HasExistingSession() {
+		return fmt.Errorf("no session found to recover. Use 'claudio start' to create a new session")
+	}
+
+	fmt.Println("Recovering session...")
+
+	session, reconnected, err := orch.RecoverSession()
+	if err != nil {
+		return fmt.Errorf("failed to recover session: %w", err)
+	}
+
+	fmt.Printf("Loaded session: %s\n", session.Name)
+	fmt.Printf("Total instances: %d\n", len(session.Instances))
+	fmt.Printf("Reconnected to tmux: %d\n", len(reconnected))
+
+	if len(reconnected) > 0 {
+		fmt.Println("Reconnected instances:")
+		for _, id := range reconnected {
+			fmt.Printf("  - %s\n", id)
+		}
+	}
+
+	// Get terminal dimensions and set them on the orchestrator before launching TUI
+	if termWidth, termHeight, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+		contentWidth, contentHeight := tui.CalculateContentDimensions(termWidth, termHeight)
+		if contentWidth > 0 && contentHeight > 0 {
+			orch.SetDisplayDimensions(contentWidth, contentHeight)
+		}
+	}
+
+	fmt.Println("\nLaunching TUI...")
+
+	// Launch TUI
+	app := tui.New(orch, session)
+	if err := app.Run(); err != nil {
+		return fmt.Errorf("TUI error: %w", err)
+	}
+
+	return nil
+}
+
+func runSessionsClean(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	orch, err := orchestrator.New(cwd)
+	if err != nil {
+		return fmt.Errorf("failed to create orchestrator: %w", err)
+	}
+
+	// Load session first to find orphaned sessions
+	if orch.HasExistingSession() {
+		orch.LoadSession()
+	}
+
+	// Clean orphaned tmux sessions
+	cleaned, err := orch.CleanOrphanedTmuxSessions()
+	if err != nil {
+		fmt.Printf("Warning: failed to clean some tmux sessions: %v\n", err)
+	}
+
+	if cleaned > 0 {
+		fmt.Printf("Cleaned %d orphaned tmux session(s)\n", cleaned)
+	} else {
+		fmt.Println("No orphaned tmux sessions to clean")
+	}
+
+	// Remove session file if --all flag is set
+	if cleanAll {
+		sessionFile := fmt.Sprintf("%s/.claudio/session.json", cwd)
+		if err := os.Remove(sessionFile); err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("failed to remove session file: %w", err)
+			}
+			fmt.Println("No session file to remove")
+		} else {
+			fmt.Println("Removed session file")
+		}
+	}
+
+	return nil
+}
+
+func truncateTask(task string, maxLen int) string {
+	task = strings.ReplaceAll(task, "\n", " ")
+	if len(task) > maxLen {
+		return task[:maxLen-3] + "..."
+	}
+	return task
+}

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/Iron-Ham/claudio/internal/orchestrator"
 	"github.com/Iron-Ham/claudio/internal/tui"
@@ -14,13 +16,20 @@ var startCmd = &cobra.Command{
 	Use:   "start [session-name]",
 	Short: "Start a new Claudio session",
 	Long: `Start a new Claudio session with an optional name.
-This launches the TUI dashboard where you can add and manage Claude instances.`,
+This launches the TUI dashboard where you can add and manage Claude instances.
+
+If a previous session exists, you will be prompted to recover it or start fresh.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runStart,
 }
 
+var (
+	forceNew bool
+)
+
 func init() {
 	rootCmd.AddCommand(startCmd)
+	startCmd.Flags().BoolVar(&forceNew, "new", false, "Force start a new session, replacing any existing one")
 }
 
 func runStart(cmd *cobra.Command, args []string) error {
@@ -40,8 +49,60 @@ func runStart(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create orchestrator: %w", err)
 	}
 
+	var session *orchestrator.Session
+
+	// Check for existing session
+	if !forceNew && orch.HasExistingSession() {
+		// Prompt user for what to do
+		action, err := promptSessionAction()
+		if err != nil {
+			return err
+		}
+
+		switch action {
+		case "recover":
+			fmt.Println("Recovering session...")
+			session, reconnected, err := orch.RecoverSession()
+			if err != nil {
+				return fmt.Errorf("failed to recover session: %w", err)
+			}
+			if len(reconnected) > 0 {
+				fmt.Printf("Reconnected to %d running instance(s)\n", len(reconnected))
+			}
+
+			// Get terminal dimensions and set them on the orchestrator before launching TUI
+			if termWidth, termHeight, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+				contentWidth, contentHeight := tui.CalculateContentDimensions(termWidth, termHeight)
+				if contentWidth > 0 && contentHeight > 0 {
+					orch.SetDisplayDimensions(contentWidth, contentHeight)
+				}
+			}
+
+			// Launch TUI with recovered session
+			app := tui.New(orch, session)
+			if err := app.Run(); err != nil {
+				return fmt.Errorf("TUI error: %w", err)
+			}
+			return nil
+
+		case "new":
+			// Clean up orphaned tmux sessions before starting fresh
+			orch.LoadSession()
+			cleaned, _ := orch.CleanOrphanedTmuxSessions()
+			if cleaned > 0 {
+				fmt.Printf("Cleaned %d orphaned tmux session(s)\n", cleaned)
+			}
+			// Continue to start new session below
+
+		case "quit":
+			fmt.Println("Use 'claudio sessions list' to see session details")
+			fmt.Println("Use 'claudio sessions recover' to recover the existing session")
+			return nil
+		}
+	}
+
 	// Start a new session
-	session, err := orch.StartSession(sessionName)
+	session, err = orch.StartSession(sessionName)
 	if err != nil {
 		return fmt.Errorf("failed to start session: %w", err)
 	}
@@ -62,4 +123,34 @@ func runStart(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// promptSessionAction prompts the user to choose what to do with an existing session
+func promptSessionAction() (string, error) {
+	fmt.Println("\nAn existing session was found.")
+	fmt.Println("What would you like to do?")
+	fmt.Println("  [r] Recover - Resume the existing session")
+	fmt.Println("  [n] New     - Start fresh (cleans up old session)")
+	fmt.Println("  [q] Quit    - Exit without changes")
+	fmt.Print("\nChoice [r/n/q]: ")
+
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("failed to read input: %w", err)
+	}
+
+	input = strings.TrimSpace(strings.ToLower(input))
+
+	switch input {
+	case "r", "recover", "":
+		return "recover", nil
+	case "n", "new":
+		return "new", nil
+	case "q", "quit":
+		return "quit", nil
+	default:
+		fmt.Printf("Unknown option '%s', defaulting to recover\n", input)
+		return "recover", nil
+	}
 }

--- a/internal/instance/manager_test.go
+++ b/internal/instance/manager_test.go
@@ -1,0 +1,259 @@
+package instance
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractInstanceIDFromSession(t *testing.T) {
+	tests := []struct {
+		name        string
+		sessionName string
+		expected    string
+	}{
+		{
+			name:        "valid claudio session",
+			sessionName: "claudio-abc123",
+			expected:    "abc123",
+		},
+		{
+			name:        "valid claudio session with longer ID",
+			sessionName: "claudio-a1b2c3d4",
+			expected:    "a1b2c3d4",
+		},
+		{
+			name:        "non-claudio session",
+			sessionName: "other-session",
+			expected:    "",
+		},
+		{
+			name:        "empty string",
+			sessionName: "",
+			expected:    "",
+		},
+		{
+			name:        "just prefix",
+			sessionName: "claudio-",
+			expected:    "",
+		},
+		{
+			name:        "similar but not claudio prefix",
+			sessionName: "claudio2-abc",
+			expected:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractInstanceIDFromSession(tt.sessionName)
+			if result != tt.expected {
+				t.Errorf("ExtractInstanceIDFromSession(%q) = %q, want %q", tt.sessionName, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewManagerWithConfig(t *testing.T) {
+	cfg := ManagerConfig{
+		OutputBufferSize:  1000,
+		CaptureIntervalMs: 50,
+		TmuxWidth:         100,
+		TmuxHeight:        30,
+	}
+
+	mgr := NewManagerWithConfig("test-id", "/tmp/test", "test task", cfg)
+
+	if mgr == nil {
+		t.Fatal("NewManagerWithConfig returned nil")
+	}
+
+	if mgr.id != "test-id" {
+		t.Errorf("id = %q, want %q", mgr.id, "test-id")
+	}
+
+	if mgr.workdir != "/tmp/test" {
+		t.Errorf("workdir = %q, want %q", mgr.workdir, "/tmp/test")
+	}
+
+	if mgr.task != "test task" {
+		t.Errorf("task = %q, want %q", mgr.task, "test task")
+	}
+
+	expectedSession := "claudio-test-id"
+	if mgr.sessionName != expectedSession {
+		t.Errorf("sessionName = %q, want %q", mgr.sessionName, expectedSession)
+	}
+
+	if mgr.config.TmuxWidth != 100 {
+		t.Errorf("config.TmuxWidth = %d, want %d", mgr.config.TmuxWidth, 100)
+	}
+
+	if mgr.config.TmuxHeight != 30 {
+		t.Errorf("config.TmuxHeight = %d, want %d", mgr.config.TmuxHeight, 30)
+	}
+}
+
+func TestNewManager(t *testing.T) {
+	mgr := NewManager("test-id", "/tmp/test", "test task")
+
+	if mgr == nil {
+		t.Fatal("NewManager returned nil")
+	}
+
+	// Should use default config
+	defaultCfg := DefaultManagerConfig()
+	if mgr.config.OutputBufferSize != defaultCfg.OutputBufferSize {
+		t.Errorf("config.OutputBufferSize = %d, want %d", mgr.config.OutputBufferSize, defaultCfg.OutputBufferSize)
+	}
+}
+
+func TestManager_SessionName(t *testing.T) {
+	mgr := NewManager("abc123", "/tmp", "task")
+	expected := "claudio-abc123"
+	if mgr.SessionName() != expected {
+		t.Errorf("SessionName() = %q, want %q", mgr.SessionName(), expected)
+	}
+}
+
+func TestManager_ID(t *testing.T) {
+	mgr := NewManager("test-id-123", "/tmp", "task")
+	if mgr.ID() != "test-id-123" {
+		t.Errorf("ID() = %q, want %q", mgr.ID(), "test-id-123")
+	}
+}
+
+func TestManager_AttachCommand(t *testing.T) {
+	mgr := NewManager("abc123", "/tmp", "task")
+	cmd := mgr.AttachCommand()
+
+	if !strings.Contains(cmd, "tmux attach") {
+		t.Errorf("AttachCommand() should contain 'tmux attach', got %q", cmd)
+	}
+
+	if !strings.Contains(cmd, "claudio-abc123") {
+		t.Errorf("AttachCommand() should contain session name, got %q", cmd)
+	}
+}
+
+func TestManager_Running_NotStarted(t *testing.T) {
+	mgr := NewManager("test", "/tmp", "task")
+
+	if mgr.Running() {
+		t.Error("Running() should be false before Start()")
+	}
+}
+
+func TestManager_Paused_NotStarted(t *testing.T) {
+	mgr := NewManager("test", "/tmp", "task")
+
+	if mgr.Paused() {
+		t.Error("Paused() should be false before Start()")
+	}
+}
+
+func TestManager_GetOutput_Empty(t *testing.T) {
+	mgr := NewManager("test", "/tmp", "task")
+
+	output := mgr.GetOutput()
+	if len(output) != 0 {
+		t.Errorf("GetOutput() should return empty slice before any output, got %d bytes", len(output))
+	}
+}
+
+func TestManager_CurrentState_Initial(t *testing.T) {
+	mgr := NewManager("test", "/tmp", "task")
+
+	if mgr.CurrentState() != StateWorking {
+		t.Errorf("CurrentState() should be StateWorking initially, got %v", mgr.CurrentState())
+	}
+}
+
+func TestManager_TmuxSessionExists_NotCreated(t *testing.T) {
+	mgr := NewManager("nonexistent-session-id-12345", "/tmp", "task")
+
+	// This session shouldn't exist since we never created it
+	if mgr.TmuxSessionExists() {
+		t.Error("TmuxSessionExists() should return false for non-existent session")
+	}
+}
+
+func TestManager_Reconnect_NoSession(t *testing.T) {
+	mgr := NewManager("nonexistent-reconnect-test", "/tmp", "task")
+
+	err := mgr.Reconnect()
+	if err == nil {
+		t.Error("Reconnect() should return error when tmux session doesn't exist")
+	}
+
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("Reconnect() error should mention session doesn't exist, got: %v", err)
+	}
+}
+
+func TestManager_Stop_NotRunning(t *testing.T) {
+	mgr := NewManager("test", "/tmp", "task")
+
+	// Stop should not error when not running
+	err := mgr.Stop()
+	if err != nil {
+		t.Errorf("Stop() should not error when not running, got: %v", err)
+	}
+}
+
+func TestManager_Pause_NotRunning(t *testing.T) {
+	mgr := NewManager("test", "/tmp", "task")
+
+	// Pause should not error when not running
+	err := mgr.Pause()
+	if err != nil {
+		t.Errorf("Pause() should not error when not running, got: %v", err)
+	}
+}
+
+func TestManager_Resume_NotRunning(t *testing.T) {
+	mgr := NewManager("test", "/tmp", "task")
+
+	// Resume should not error when not running
+	err := mgr.Resume()
+	if err != nil {
+		t.Errorf("Resume() should not error when not running, got: %v", err)
+	}
+}
+
+func TestDefaultManagerConfig(t *testing.T) {
+	cfg := DefaultManagerConfig()
+
+	if cfg.OutputBufferSize <= 0 {
+		t.Errorf("OutputBufferSize should be positive, got %d", cfg.OutputBufferSize)
+	}
+
+	if cfg.CaptureIntervalMs <= 0 {
+		t.Errorf("CaptureIntervalMs should be positive, got %d", cfg.CaptureIntervalMs)
+	}
+
+	if cfg.TmuxWidth <= 0 {
+		t.Errorf("TmuxWidth should be positive, got %d", cfg.TmuxWidth)
+	}
+
+	if cfg.TmuxHeight <= 0 {
+		t.Errorf("TmuxHeight should be positive, got %d", cfg.TmuxHeight)
+	}
+}
+
+func TestListClaudioTmuxSessions_NoTmuxServer(t *testing.T) {
+	// This test may return nil or an empty list depending on whether tmux is running
+	// The important thing is it should not error in a way that causes a panic
+	sessions, err := ListClaudioTmuxSessions()
+
+	// If tmux isn't running or no sessions exist, we should get nil/empty result, not an error
+	if err != nil {
+		t.Logf("ListClaudioTmuxSessions returned error (expected if no tmux server): %v", err)
+	}
+
+	// Sessions should be nil or contain only claudio-prefixed sessions
+	for _, sess := range sessions {
+		if !strings.HasPrefix(sess, "claudio-") {
+			t.Errorf("ListClaudioTmuxSessions returned non-claudio session: %q", sess)
+		}
+	}
+}

--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -28,7 +28,8 @@ type Instance struct {
 	PID           int            `json:"pid,omitempty"`
 	FilesModified []string       `json:"files_modified,omitempty"`
 	Created       time.Time      `json:"created"`
-	Output        []byte         `json:"-"` // Not persisted, runtime only
+	TmuxSession   string         `json:"tmux_session,omitempty"` // Tmux session name for recovery
+	Output        []byte         `json:"-"`                      // Not persisted, runtime only
 }
 
 // Session represents a Claudio work session

--- a/internal/orchestrator/session_test.go
+++ b/internal/orchestrator/session_test.go
@@ -1,0 +1,222 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewSession(t *testing.T) {
+	tests := []struct {
+		name         string
+		sessionName  string
+		baseRepo     string
+		expectedName string
+	}{
+		{
+			name:         "with custom name",
+			sessionName:  "my-session",
+			baseRepo:     "/path/to/repo",
+			expectedName: "my-session",
+		},
+		{
+			name:         "with empty name uses default",
+			sessionName:  "",
+			baseRepo:     "/path/to/repo",
+			expectedName: "claudio-session",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := NewSession(tt.sessionName, tt.baseRepo)
+
+			if session == nil {
+				t.Fatal("NewSession returned nil")
+			}
+
+			if session.ID == "" {
+				t.Error("session ID should not be empty")
+			}
+
+			if session.Name != tt.expectedName {
+				t.Errorf("session.Name = %q, want %q", session.Name, tt.expectedName)
+			}
+
+			if session.BaseRepo != tt.baseRepo {
+				t.Errorf("session.BaseRepo = %q, want %q", session.BaseRepo, tt.baseRepo)
+			}
+
+			if session.Instances == nil {
+				t.Error("session.Instances should not be nil")
+			}
+
+			if len(session.Instances) != 0 {
+				t.Errorf("session.Instances should be empty, got %d", len(session.Instances))
+			}
+
+			if session.Created.IsZero() {
+				t.Error("session.Created should be set")
+			}
+		})
+	}
+}
+
+func TestNewInstance(t *testing.T) {
+	task := "implement feature X"
+	inst := NewInstance(task)
+
+	if inst == nil {
+		t.Fatal("NewInstance returned nil")
+	}
+
+	if inst.ID == "" {
+		t.Error("instance ID should not be empty")
+	}
+
+	if inst.Task != task {
+		t.Errorf("instance.Task = %q, want %q", inst.Task, task)
+	}
+
+	if inst.Status != StatusPending {
+		t.Errorf("instance.Status = %q, want %q", inst.Status, StatusPending)
+	}
+
+	if inst.Created.IsZero() {
+		t.Error("instance.Created should be set")
+	}
+}
+
+func TestSession_GetInstance(t *testing.T) {
+	session := NewSession("test", "/repo")
+
+	// Add some instances
+	inst1 := NewInstance("task 1")
+	inst1.ID = "inst-1"
+	inst2 := NewInstance("task 2")
+	inst2.ID = "inst-2"
+	inst3 := NewInstance("task 3")
+	inst3.ID = "inst-3"
+
+	session.Instances = []*Instance{inst1, inst2, inst3}
+
+	tests := []struct {
+		name     string
+		id       string
+		expected *Instance
+	}{
+		{
+			name:     "find first instance",
+			id:       "inst-1",
+			expected: inst1,
+		},
+		{
+			name:     "find middle instance",
+			id:       "inst-2",
+			expected: inst2,
+		},
+		{
+			name:     "find last instance",
+			id:       "inst-3",
+			expected: inst3,
+		},
+		{
+			name:     "not found",
+			id:       "inst-4",
+			expected: nil,
+		},
+		{
+			name:     "empty id",
+			id:       "",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := session.GetInstance(tt.id)
+			if result != tt.expected {
+				t.Errorf("GetInstance(%q) = %v, want %v", tt.id, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGenerateID(t *testing.T) {
+	// Generate multiple IDs and ensure they're unique
+	ids := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		id := generateID()
+		if id == "" {
+			t.Error("generateID returned empty string")
+		}
+		if ids[id] {
+			t.Errorf("generateID returned duplicate ID: %s", id)
+		}
+		ids[id] = true
+	}
+}
+
+func TestGenerateID_Length(t *testing.T) {
+	id := generateID()
+	// 4 bytes = 8 hex characters
+	expectedLen := 8
+	if len(id) != expectedLen {
+		t.Errorf("generateID() length = %d, want %d", len(id), expectedLen)
+	}
+}
+
+func TestInstanceStatus_Constants(t *testing.T) {
+	// Ensure status constants have expected values
+	tests := []struct {
+		status   InstanceStatus
+		expected string
+	}{
+		{StatusPending, "pending"},
+		{StatusWorking, "working"},
+		{StatusWaitingInput, "waiting_input"},
+		{StatusPaused, "paused"},
+		{StatusCompleted, "completed"},
+		{StatusError, "error"},
+	}
+
+	for _, tt := range tests {
+		if string(tt.status) != tt.expected {
+			t.Errorf("status constant = %q, want %q", tt.status, tt.expected)
+		}
+	}
+}
+
+func TestInstance_TmuxSession_Field(t *testing.T) {
+	inst := NewInstance("test task")
+
+	// TmuxSession should be empty initially
+	if inst.TmuxSession != "" {
+		t.Errorf("instance.TmuxSession should be empty initially, got %q", inst.TmuxSession)
+	}
+
+	// Should be settable
+	inst.TmuxSession = "claudio-abc123"
+	if inst.TmuxSession != "claudio-abc123" {
+		t.Errorf("instance.TmuxSession = %q, want %q", inst.TmuxSession, "claudio-abc123")
+	}
+}
+
+func TestSession_Created_Timestamp(t *testing.T) {
+	before := time.Now()
+	session := NewSession("test", "/repo")
+	after := time.Now()
+
+	if session.Created.Before(before) || session.Created.After(after) {
+		t.Errorf("session.Created = %v, should be between %v and %v", session.Created, before, after)
+	}
+}
+
+func TestInstance_Created_Timestamp(t *testing.T) {
+	before := time.Now()
+	inst := NewInstance("test task")
+	after := time.Now()
+
+	if inst.Created.Before(before) || inst.Created.After(after) {
+		t.Errorf("instance.Created = %v, should be between %v and %v", inst.Created, before, after)
+	}
+}


### PR DESCRIPTION
## Summary
- Add session recovery on `claudio start` with interactive prompt
- New `claudio sessions` subcommands for session management
- Reconnect to still-running tmux sessions automatically
- Graceful signal handling for clean shutdowns

## New Commands
- `claudio sessions list` - Show recoverable sessions and tmux status
- `claudio sessions recover` - Explicitly recover a previous session
- `claudio sessions clean` - Clean up orphaned tmux sessions
- `claudio start --new` - Force start fresh session

## Test plan
- [ ] Start a session, add instances, exit with Ctrl+C
- [ ] Run `claudio sessions list` to see session status
- [ ] Run `claudio start` and verify recovery prompt appears
- [ ] Choose recover and verify instances reconnect
- [ ] Kill tmux sessions manually, run `claudio sessions clean`
- [ ] Run `claudio sessions clean --all` to remove session file

Closes #14