### PR TITLE
feat: add timeout detection and recovery for stuck instances

### DIFF
--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -17,6 +17,8 @@ const (
 	StatusCompleted    InstanceStatus = "completed"
 	StatusError        InstanceStatus = "error"
 	StatusCreatingPR   InstanceStatus = "creating_pr"
+	StatusStuck        InstanceStatus = "stuck"   // No activity for configured timeout period
+	StatusTimeout      InstanceStatus = "timeout" // Total runtime exceeded configured limit
 )
 
 // Metrics tracks resource usage and costs for an instance

--- a/internal/tui/config/config.go
+++ b/internal/tui/config/config.go
@@ -117,6 +117,27 @@ func New() Model {
 					Type:        "int",
 					Category:    "instance",
 				},
+				{
+					Key:         "instance.activity_timeout_minutes",
+					Label:       "Activity Timeout (min)",
+					Description: "Minutes of no output before marking as stuck (0 = disabled)",
+					Type:        "int",
+					Category:    "instance",
+				},
+				{
+					Key:         "instance.completion_timeout_minutes",
+					Label:       "Max Runtime (min)",
+					Description: "Maximum runtime in minutes before timeout (0 = disabled)",
+					Type:        "int",
+					Category:    "instance",
+				},
+				{
+					Key:         "instance.stale_detection",
+					Label:       "Stale Detection",
+					Description: "Detect stuck loops producing identical output",
+					Type:        "bool",
+					Category:    "instance",
+				},
 			},
 		},
 		{
@@ -563,17 +584,20 @@ func (m *Model) resetCurrentToDefault() {
 
 	// Map of keys to default values
 	defaultValues := map[string]interface{}{
-		"completion.default_action":    defaults.Completion.DefaultAction,
-		"tui.auto_focus_on_input":      defaults.TUI.AutoFocusOnInput,
-		"tui.max_output_lines":         defaults.TUI.MaxOutputLines,
-		"instance.output_buffer_size":  defaults.Instance.OutputBufferSize,
-		"instance.capture_interval_ms": defaults.Instance.CaptureIntervalMs,
-		"instance.tmux_width":          defaults.Instance.TmuxWidth,
-		"instance.tmux_height":         defaults.Instance.TmuxHeight,
-		"pr.draft":                     defaults.PR.Draft,
-		"pr.auto_rebase":               defaults.PR.AutoRebase,
-		"pr.use_ai":                    defaults.PR.UseAI,
-		"pr.auto_pr_on_stop":           defaults.PR.AutoPROnStop,
+		"completion.default_action":             defaults.Completion.DefaultAction,
+		"tui.auto_focus_on_input":               defaults.TUI.AutoFocusOnInput,
+		"tui.max_output_lines":                  defaults.TUI.MaxOutputLines,
+		"instance.output_buffer_size":           defaults.Instance.OutputBufferSize,
+		"instance.capture_interval_ms":          defaults.Instance.CaptureIntervalMs,
+		"instance.tmux_width":                   defaults.Instance.TmuxWidth,
+		"instance.tmux_height":                  defaults.Instance.TmuxHeight,
+		"instance.activity_timeout_minutes":     defaults.Instance.ActivityTimeoutMinutes,
+		"instance.completion_timeout_minutes":   defaults.Instance.CompletionTimeoutMinutes,
+		"instance.stale_detection":              defaults.Instance.StaleDetection,
+		"pr.draft":                              defaults.PR.Draft,
+		"pr.auto_rebase":                        defaults.PR.AutoRebase,
+		"pr.use_ai":                             defaults.PR.UseAI,
+		"pr.auto_pr_on_stop":                    defaults.PR.AutoPROnStop,
 	}
 
 	if defaultVal, ok := defaultValues[item.Key]; ok {

--- a/internal/tui/styles/styles.go
+++ b/internal/tui/styles/styles.go
@@ -30,6 +30,8 @@ var (
 	StatusComplete   = lipgloss.Color("#A78BFA") // Purple (brighter for readability)
 	StatusError      = lipgloss.Color("#EF4444") // Red
 	StatusCreatingPR = lipgloss.Color("#F472B6") // Pink (brighter for readability)
+	StatusStuck      = lipgloss.Color("#FB923C") // Orange - for stuck/no activity
+	StatusTimeout    = lipgloss.Color("#DC2626") // Dark red - for timeout exceeded
 
 	// Base styles
 	Title = lipgloss.NewStyle().
@@ -273,7 +275,37 @@ func StatusColor(status string) lipgloss.Color {
 		return StatusError
 	case "creating_pr":
 		return StatusCreatingPR
+	case "stuck":
+		return StatusStuck
+	case "timeout":
+		return StatusTimeout
 	default:
 		return MutedColor
+	}
+}
+
+// StatusIcon returns an icon for a given status
+func StatusIcon(status string) string {
+	switch status {
+	case "working":
+		return "●"
+	case "pending":
+		return "○"
+	case "waiting_input":
+		return "?"
+	case "paused":
+		return "⏸"
+	case "completed":
+		return "✓"
+	case "error":
+		return "✗"
+	case "creating_pr":
+		return "↗"
+	case "stuck":
+		return "⏱" // Timer icon for stuck/no activity
+	case "timeout":
+		return "⏰" // Alarm icon for timeout exceeded
+	default:
+		return "●"
 	}
 }


### PR DESCRIPTION
## Summary
- Add automatic detection of stuck or unresponsive Claude instances
- Configurable activity timeout (30 min default) triggers when no new output
- Configurable completion timeout (2 hr default) for maximum total runtime
- Stale detection via output pattern analysis
- UI indicators for stuck/timeout status
- Keyboard shortcuts for manual recovery (Ctrl+R to restart, Ctrl+K to kill)

## Test plan
- [ ] Verify activity timeout triggers after configured minutes of no output
- [ ] Verify completion timeout triggers after configured max runtime
- [ ] Test stuck detection with repetitive output patterns
- [ ] Test Ctrl+R to restart a stuck instance
- [ ] Test Ctrl+K to kill a stuck instance
- [ ] Verify status indicators update correctly in sidebar

Closes #18