### PR TITLE
fix(instance): inherit full environment when spawning tmux sessions

### DIFF
--- a/internal/instance/manager.go
+++ b/internal/instance/manager.go
@@ -207,8 +207,8 @@ func (m *Manager) Start() error {
 		"-y", fmt.Sprintf("%d", m.config.TmuxHeight), // height
 	)
 	createCmd.Dir = m.workdir
-	// Ensure TERM supports colors
-	createCmd.Env = append(createCmd.Env, "TERM=xterm-256color")
+	// Inherit full environment (required for Claude credentials) and ensure TERM supports colors
+	createCmd.Env = append(os.Environ(), "TERM=xterm-256color")
 	if err := createCmd.Run(); err != nil {
 		return fmt.Errorf("failed to create tmux session: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Fix environment inheritance bug where tmux sessions lost all environment variables
- Spawned Claude instances now properly inherit API credentials and other env vars

## Problem

When creating a tmux session, the code was using:
```go
createCmd.Env = append(createCmd.Env, "TERM=xterm-256color")
```

Since `createCmd.Env` starts as nil, this created an environment with ONLY `TERM=xterm-256color`, losing:
- `HOME` - needed for `~/.claude` credentials
- `PATH` - needed to find the claude command  
- Any API keys or auth tokens

## Solution

Changed to:
```go
createCmd.Env = append(os.Environ(), "TERM=xterm-256color")
```

This properly inherits the full parent environment and then adds the TERM variable.

## Test plan

- [x] Build succeeds
- [x] Instance tests pass
- [ ] Manual test: Run ultraplan mode - should now inherit API credentials