### PR TITLE
fix(instance): properly detect task completion in ultraplan mode

### DIFF
--- a/internal/instance/manager.go
+++ b/internal/instance/manager.go
@@ -334,10 +334,18 @@ func (m *Manager) captureLoop() {
 			// Check if the session is still running
 			checkCmd := exec.Command("tmux", "has-session", "-t", sessionName)
 			if checkCmd.Run() != nil {
-				// Session ended
+				// Session ended - notify completion and stop
 				m.mu.Lock()
 				m.running = false
+				callback := m.stateCallback
+				instanceID := m.id
+				m.currentState = StateCompleted
 				m.mu.Unlock()
+
+				// Fire the completion callback so coordinator knows task is done
+				if callback != nil {
+					callback(instanceID, StateCompleted)
+				}
 				return
 			}
 		}


### PR DESCRIPTION
## Summary
Two fixes for ultraplan task completion detection:

1. **Detector**: Add patterns to recognize Claude Code's idle prompt indicators (`⏵⏵ bypass permissions`, `↵ send`) as `StateWaitingInput`. Previously, when Claude finished a task and returned to its prompt, no pattern matched and it stayed in `StateWorking`.

2. **Manager**: Fire `StateCompleted` callback when tmux session terminates. When Claude exits (via `/exit` or process termination), the capture loop would silently return without notifying the coordinator. Now it fires the completion callback so dependent tasks can start.

## Problem
Ultraplan tasks would complete their work but the coordinator never recognized it:
- Claude finishes task → returns to prompt → detector returns `StateWorking` (no pattern matches)
- User sends `/exit` → Claude exits → capture loop returns without firing callback → coordinator never knows

## Test plan
- [ ] Start ultraplan with dependent task groups
- [ ] Verify group 1 tasks are detected as complete when Claude returns to prompt
- [ ] Send `/exit` to a task and verify completion is detected
- [ ] Verify group 2 tasks start after group 1 completes