### PR TITLE
feat(ultraplan): auto-proceed after plan detection

### DIFF
--- a/internal/orchestrator/coordinator.go
+++ b/internal/orchestrator/coordinator.go
@@ -232,6 +232,10 @@ func (c *Coordinator) SetPlan(plan *PlanSpec) error {
 	_ = c.orch.SaveSession()
 
 	c.notifyPlanReady(plan)
+
+	// Transition to refresh phase (plan ready, waiting for execution)
+	c.notifyPhaseChange(PhaseRefresh)
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- `SetPlan()` now automatically transitions to `PhaseRefresh` after a plan is set
- `checkForPlanFile()` stops the coordinator instance after plan is detected (it's done its job)
- If `AutoApprove` config is enabled, execution starts automatically
- Removes the need for manual "Exit plan mode?" confirmation in the Claude session

This addresses the issue where the planning coordinator would get stuck waiting for user input after writing the plan file, requiring manual intervention to proceed.

## Test plan

- [x] Plan detection automatically transitions phase to `PhaseRefresh`
- [x] Coordinator instance is stopped after plan detection
- [x] With `AutoApprove=false`: Shows message prompting user to press [e]
- [x] With `AutoApprove=true`: Auto-starts execution