### PR TITLE
fix: use infoMessage instead of undefined warningMessage field

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -226,7 +226,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case instance.TimeoutStale:
 				statusText = "stuck (repeated output)"
 			}
-			m.warningMessage = fmt.Sprintf("Instance %s is %s - use Ctrl+R to restart or Ctrl+K to kill", inst.ID, statusText)
+			m.infoMessage = fmt.Sprintf("Instance %s is %s - use Ctrl+R to restart or Ctrl+K to kill", inst.ID, statusText)
 		}
 		return m, nil
 	}


### PR DESCRIPTION
## Summary
- Fixes build error caused by reference to undefined `warningMessage` field on Model struct
- The timeout detection feature (8318f3f) added code referencing `m.warningMessage` but the field was never added to the struct
- Changed to use existing `infoMessage` field which serves the same purpose for non-error status messages

## Test plan
- [x] Verified `go build ./...` succeeds
- [x] Verified `go test ./...` passes