### PR TITLE
fix: reduce false positives in error state detection

### DIFF
--- a/internal/instance/detector.go
+++ b/internal/instance/detector.go
@@ -101,12 +101,18 @@ func NewDetector() *Detector {
 		`(?i)is there anything else`,
 	}
 
-	// Error patterns - Claude encountered an issue
+	// Error patterns - Claude encountered a critical issue that stopped it
+	// These patterns should be specific to actual Claude failures, not just error text appearing in output
+	// We want to avoid false positives from commands that show errors (like test output, build logs, etc.)
 	errorStrings := []string{
-		`(?i)(?:error|exception|failed|failure)(?::|!)`,
-		`(?i)(?:could not|couldn'?t|unable to|cannot|can'?t) (?:complete|finish|proceed|continue)`,
-		`(?i)(?:fatal|critical|severe) (?:error|issue|problem)`,
-		`(?i)process (?:exited|terminated|crashed|died)`,
+		// Claude CLI specific error messages
+		`(?i)^Error: (?:session|connection|authentication|api) `,
+		`(?i)claude (?:exited|terminated|crashed|died) (?:with|unexpectedly)`,
+		// Process termination signals
+		`(?i)(?:signal|killed|terminated): (?:SIGTERM|SIGKILL|SIGINT)`,
+		// Rate limiting or API errors from Claude
+		`(?i)(?:rate limit|quota) (?:exceeded|reached)`,
+		`(?i)(?:api|request) (?:error|failed).*(?:401|403|429|500|502|503)`,
 	}
 
 	// Working patterns - Claude is actively doing something (these override waiting detection)

--- a/internal/instance/detector_test.go
+++ b/internal/instance/detector_test.go
@@ -229,30 +229,57 @@ func TestDetector_ErrorPatterns(t *testing.T) {
 		output   string
 		expected WaitingState
 	}{
+		// Real error patterns that should trigger StateError
 		{
-			name:     "error colon",
-			output:   "Error: could not find file",
+			name:     "claude session error",
+			output:   "Error: session expired, please restart",
 			expected: StateError,
 		},
 		{
-			name:     "could not complete",
-			output:   "Could not complete the operation",
+			name:     "claude connection error",
+			output:   "Error: connection failed to API",
 			expected: StateError,
 		},
 		{
-			name:     "unable to proceed",
-			output:   "Unable to proceed with the task",
+			name:     "claude crashed",
+			output:   "claude exited unexpectedly with code 1",
 			expected: StateError,
 		},
 		{
-			name:     "fatal error",
-			output:   "Fatal error encountered",
+			name:     "rate limit exceeded",
+			output:   "Rate limit exceeded, please wait before retrying",
 			expected: StateError,
 		},
 		{
-			name:     "process crashed",
-			output:   "The process crashed unexpectedly",
+			name:     "api error with status code",
+			output:   "API error failed with status 429",
 			expected: StateError,
+		},
+		{
+			name:     "signal termination",
+			output:   "Terminated: SIGTERM received",
+			expected: StateError,
+		},
+		// These should NOT trigger StateError (false positives we're avoiding)
+		{
+			name:     "error in test output - should not trigger error state",
+			output:   "Error: could not find file\nLet me try a different approach...",
+			expected: StateWorking,
+		},
+		{
+			name:     "build failure output - should not trigger error state",
+			output:   "Build failed: 3 errors\nI'll fix these compilation errors now.",
+			expected: StateWorking,
+		},
+		{
+			name:     "test failure output - should not trigger error state",
+			output:   "FAIL: TestSomething\nError: assertion failed\nLet me investigate the test failure...",
+			expected: StateWorking,
+		},
+		{
+			name:     "generic error mention - should not trigger error state",
+			output:   "The error handling code needs to be improved",
+			expected: StateWorking,
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Narrowed error detection patterns to match only actual Claude failures (session errors, crashes, rate limits, API errors)
- Prevents false positive "Error" state when Claude shows test output, build logs, or discusses errors
- Added test cases covering both real errors and false positive scenarios

## Test plan
- [x] Unit tests pass for error detection patterns
- [x] Verified real errors are still detected (session errors, crashes, rate limits)
- [x] Verified false positives are avoided (test output, build logs, error mentions in text)