### PR TITLE
feat(ultraplan): add synthesis phase visibility in sidebar

### DIFF
--- a/internal/orchestrator/coordinator.go
+++ b/internal/orchestrator/coordinator.go
@@ -520,6 +520,10 @@ func (c *Coordinator) RunSynthesis() error {
 		return fmt.Errorf("failed to create synthesis instance: %w", err)
 	}
 
+	// Store the synthesis instance ID for TUI visibility
+	session := c.Session()
+	session.SynthesisID = inst.ID
+
 	// Start the instance
 	if err := c.orch.StartInstance(inst); err != nil {
 		return fmt.Errorf("failed to start synthesis instance: %w", err)

--- a/internal/orchestrator/ultraplan.go
+++ b/internal/orchestrator/ultraplan.go
@@ -93,8 +93,9 @@ type UltraPlanSession struct {
 	Plan            *PlanSpec         `json:"plan,omitempty"`
 	Phase           UltraPlanPhase    `json:"phase"`
 	Config          UltraPlanConfig   `json:"config"`
-	CoordinatorID   string            `json:"coordinator_id,omitempty"`    // Instance ID of the coordinator
-	TaskToInstance  map[string]string `json:"task_to_instance"`            // PlannedTask.ID -> Instance.ID
+	CoordinatorID  string            `json:"coordinator_id,omitempty"` // Instance ID of the planning coordinator
+	SynthesisID    string            `json:"synthesis_id,omitempty"`   // Instance ID of the synthesis reviewer
+	TaskToInstance map[string]string `json:"task_to_instance"`         // PlannedTask.ID -> Instance.ID
 	CompletedTasks  []string          `json:"completed_tasks"`
 	FailedTasks     []string          `json:"failed_tasks"`
 	CurrentGroup    int               `json:"current_group"`               // Index into ExecutionOrder


### PR DESCRIPTION
## Summary
- Add dedicated sidebar view during synthesis phase showing reviewer status
- Track synthesis instance ID in UltraPlanSession for TUI visibility
- Match existing pattern used for Planning and Consolidation phases

## Test plan
- [x] Code compiles successfully
- [x] All tests pass
- [ ] Manual test: run ultraplan session through synthesis phase and verify sidebar shows reviewer status