### PR TITLE
fix(instance): reduce default tmux height for better visibility

### DIFF
--- a/internal/instance/manager.go
+++ b/internal/instance/manager.go
@@ -45,8 +45,8 @@ func DefaultManagerConfig() ManagerConfig {
 		OutputBufferSize:         100000, // 100KB
 		CaptureIntervalMs:        100,
 		TmuxWidth:                200,
-		TmuxHeight:               50,
-		ActivityTimeoutMinutes:   30,  // 30 minutes of no activity
+		TmuxHeight:               30, // Shorter height so prompts scroll off and users see actual work
+		ActivityTimeoutMinutes:   30, // 30 minutes of no activity
 		CompletionTimeoutMinutes: 120, // 2 hours max runtime
 		StaleDetection:           true,
 	}


### PR DESCRIPTION
## Summary

- Reduce default tmux pane height from 50 to 30 lines
- In ultraplan mode, the planning prompt dominated the view making it hard for users to see actual work happening
- Shorter height allows the prompt to scroll off faster so users can observe the planning progress

## Test plan

- [x] Run ultraplan mode and verify pane height is more reasonable
- [x] Verify users can see actual Claude activity after initial prompt