### PR TITLE
fix(tui): prevent panic when backspacing in slash-command mode

### DIFF
--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -490,3 +490,54 @@ func TestIsWordChar(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderAddTaskCursorBounds(t *testing.T) {
+	// This test verifies that renderAddTask doesn't panic when cursor is out of bounds
+	// Regression test for: https://github.com/Iron-Ham/claudio/issues/XX
+	// The bug occurred when backspacing in slash-command mode caused cursor > len(text)
+	tests := []struct {
+		name   string
+		input  string
+		cursor int
+	}{
+		{
+			name:   "cursor beyond empty string",
+			input:  "",
+			cursor: 1, // This was the panic case: [1:0]
+		},
+		{
+			name:   "cursor way beyond string length",
+			input:  "ab",
+			cursor: 10,
+		},
+		{
+			name:   "negative cursor",
+			input:  "hello",
+			cursor: -5,
+		},
+		{
+			name:   "cursor at exact length (valid)",
+			input:  "hello",
+			cursor: 5,
+		},
+		{
+			name:   "cursor at beginning (valid)",
+			input:  "hello",
+			cursor: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Model{
+				taskInput:       tt.input,
+				taskInputCursor: tt.cursor,
+			}
+			// This should not panic
+			result := m.renderAddTask(80)
+			if result == "" {
+				t.Error("renderAddTask returned empty string")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fix cursor position desynchronization in template dropdown handler
- Add defensive bounds checking in `renderAddTask()` as safety net
- Add regression test for cursor bounds validation

## Problem

When in slash-command mode (e.g., typing `/abc`), backspacing would cause a panic:

```
runtime error: slice bounds out of range [1:0]
```

The template dropdown handler modified `taskInput` directly without updating `taskInputCursor`. After backspacing through the text, cursor position exceeded the text length, causing slice operations to panic.

## Test plan

- [x] Run `go test ./internal/tui/...` - all tests pass including new regression test
- [x] Run `go build ./...` - builds successfully
- [ ] Manual: Start app, type `/`, then backspace - should not panic