### PR TITLE
fix(ultraplan): detect task completion when waiting for input

### DIFF
--- a/internal/orchestrator/coordinator.go
+++ b/internal/orchestrator/coordinator.go
@@ -431,6 +431,18 @@ func (c *Coordinator) monitorTaskInstance(taskID, instanceID string, completionC
 				}
 				return
 
+			case StatusWaitingInput:
+				// Task finished its assigned work and is now waiting at a prompt.
+				// For ultraplan tasks, this means the task is complete.
+				// Stop the instance to free up resources.
+				_ = c.orch.StopInstance(inst)
+				completionChan <- taskCompletion{
+					taskID:     taskID,
+					instanceID: instanceID,
+					success:    true,
+				}
+				return
+
 			case StatusError, StatusTimeout, StatusStuck:
 				completionChan <- taskCompletion{
 					taskID:     taskID,


### PR DESCRIPTION
## Summary
- Treats `StatusWaitingInput` as task completion for ultraplan tasks
- When a task finishes its work and Claude waits at a prompt, the task is now marked complete
- Stops the completed instance to free resources for the next execution group

## Problem
Previously, `monitorTaskInstance` only recognized `StatusCompleted` (Claude fully exited). But ultraplan tasks reach `StatusWaitingInput` when Claude finishes its assigned work and waits at a prompt offering to do more. This caused dependent tasks (group 2+) to never start.

## Test plan
- [ ] Start an ultraplan with dependent task groups
- [ ] Verify group 1 tasks are marked complete when they reach a prompt
- [ ] Verify group 2 tasks automatically start after group 1 completes
- [ ] Verify task instances are stopped after completion