### PR TITLE
feat(ultraplan): consolidate groups incrementally to preserve context

### DIFF
--- a/internal/orchestrator/ultraplan.go
+++ b/internal/orchestrator/ultraplan.go
@@ -208,6 +208,11 @@ type UltraPlanSession struct {
 	// Task worktree information for consolidation context
 	TaskWorktrees []TaskWorktreeInfo `json:"task_worktrees,omitempty"`
 
+	// Per-group consolidated branches: index -> branch name
+	// After each group completes, parallel task branches are merged into one consolidated branch
+	// The next group's tasks use this consolidated branch as their base
+	GroupConsolidatedBranches []string `json:"group_consolidated_branches,omitempty"`
+
 	// Consolidation results (persisted for recovery and display)
 	Consolidation *ConsolidationState `json:"consolidation,omitempty"`
 	PRUrls        []string            `json:"pr_urls,omitempty"`

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -39,6 +39,22 @@ func (m *Manager) Create(path, branch string) error {
 	return nil
 }
 
+// CreateFromBranch creates a new worktree at the given path with a new branch based off a specific base branch.
+// This is used when we want a task's branch to start from a consolidated branch rather than HEAD.
+func (m *Manager) CreateFromBranch(path, newBranch, baseBranch string) error {
+	// Use git worktree add -b <newBranch> <path> <baseBranch>
+	// This creates a worktree at <path> with a new branch <newBranch> starting from <baseBranch>
+	cmd := exec.Command("git", "worktree", "add", "-b", newBranch, path, baseBranch)
+	cmd.Dir = m.repoDir
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to create worktree from branch %s: %w\n%s", baseBranch, err, string(output))
+	}
+
+	return nil
+}
+
 // Remove removes a worktree
 func (m *Manager) Remove(path string) error {
 	// First, try to remove the worktree


### PR DESCRIPTION
## Summary
- Adds incremental consolidation after each execution group completes
- Parallel task branches in a group are merged into one consolidated branch
- Next group's tasks branch from the consolidated branch, preserving context
- Changes become additive across groups rather than parallel and disconnected

## Changes
- `UltraPlanSession.GroupConsolidatedBranches`: Track consolidated branch per group
- `worktree.CreateFromBranch()`: Create worktree with branch from specific base
- `Orchestrator.AddInstanceFromBranch()`: Create instance branching from consolidated
- `Coordinator.consolidateGroup()`: Cherry-pick merge parallel branches per group
- `checkAndAdvanceGroup()`: Trigger consolidation after group completion
- `startTask()`: Use consolidated branch as base for subsequent groups

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/orchestrator/...` passes
- [x] `go vet ./...` passes