### PR TITLE
feat: add configurable branch naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Each Claude instance runs in its own [git worktree](https://git-scm.com/docs/git
 - **Parallel branches**: Each instance works on its own branch
 - **Easy cleanup**: Worktrees can be removed without losing the main repo
 
-Worktrees are created in `.claudio/worktrees/<instance-id>/` with branches named `claudio/<instance-id>-<task-slug>`.
+Worktrees are created in `.claudio/worktrees/<instance-id>/` with branches named `<prefix>/<instance-id>-<task-slug>` (the prefix and whether to include the instance ID are configurable).
 
 ### Shared Context
 
@@ -199,6 +199,16 @@ instance:
   # tmux pane dimensions
   tmux_width: 200
   tmux_height: 50
+
+# Branch naming convention
+branch:
+  # Prefix for branch names (default: "claudio")
+  # Examples: "claudio", "Iron-Ham", "feature"
+  prefix: claudio
+  # Include instance ID in branch names (default: true)
+  # When true: <prefix>/<id>-<slug> (e.g., claudio/abc123-fix-bug)
+  # When false: <prefix>/<slug> (e.g., claudio/fix-bug)
+  include_id: true
 ```
 
 ### Environment Variables
@@ -209,7 +219,8 @@ Use underscores instead of dots for nested keys:
 ```bash
 export CLAUDIO_COMPLETION_DEFAULT_ACTION=auto_pr
 export CLAUDIO_TUI_MAX_OUTPUT_LINES=2000
-export CLAUDIO_SESSION_MAX_INSTANCES=5
+export CLAUDIO_BRANCH_PREFIX=Iron-Ham
+export CLAUDIO_BRANCH_INCLUDE_ID=false
 ```
 
 ### Config Commands

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	TUI        TUIConfig        `mapstructure:"tui"`
 	Session    SessionConfig    `mapstructure:"session"`
 	Instance   InstanceConfig   `mapstructure:"instance"`
+	Branch     BranchConfig     `mapstructure:"branch"`
 	PR         PRConfig         `mapstructure:"pr"`
 	Cleanup    CleanupConfig    `mapstructure:"cleanup"`
 	Resources  ResourceConfig   `mapstructure:"resources"`
@@ -49,6 +50,17 @@ type InstanceConfig struct {
 	TmuxWidth int `mapstructure:"tmux_width"`
 	// TmuxHeight is the height of the tmux pane
 	TmuxHeight int `mapstructure:"tmux_height"`
+}
+
+// BranchConfig controls branch naming conventions
+type BranchConfig struct {
+	// Prefix is the branch name prefix (default: "claudio")
+	// Examples: "claudio", "Iron-Ham", "feature"
+	Prefix string `mapstructure:"prefix"`
+	// IncludeID includes the instance ID in branch names (default: true)
+	// When true: <prefix>/<id>-<slug>
+	// When false: <prefix>/<slug>
+	IncludeID bool `mapstructure:"include_id"`
 }
 
 // PRConfig controls pull request creation behavior
@@ -114,6 +126,10 @@ func Default() *Config {
 			TmuxWidth:         200,
 			TmuxHeight:        50,
 		},
+		Branch: BranchConfig{
+			Prefix:    "claudio",
+			IncludeID: true,
+		},
 		PR: PRConfig{
 			Draft:        false,
 			AutoRebase:   true,
@@ -162,6 +178,10 @@ func SetDefaults() {
 	viper.SetDefault("instance.capture_interval_ms", defaults.Instance.CaptureIntervalMs)
 	viper.SetDefault("instance.tmux_width", defaults.Instance.TmuxWidth)
 	viper.SetDefault("instance.tmux_height", defaults.Instance.TmuxHeight)
+
+	// Branch defaults
+	viper.SetDefault("branch.prefix", defaults.Branch.Prefix)
+	viper.SetDefault("branch.include_id", defaults.Branch.IncludeID)
 
 	// PR defaults
 	viper.SetDefault("pr.draft", defaults.PR.Draft)

--- a/internal/orchestrator/branch_test.go
+++ b/internal/orchestrator/branch_test.go
@@ -1,0 +1,186 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/config"
+)
+
+func TestSlugify(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple text",
+			input:    "implement user authentication",
+			expected: "implement-user-authentication",
+		},
+		{
+			name:     "uppercase converted",
+			input:    "Fix Bug In Parser",
+			expected: "fix-bug-in-parser",
+		},
+		{
+			name:     "special characters removed",
+			input:    "add: user-auth (v2)",
+			expected: "add-user-auth-v2",
+		},
+		{
+			name:     "long text truncated",
+			input:    "this is a very long task description that exceeds the limit",
+			expected: "this-is-a-very-long-task-descr",
+		},
+		{
+			name:     "trailing dash removed",
+			input:    "fix bug: ",
+			expected: "fix-bug",
+		},
+		{
+			name:     "numbers preserved",
+			input:    "update api v2",
+			expected: "update-api-v2",
+		},
+		{
+			name:     "multiple spaces collapsed",
+			input:    "fix  multiple   spaces",
+			expected: "fix--multiple---spaces",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := slugify(tt.input)
+			if result != tt.expected {
+				t.Errorf("slugify(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGenerateBranchName(t *testing.T) {
+	tests := []struct {
+		name       string
+		prefix     string
+		includeID  bool
+		instanceID string
+		slug       string
+		expected   string
+	}{
+		{
+			name:       "default prefix with ID",
+			prefix:     "claudio",
+			includeID:  true,
+			instanceID: "abc12345",
+			slug:       "fix-bug",
+			expected:   "claudio/abc12345-fix-bug",
+		},
+		{
+			name:       "custom prefix with ID",
+			prefix:     "Iron-Ham",
+			includeID:  true,
+			instanceID: "def67890",
+			slug:       "add-feature",
+			expected:   "Iron-Ham/def67890-add-feature",
+		},
+		{
+			name:       "custom prefix without ID",
+			prefix:     "Iron-Ham",
+			includeID:  false,
+			instanceID: "xyz99999",
+			slug:       "refactor-auth",
+			expected:   "Iron-Ham/refactor-auth",
+		},
+		{
+			name:       "default prefix without ID",
+			prefix:     "claudio",
+			includeID:  false,
+			instanceID: "ignored",
+			slug:       "update-deps",
+			expected:   "claudio/update-deps",
+		},
+		{
+			name:       "empty prefix uses fallback",
+			prefix:     "",
+			includeID:  true,
+			instanceID: "abc123",
+			slug:       "test-task",
+			expected:   "claudio/abc123-test-task",
+		},
+		{
+			name:       "feature prefix",
+			prefix:     "feature",
+			includeID:  false,
+			instanceID: "ignored",
+			slug:       "user-dashboard",
+			expected:   "feature/user-dashboard",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Branch: config.BranchConfig{
+					Prefix:    tt.prefix,
+					IncludeID: tt.includeID,
+				},
+			}
+
+			// Create a minimal orchestrator with the config
+			o := &Orchestrator{
+				config: cfg,
+			}
+
+			result := o.generateBranchName(tt.instanceID, tt.slug)
+			if result != tt.expected {
+				t.Errorf("generateBranchName(%q, %q) with prefix=%q, includeID=%v = %q, want %q",
+					tt.instanceID, tt.slug, tt.prefix, tt.includeID, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBranchPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		expected string
+	}{
+		{
+			name:     "default prefix",
+			prefix:   "claudio",
+			expected: "claudio",
+		},
+		{
+			name:     "custom prefix",
+			prefix:   "Iron-Ham",
+			expected: "Iron-Ham",
+		},
+		{
+			name:     "empty prefix returns default",
+			prefix:   "",
+			expected: "claudio",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Branch: config.BranchConfig{
+					Prefix: tt.prefix,
+				},
+			}
+
+			o := &Orchestrator{
+				config: cfg,
+			}
+
+			result := o.BranchPrefix()
+			if result != tt.expected {
+				t.Errorf("BranchPrefix() with config prefix=%q = %q, want %q",
+					tt.prefix, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -251,9 +251,9 @@ func (o *Orchestrator) AddInstance(session *Session, task string) (*Instance, er
 	// Create instance
 	inst := NewInstance(task)
 
-	// Generate branch name from task
+	// Generate branch name from task using configured naming convention
 	branchSlug := slugify(task)
-	inst.Branch = fmt.Sprintf("claudio/%s-%s", inst.ID, branchSlug)
+	inst.Branch = o.generateBranchName(inst.ID, branchSlug)
 
 	// Create worktree
 	wtPath := filepath.Join(o.worktreeDir, inst.ID)
@@ -682,6 +682,28 @@ func (o *Orchestrator) generateContextMarkdown() string {
 	sb.WriteString("- Check this context file for updates on what others are doing\n")
 
 	return sb.String()
+}
+
+// generateBranchName creates a branch name using the configured naming convention
+func (o *Orchestrator) generateBranchName(instanceID, slug string) string {
+	prefix := o.config.Branch.Prefix
+	if prefix == "" {
+		prefix = "claudio" // fallback default
+	}
+
+	if o.config.Branch.IncludeID {
+		return fmt.Sprintf("%s/%s-%s", prefix, instanceID, slug)
+	}
+	return fmt.Sprintf("%s/%s", prefix, slug)
+}
+
+// BranchPrefix returns the configured branch prefix for use by other packages
+func (o *Orchestrator) BranchPrefix() string {
+	prefix := o.config.Branch.Prefix
+	if prefix == "" {
+		return "claudio"
+	}
+	return prefix
 }
 
 // slugify creates a URL-friendly slug from text


### PR DESCRIPTION
## Summary
- Add `branch.prefix` config option to customize branch name prefix (default: "claudio")
- Add `branch.include_id` config option to optionally omit instance ID from branch names
- Update cleanup command to respect configured branch prefix when discovering stale branches

## Test plan
- [ ] Verify default behavior unchanged (`claudio/<id>-<slug>`)
- [ ] Test custom prefix via config file (`branch.prefix: Iron-Ham`)
- [ ] Test `include_id: false` produces `<prefix>/<slug>` branches
- [ ] Verify cleanup discovers stale branches with custom prefix
- [ ] Run `go test ./internal/orchestrator/...` for unit tests