### PR TITLE
feat: forward terminal bell notifications from tmux sessions

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -44,6 +44,9 @@ type Orchestrator struct {
 	// Callback for when an instance timeout is detected
 	timeoutCallback func(instanceID string, timeoutType instance.TimeoutType)
 
+	// Callback for when a terminal bell is detected in an instance
+	bellCallback func(instanceID string)
+
 	mu sync.RWMutex
 }
 
@@ -176,6 +179,11 @@ func (o *Orchestrator) RecoverSession() (*Session, []string, error) {
 			// Configure timeout callback
 			mgr.SetTimeoutCallback(func(id string, timeoutType instance.TimeoutType) {
 				o.handleInstanceTimeout(id, timeoutType)
+			})
+
+			// Configure bell callback to forward terminal bells
+			mgr.SetBellCallback(func(id string) {
+				o.handleInstanceBell(id)
 			})
 
 			if err := mgr.Reconnect(); err == nil {
@@ -337,6 +345,11 @@ func (o *Orchestrator) StartInstance(inst *Instance) error {
 		o.handleInstanceTimeout(id, timeoutType)
 	})
 
+	// Configure bell callback to forward terminal bells
+	mgr.SetBellCallback(func(id string) {
+		o.handleInstanceBell(id)
+	})
+
 	if err := mgr.Start(); err != nil {
 		return fmt.Errorf("failed to start instance: %w", err)
 	}
@@ -468,6 +481,13 @@ func (o *Orchestrator) SetTimeoutCallback(cb func(instanceID string, timeoutType
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.timeoutCallback = cb
+}
+
+// SetBellCallback sets the callback for when a terminal bell is detected in an instance
+func (o *Orchestrator) SetBellCallback(cb func(instanceID string)) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.bellCallback = cb
 }
 
 // GetPRWorkflow returns the PR workflow for an instance, if any
@@ -974,6 +994,17 @@ func (o *Orchestrator) handleInstanceTimeout(id string, timeoutType instance.Tim
 	}
 }
 
+// handleInstanceBell handles when a terminal bell is detected in an instance
+func (o *Orchestrator) handleInstanceBell(id string) {
+	o.mu.RLock()
+	callback := o.bellCallback
+	o.mu.RUnlock()
+
+	if callback != nil {
+		callback(id)
+	}
+}
+
 // executeNotification executes a notification command from config
 func (o *Orchestrator) executeNotification(configKey string, inst *Instance) {
 	cmd := viper.GetString(configKey)
@@ -1049,6 +1080,11 @@ func (o *Orchestrator) ReconnectInstance(inst *Instance) error {
 	// Configure timeout callback
 	mgr.SetTimeoutCallback(func(id string, timeoutType instance.TimeoutType) {
 		o.handleInstanceTimeout(id, timeoutType)
+	})
+
+	// Configure bell callback to forward terminal bells
+	mgr.SetBellCallback(func(id string) {
+		o.handleInstanceBell(id)
 	})
 
 	// Check if the tmux session still exists


### PR DESCRIPTION
## Summary
- Add bell detection and forwarding to propagate terminal bell notifications from Claude sessions running in tmux up to the parent terminal
- Enable users to receive system notifications when Claude requires attention (e.g., permission prompts, task completion)
- Use edge detection to fire callback once per bell event rather than continuously

## Changes
- Add `BellCallback` to instance `Manager` with edge detection
- Enable `monitor-bell` tmux option for bell flag tracking
- Forward bell events through `Orchestrator` to TUI layer
- Output bell character to stdout in Bubbletea's alt-screen mode

## Test plan
- [ ] Start a Claudio instance and trigger a bell in the tmux session
- [ ] Verify the bell is forwarded to the parent terminal
- [ ] Verify bell only fires once per event (edge detection works)
- [ ] Test reconnection preserves bell functionality