### PR TITLE
feat: add instance output search and filtering

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"regexp"
+
 	"github.com/Iron-Ham/claudio/internal/conflict"
 	"github.com/Iron-Ham/claudio/internal/orchestrator"
 )
@@ -51,8 +53,22 @@ type Model struct {
 	sidebarScrollOffset int // Index of the first visible instance in sidebar
 
 	// Resource metrics display
-	showStats       bool // When true, show the stats panel
-	budgetWarning   bool // True when session cost exceeds warning threshold
+	showStats     bool // When true, show the stats panel
+	budgetWarning bool // True when session cost exceeds warning threshold
+
+	// Search state
+	searchMode    bool           // Whether search mode is active (typing pattern)
+	searchPattern string         // Current search pattern
+	searchRegex   *regexp.Regexp // Compiled regex (nil for literal search)
+	searchMatches []int          // Line numbers containing matches
+	searchCurrent int            // Current match index (for n/N navigation)
+
+	// Filter state
+	filterMode       bool            // Whether filter mode is active
+	filterCategories map[string]bool // Which categories are enabled
+	filterCustom     string          // Custom filter pattern
+	filterRegex      *regexp.Regexp  // Compiled custom filter regex
+	outputScroll     int             // Scroll position in output (for search navigation)
 }
 
 // NewModel creates a new TUI model
@@ -64,6 +80,13 @@ func NewModel(orch *orchestrator.Orchestrator, session *orchestrator.Session) Mo
 		outputScrolls:    make(map[string]int),
 		outputAutoScroll: make(map[string]bool),
 		outputLineCount:  make(map[string]int),
+		filterCategories: map[string]bool{
+			"errors":   true,
+			"warnings": true,
+			"tools":    true,
+			"thinking": true,
+			"progress": true,
+		},
 	}
 }
 

--- a/internal/tui/styles/styles.go
+++ b/internal/tui/styles/styles.go
@@ -200,6 +200,58 @@ var (
 
 	DiffContext = lipgloss.NewStyle().
 			Foreground(MutedColor) // Gray for context lines
+
+	// Search styles
+	SearchBar = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(PrimaryColor).
+			Padding(0, 1).
+			MarginTop(1)
+
+	SearchInput = lipgloss.NewStyle().
+			Foreground(TextColor)
+
+	SearchPrompt = lipgloss.NewStyle().
+			Foreground(SecondaryColor).
+			Bold(true)
+
+	SearchMatch = lipgloss.NewStyle().
+			Background(lipgloss.Color("#FCD34D")). // Yellow highlight
+			Foreground(lipgloss.Color("#1F2937"))  // Dark text on yellow
+
+	SearchCurrentMatch = lipgloss.NewStyle().
+				Background(lipgloss.Color("#F97316")). // Orange for current match
+				Foreground(lipgloss.Color("#1F2937")).  // Dark text
+				Bold(true)
+
+	SearchInfo = lipgloss.NewStyle().
+			Foreground(MutedColor).
+			MarginLeft(2)
+
+	// Filter styles
+	FilterBar = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(PrimaryColor).
+			Padding(1, 2)
+
+	FilterCategory = lipgloss.NewStyle().
+			Foreground(TextColor).
+			MarginRight(2)
+
+	FilterCategoryEnabled = lipgloss.NewStyle().
+				Foreground(SecondaryColor).
+				Bold(true).
+				MarginRight(2)
+
+	FilterCategoryDisabled = lipgloss.NewStyle().
+				Foreground(MutedColor).
+				MarginRight(2)
+
+	FilterCheckbox = lipgloss.NewStyle().
+			Foreground(SecondaryColor)
+
+	FilterCheckboxEmpty = lipgloss.NewStyle().
+				Foreground(MutedColor)
 )
 
 // StatusColor returns the color for a given status


### PR DESCRIPTION
## Summary

- Add search mode (`/`) to search instance output with live highlighting
- Support literal and regex search (prefix with `r:`)
- Navigate matches with `n`/`N`, clear with `Ctrl+/`
- Add filter mode (`F`) to toggle output categories (errors, warnings, tool calls, thinking, progress)
- Support custom regex filter pattern

## Test plan

- [ ] Press `/` to enter search mode, type a pattern
- [ ] Verify matches highlight in yellow, current match in orange
- [ ] Press `n`/`N` to navigate between matches
- [ ] Press `Ctrl+/` to clear search
- [ ] Press `F` to open filter panel
- [ ] Toggle categories with `e/w/t/h/p` keys
- [ ] Verify output updates when filters change
- [ ] Press `Esc` or `F` to close filter panel

Closes #34