### PR TITLE
fix: correct tmux pane dimension offsets for proper sizing

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -84,8 +84,8 @@ const (
 	SidebarMinWidth = 20 // Minimum sidebar width
 
 	// Layout offsets for content area calculation
-	ContentWidthOffset  = 5 // sidebar gap (3) + border chars (2)
-	ContentHeightOffset = 6 // header + help bar + margins
+	ContentWidthOffset  = 7  // sidebar gap (3) + output area margin (4)
+	ContentHeightOffset = 12 // header + help bar + instance info + task + status + scroll indicator
 )
 
 // CalculateContentDimensions returns the effective content area dimensions


### PR DESCRIPTION
## Summary
- Fixes tmux pane dimensions being larger than the TUI display area
- Width offset: 5 → 7 (accounts for sidebar gap of 3 + output area margin of 4)
- Height offset: 6 → 12 (matches `getOutputMaxLines()` calculation of `height - 12`)

## Problem
The Claude Code UI appeared slightly misaligned or cut off in its tmux panel because the tmux pane was created 2 characters wider and 6 lines taller than the actual display area.

## Test plan
- [ ] Launch Claudio and verify Claude Code UI fits properly within its panel
- [ ] Resize terminal window and confirm dimensions stay correct