### PR TITLE
ci: add github pages deployment for documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,60 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+      - 'requirements-docs.txt'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Build documentation
+        run: mkdocs build --strict
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,5 @@
+# MkDocs documentation dependencies
+mkdocs>=1.6.0
+mkdocs-material>=9.5.0
+mkdocs-minify-plugin>=0.8.0
+pymdown-extensions>=10.0


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to automatically deploy MkDocs documentation to GitHub Pages
- Add `requirements-docs.txt` to pin Python dependencies for reproducible builds

The workflow triggers on:
- Pushes to `main` that modify `docs/`, `mkdocs.yml`, or the workflow itself
- Manual dispatch from the Actions tab

## Setup Required

After merging, enable GitHub Pages in repository settings:
1. Go to **Settings → Pages**
2. Under **Source**, select **"GitHub Actions"**

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] After merging, trigger workflow manually and confirm docs deploy to https://iron-ham.github.io/claudio/