### PR TITLE
fix: jump to latest now scrolls to bottom of filtered output

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -156,8 +156,14 @@ func (m Model) getOutputMaxLines() int {
 }
 
 // getOutputLineCount returns the total number of lines in the output for an instance
-func (m Model) getOutputLineCount(instanceID string) int {
+// This counts lines after filtering is applied to match what the user sees
+func (m *Model) getOutputLineCount(instanceID string) int {
 	output := m.outputs[instanceID]
+	if output == "" {
+		return 0
+	}
+	// Apply filters to match what's displayed
+	output = m.filterOutput(output)
 	if output == "" {
 		return 0
 	}
@@ -172,7 +178,7 @@ func (m Model) getOutputLineCount(instanceID string) int {
 }
 
 // getOutputMaxScroll returns the maximum scroll offset for an instance
-func (m Model) getOutputMaxScroll(instanceID string) int {
+func (m *Model) getOutputMaxScroll(instanceID string) int {
 	totalLines := m.getOutputLineCount(instanceID)
 	maxLines := m.getOutputMaxLines()
 	maxScroll := totalLines - maxLines


### PR DESCRIPTION
## Summary
- Fixed the "Jump to Latest" command scrolling to the top instead of the bottom
- `getOutputLineCount` now applies filters before counting lines, matching what the user actually sees
- Changed receiver type from value to pointer for consistency

## Test plan
- [ ] Open the TUI with an instance that has output
- [ ] Apply a filter to the output
- [ ] Use "Jump to Latest" (typically 'G' or similar keybinding)
- [ ] Verify it scrolls to the bottom (newest content) instead of the top