### PR TITLE
fix(instance): increase stale detection threshold to 5 minutes

### DIFF
--- a/internal/instance/manager.go
+++ b/internal/instance/manager.go
@@ -369,9 +369,10 @@ func (m *Manager) checkTimeouts() {
 	}
 
 	// Check for stale detection (repeated identical output)
-	// Trigger if we've seen the same output 600 times (1 minute at 100ms interval)
-	// This catches stuck loops producing identical output
-	if triggeredTimeout == nil && m.config.StaleDetection && m.repeatedOutputCount > 600 {
+	// Trigger if we've seen the same output 3000 times (5 minutes at 100ms interval)
+	// This catches stuck loops producing identical output while allowing time for
+	// legitimate long-running operations like planning and exploration
+	if triggeredTimeout == nil && m.config.StaleDetection && m.repeatedOutputCount > 3000 {
 		t := TimeoutStale
 		triggeredTimeout = &t
 		m.timedOut = true


### PR DESCRIPTION
## Summary

The stale detection threshold was 1 minute (600 captures at 100ms), which is too aggressive for planning and exploration tasks where Claude may read files and think without producing visible output for extended periods.

Increased to 5 minutes (3000 captures).

## Root cause

During ultra-plan planning phase, Claude explores the codebase by reading many files. If it doesn't produce visible output for >1 minute, the stale detection triggers and marks the instance as "stuck (repeated output)".

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/instance/...` passes