### PR TITLE
feat(ultraplan): use file-based plan detection for better reliability

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -217,6 +217,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tickMsg:
 		// Update outputs from instances
 		m.updateOutputs()
+		// Check for plan file during planning phase (proactive detection)
+		m.checkForPlanFile()
 		// Clear info message after display (will show for ~100ms per tick, so a few ticks)
 		// We'll let it persist for a bit by not clearing immediately
 		return m, tick()


### PR DESCRIPTION
## Summary

- Shorter planning prompt (~25 lines vs ~50) improves user visibility
- Claude writes plan to `.claudio-plan.json` file instead of `<plan></plan>` output tags
- Proactive file detection during tick updates catches plan as soon as it's written
- Maintains backwards compatibility with output parsing as fallback

## Problem

The previous approach had two issues:
1. **Visibility**: The 50-line prompt made it hard for users to see actual work happening
2. **Reliability**: Getting Claude to output `<plan>` tags was unreliable - it would explore thoroughly but stop before outputting the plan

## Solution

Changed the planning flow to instruct Claude to write a JSON file:
- `PlanFileName = ".claudio-plan.json"` written to the worktree
- `ParsePlanFromFile()` reads and parses the plan
- `checkForPlanFile()` checks during tick updates (proactive detection)
- `tryParsePlan()` tries file first, falls back to output parsing

## Test plan

- [x] Build succeeds
- [x] All orchestrator tests pass
- [ ] Manual test: Run ultraplan and verify file-based detection works