### PR TITLE
fix(ultraplan): verify task commits before marking complete

### DIFF
--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -403,6 +403,22 @@ func (m *Manager) GetCommitsBetween(path, baseBranch, headBranch string) ([]stri
 	return strings.Split(lines, "\n"), nil
 }
 
+// CountCommitsBetween returns the number of commits between base and head branches.
+// This is more efficient than GetCommitsBetween when you only need the count.
+func (m *Manager) CountCommitsBetween(path, baseBranch, headBranch string) (int, error) {
+	cmd := exec.Command("git", "rev-list", "--count", baseBranch+".."+headBranch)
+	cmd.Dir = path
+
+	output, err := cmd.Output()
+	if err != nil {
+		return 0, fmt.Errorf("failed to count commits between %s and %s: %w", baseBranch, headBranch, err)
+	}
+
+	count := 0
+	_, _ = fmt.Sscanf(strings.TrimSpace(string(output)), "%d", &count)
+	return count, nil
+}
+
 // CherryPickBranch cherry-picks all commits from sourceBranch that aren't in the current branch
 // It cherry-picks commits one by one in order (oldest first)
 func (m *Manager) CherryPickBranch(path, sourceBranch string) error {


### PR DESCRIPTION
## Summary

- Tasks were being marked as complete without producing any commits, causing consolidation to fail silently
- Add commit verification before marking tasks complete
- Implement automatic retry mechanism for tasks that produce no commits
- Make consolidation synchronous and blocking to ensure proper sequencing
- Add TUI dialog for user decision when groups have partial success/failure

## Changes

| File | Description |
|------|-------------|
| `internal/worktree/worktree.go` | Add `CountCommitsBetween()` for efficient commit counting |
| `internal/orchestrator/ultraplan.go` | Add `TaskRetryState`, `GroupDecisionState` types and config fields |
| `internal/orchestrator/coordinator.go` | Implement verification, retry logic, synchronous consolidation |
| `internal/orchestrator/consolidation.go` | Fail on empty branches instead of silent success |
| `internal/tui/ultraplan.go` | Add group decision dialog and key handlers |

## Test plan

- [x] All existing tests pass
- [ ] Manual test: Run ultraplan with tasks that intentionally produce no commits, verify retry
- [ ] Manual test: Verify partial group handling shows decision dialog