### PR TITLE
feat(ultraplan): auto-parse plan when coordinator completes

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1733,6 +1733,11 @@ func (m *Model) updateInstanceStatus(inst *orchestrator.Instance, mgr *instance.
 
 // handleInstanceCompleted handles post-completion actions based on config
 func (m *Model) handleInstanceCompleted(inst *orchestrator.Instance) {
+	// Check if this is an ultra-plan coordinator instance completing
+	if m.handleUltraPlanCoordinatorCompletion(inst) {
+		return
+	}
+
 	cfg := config.Get()
 
 	switch cfg.Completion.DefaultAction {


### PR DESCRIPTION
## Summary

- Auto-detect when the planning coordinator instance completes
- Automatically parse the plan from output and transition to refresh phase
- Display helpful message with task/group counts and next steps

Previously users had to manually press `[p]` to parse the plan with no indication of when planning was done. Now the UX is seamless.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/tui/... ./internal/orchestrator/...` passes
- [ ] Manual test with `claudio ultraplan "objective"` to verify auto-parse works