### PR TITLE
feat: add multi-session support for concurrent TUI windows

### DIFF
--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -117,3 +117,9 @@ func generateID() string {
 	_, _ = rand.Read(bytes)
 	return hex.EncodeToString(bytes)
 }
+
+// GenerateID generates a new random 8-character hex ID for sessions and instances.
+// Exported for use by cmd package.
+func GenerateID() string {
+	return generateID()
+}

--- a/internal/session/discovery.go
+++ b/internal/session/discovery.go
@@ -1,0 +1,176 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// SessionsDir is the directory name within .claudio that contains all sessions
+const SessionsDir = "sessions"
+
+// SessionFileName is the name of the session data file within a session directory
+const SessionFileName = "session.json"
+
+// Info contains summary information about a session
+type Info struct {
+	ID            string    `json:"id"`
+	Name          string    `json:"name"`
+	Created       time.Time `json:"created"`
+	InstanceCount int       `json:"instance_count"`
+	IsLocked      bool      `json:"is_locked"`
+	LockInfo      *Lock     `json:"lock_info,omitempty"`
+	SessionDir    string    `json:"session_dir"`
+}
+
+// SessionData represents the minimal session structure needed for discovery.
+// This mirrors the Session struct from orchestrator but only includes
+// the fields we need for listing.
+type SessionData struct {
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Created   time.Time       `json:"created"`
+	Instances json.RawMessage `json:"instances"` // Keep raw to count without full parsing
+}
+
+// GetSessionsDir returns the path to the sessions directory for a given base directory
+func GetSessionsDir(baseDir string) string {
+	return filepath.Join(baseDir, ".claudio", SessionsDir)
+}
+
+// GetSessionDir returns the path to a specific session's directory
+func GetSessionDir(baseDir, sessionID string) string {
+	return filepath.Join(GetSessionsDir(baseDir), sessionID)
+}
+
+// ListSessions returns information about all sessions in the base directory.
+// Sessions are discovered by scanning .claudio/sessions/ for subdirectories
+// containing session.json files.
+func ListSessions(baseDir string) ([]*Info, error) {
+	sessionsDir := GetSessionsDir(baseDir)
+
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // No sessions directory = no sessions
+		}
+		return nil, err
+	}
+
+	var sessions []*Info
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		sessionID := entry.Name()
+		info, err := GetSessionInfo(baseDir, sessionID)
+		if err != nil {
+			// Skip sessions we can't read
+			continue
+		}
+
+		sessions = append(sessions, info)
+	}
+
+	return sessions, nil
+}
+
+// GetSessionInfo returns detailed information about a specific session.
+func GetSessionInfo(baseDir, sessionID string) (*Info, error) {
+	sessionDir := GetSessionDir(baseDir, sessionID)
+	sessionFile := filepath.Join(sessionDir, SessionFileName)
+
+	data, err := os.ReadFile(sessionFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var sessionData SessionData
+	if err := json.Unmarshal(data, &sessionData); err != nil {
+		return nil, err
+	}
+
+	// Count instances from raw JSON
+	instanceCount := 0
+	if sessionData.Instances != nil {
+		var instances []json.RawMessage
+		if err := json.Unmarshal(sessionData.Instances, &instances); err == nil {
+			instanceCount = len(instances)
+		}
+	}
+
+	// Check lock status
+	lockInfo, isLocked := IsLocked(sessionDir)
+
+	return &Info{
+		ID:            sessionData.ID,
+		Name:          sessionData.Name,
+		Created:       sessionData.Created,
+		InstanceCount: instanceCount,
+		IsLocked:      isLocked,
+		LockInfo:      lockInfo,
+		SessionDir:    sessionDir,
+	}, nil
+}
+
+// SessionExists checks if a session with the given ID exists.
+func SessionExists(baseDir, sessionID string) bool {
+	sessionDir := GetSessionDir(baseDir, sessionID)
+	sessionFile := filepath.Join(sessionDir, SessionFileName)
+	_, err := os.Stat(sessionFile)
+	return err == nil
+}
+
+// FindUnlockedSessions returns all sessions that are not currently locked.
+func FindUnlockedSessions(baseDir string) ([]*Info, error) {
+	sessions, err := ListSessions(baseDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var unlocked []*Info
+	for _, s := range sessions {
+		if !s.IsLocked {
+			unlocked = append(unlocked, s)
+		}
+	}
+
+	return unlocked, nil
+}
+
+// CleanupStaleLocks iterates through all sessions and removes stale lock files.
+// Returns the IDs of sessions that had stale locks cleaned.
+func CleanupStaleLocks(baseDir string) ([]string, error) {
+	sessionsDir := GetSessionsDir(baseDir)
+
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var cleaned []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		sessionID := entry.Name()
+		sessionDir := GetSessionDir(baseDir, sessionID)
+
+		wasCleaned, err := CleanStaleLock(sessionDir)
+		if err != nil {
+			continue // Skip errors, try other sessions
+		}
+
+		if wasCleaned {
+			cleaned = append(cleaned, sessionID)
+		}
+	}
+
+	return cleaned, nil
+}

--- a/internal/session/lock.go
+++ b/internal/session/lock.go
@@ -1,0 +1,181 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// LockFileName is the name of the lock file within a session directory
+const LockFileName = "session.lock"
+
+// ErrSessionLocked is returned when attempting to acquire a lock on an already-locked session
+var ErrSessionLocked = errors.New("session is locked by another process")
+
+// Lock represents an acquired session lock
+type Lock struct {
+	SessionID string    `json:"session_id"`
+	PID       int       `json:"pid"`
+	Hostname  string    `json:"hostname"`
+	StartedAt time.Time `json:"started_at"`
+
+	// Internal fields (not serialized)
+	lockFile string
+}
+
+// AcquireLock attempts to acquire an exclusive lock on the session directory.
+// Returns ErrSessionLocked if the session is already in use by another process.
+func AcquireLock(sessionDir, sessionID string) (*Lock, error) {
+	lockPath := filepath.Join(sessionDir, LockFileName)
+
+	// Check for existing lock
+	if existingLock, err := ReadLock(lockPath); err == nil {
+		// Lock file exists - check if the process is still alive
+		if isProcessAlive(existingLock.PID) {
+			return nil, fmt.Errorf("%w: PID %d on %s", ErrSessionLocked, existingLock.PID, existingLock.Hostname)
+		}
+		// Stale lock - remove it
+		if err := os.Remove(lockPath); err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to remove stale lock: %w", err)
+		}
+	}
+
+	// Get hostname
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "unknown"
+	}
+
+	// Create lock
+	lock := &Lock{
+		SessionID: sessionID,
+		PID:       os.Getpid(),
+		Hostname:  hostname,
+		StartedAt: time.Now(),
+		lockFile:  lockPath,
+	}
+
+	// Write lock file
+	data, err := json.MarshalIndent(lock, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal lock: %w", err)
+	}
+
+	// Use O_EXCL to fail if file already exists (race condition protection)
+	f, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+	if err != nil {
+		if os.IsExist(err) {
+			// Another process beat us to it - re-read and report
+			if existingLock, readErr := ReadLock(lockPath); readErr == nil {
+				return nil, fmt.Errorf("%w: PID %d on %s", ErrSessionLocked, existingLock.PID, existingLock.Hostname)
+			}
+			return nil, ErrSessionLocked
+		}
+		return nil, fmt.Errorf("failed to create lock file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(data); err != nil {
+		os.Remove(lockPath)
+		return nil, fmt.Errorf("failed to write lock file: %w", err)
+	}
+
+	return lock, nil
+}
+
+// Release releases the session lock by removing the lock file.
+// Safe to call multiple times.
+func (l *Lock) Release() error {
+	if l == nil || l.lockFile == "" {
+		return nil
+	}
+
+	// Only remove if we own the lock (PID matches)
+	existingLock, err := ReadLock(l.lockFile)
+	if err != nil {
+		// Lock file doesn't exist or can't be read - nothing to do
+		return nil
+	}
+
+	if existingLock.PID != l.PID {
+		// Not our lock - don't remove it
+		return nil
+	}
+
+	return os.Remove(l.lockFile)
+}
+
+// ReadLock reads a lock file and returns the Lock info.
+func ReadLock(lockPath string) (*Lock, error) {
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var lock Lock
+	if err := json.Unmarshal(data, &lock); err != nil {
+		return nil, fmt.Errorf("failed to parse lock file: %w", err)
+	}
+	lock.lockFile = lockPath
+
+	return &lock, nil
+}
+
+// IsLocked checks if a session directory is currently locked.
+// Returns the lock info if locked, nil otherwise.
+func IsLocked(sessionDir string) (*Lock, bool) {
+	lockPath := filepath.Join(sessionDir, LockFileName)
+
+	lock, err := ReadLock(lockPath)
+	if err != nil {
+		return nil, false
+	}
+
+	// Check if the process is still alive
+	if !isProcessAlive(lock.PID) {
+		// Stale lock
+		return lock, false
+	}
+
+	return lock, true
+}
+
+// CleanStaleLock removes a stale lock file if the owning process is no longer running.
+// Returns true if a stale lock was cleaned.
+func CleanStaleLock(sessionDir string) (bool, error) {
+	lockPath := filepath.Join(sessionDir, LockFileName)
+
+	lock, err := ReadLock(lockPath)
+	if err != nil {
+		// No lock file
+		return false, nil
+	}
+
+	if isProcessAlive(lock.PID) {
+		// Process is still running - not stale
+		return false, nil
+	}
+
+	// Stale lock - remove it
+	if err := os.Remove(lockPath); err != nil {
+		return false, fmt.Errorf("failed to remove stale lock: %w", err)
+	}
+
+	return true, nil
+}
+
+// isProcessAlive checks if a process with the given PID is still running.
+func isProcessAlive(pid int) bool {
+	// On Unix, sending signal 0 checks if process exists without affecting it
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+
+	err = process.Signal(syscall.Signal(0))
+	return err == nil
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -51,6 +51,9 @@ func NewWithUltraPlan(orch *orchestrator.Orchestrator, session *orchestrator.Ses
 
 // Run starts the TUI application
 func (a *App) Run() error {
+	// Ensure session lock is released when TUI exits (both normal and signal-based)
+	defer a.orchestrator.ReleaseLock()
+
 	a.program = tea.NewProgram(
 		a.model,
 		tea.WithAltScreen(),


### PR DESCRIPTION
## Summary
- Enable multiple Claudio TUI windows to run simultaneously with isolated sessions
- Each session gets its own storage directory (`.claudio/sessions/{sessionID}/`)
- PID-based locking prevents concurrent access to the same session
- Auto-migrate legacy single-session format on first run

## Changes
- **New `internal/session/` package**: Session locking (`lock.go`) and discovery (`discovery.go`)
- **Tmux naming**: Changed from `claudio-{instanceID}` to `claudio-{sessionID}-{instanceID}`
- **CLI commands**: Updated `sessions list`, `sessions attach`, `sessions clean`
- **Lock release**: TUI releases session lock on exit via `defer`

## CLI Usage
| Command | Behavior |
|---------|----------|
| `claudio start` | Lists unlocked sessions, prompts attach/new |
| `claudio start --session <id>` | Attach to specific session |
| `claudio start --new` | Force create new session |
| `claudio sessions list` | Show all sessions with lock status |
| `claudio sessions attach <id>` | Attach to session by ID |
| `claudio sessions clean` | Clean orphaned sessions/locks |

## Test plan
- [x] Code compiles (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [ ] Manual test: Start multiple TUI windows in different terminals
- [ ] Manual test: Verify lock prevents double-attach to same session
- [ ] Manual test: Legacy session migration works