### PR TITLE
fix(ultraplan): prevent consolidation from firing before synthesis completes

### DIFF
--- a/internal/tui/ultraplan.go
+++ b/internal/tui/ultraplan.go
@@ -837,7 +837,9 @@ func (m Model) renderUltraPlanHelp() string {
 		keys = append(keys, "[c] cancel")
 
 	case orchestrator.PhaseSynthesis:
+		keys = append(keys, "[i] input mode")
 		keys = append(keys, "[v] toggle plan view")
+		keys = append(keys, "[s] done → consolidate")
 
 	case orchestrator.PhaseConsolidating:
 		keys = append(keys, "[v] toggle plan view")
@@ -1038,6 +1040,17 @@ func (m Model) handleUltraPlanKeypress(msg tea.KeyMsg) (bool, tea.Model, tea.Cmd
 			session.Consolidation.Phase == orchestrator.ConsolidationPaused {
 			// TODO: Implement resume functionality when coordinator exposes it
 			m.infoMessage = "Resuming consolidation..."
+		}
+		return true, m, nil
+
+	case "s":
+		// Signal synthesis is done, proceed to consolidation
+		if session.Phase == orchestrator.PhaseSynthesis {
+			if err := m.ultraPlan.coordinator.TriggerConsolidation(); err != nil {
+				m.errorMessage = fmt.Sprintf("Failed to proceed: %v", err)
+			} else {
+				m.infoMessage = "Proceeding to consolidation..."
+			}
 		}
 		return true, m, nil
 	}


### PR DESCRIPTION
## Summary

- Fixes a bug where consolidation phase would fire prematurely when the synthesis instance was waiting for user input (permission approval, questions, etc.)
- `StatusWaitingInput` is no longer treated as completion for synthesis - only `StatusCompleted` triggers automatic progression
- Adds `[s]` keybinding during synthesis phase to manually signal "done, proceed to consolidation"
- Adds `[i]` input mode to synthesis help bar so users know they can interact with the reviewer

## Test plan

- [ ] Start an ultraplan session with synthesis enabled
- [ ] Let it reach synthesis phase
- [ ] Verify synthesis instance waiting for input does NOT trigger consolidation
- [ ] Interact with the synthesis instance (ask questions, etc.)
- [ ] Press `[s]` to trigger consolidation
- [ ] Verify consolidation starts properly