### PR TITLE
fix(ultraplan): prevent premature task verification from false completion detection

### DIFF
--- a/internal/instance/detector.go
+++ b/internal/instance/detector.go
@@ -110,14 +110,12 @@ func NewDetector() *Detector {
 		`>\s+.*↵`,
 	}
 
-	// Completion patterns - Claude has finished its task
-	completionStrings := []string{
-		`(?i)(?:task|work|implementation|changes?) (?:is |are )?(?:complete|done|finished)`,
-		`(?i)(?:i'?ve|I have) (?:completed|finished|done)`,
-		`(?i)(?:successfully|all done|that'?s it)`,
-		`(?i)let me know if (?:you need|there'?s) anything else`,
-		`(?i)is there anything else`,
-	}
+	// Completion patterns - intentionally empty
+	// For Claudio tasks, the sentinel file (.claudio-task-complete.json) is the
+	// authoritative completion signal. Text-based completion detection caused
+	// false positives that triggered premature task verification.
+	// The inputWaitingPatterns above already detect when Claude is at its prompt.
+	completionStrings := []string{}
 
 	// Error patterns - Claude encountered a critical issue that stopped it
 	// These patterns should be specific to actual Claude failures, not just error text appearing in output

--- a/internal/instance/detector_test.go
+++ b/internal/instance/detector_test.go
@@ -179,35 +179,52 @@ func TestDetector_QuestionPatterns(t *testing.T) {
 func TestDetector_CompletionPatterns(t *testing.T) {
 	d := NewDetector()
 
+	// NOTE: Completion patterns are intentionally DISABLED.
+	// For Claudio tasks, the sentinel file (.claudio-task-complete.json) is the
+	// authoritative completion signal. Text-based completion detection caused
+	// false positives that triggered premature task verification.
+	// All these phrases should return StateWorking (or other non-completed states).
 	tests := []struct {
 		name     string
 		output   string
 		expected WaitingState
 	}{
+		// None of these should match StateCompleted anymore - completion is
+		// determined by sentinel file, not text patterns
 		{
-			name:     "task complete",
+			name:     "task complete - no longer detected from text",
 			output:   "Task complete!",
-			expected: StateCompleted,
+			expected: StateWorking,
 		},
 		{
-			name:     "I've completed",
+			name:     "the task is complete - no longer detected from text",
+			output:   "The task is complete.",
+			expected: StateWorking,
+		},
+		{
+			name:     "work is done - no longer detected from text",
+			output:   "The work is done.",
+			expected: StateWorking,
+		},
+		{
+			name:     "I've completed the task - no longer detected from text",
+			output:   "I've completed the task as requested.",
+			expected: StateWorking,
+		},
+		{
+			name:     "casual completion phrase",
 			output:   "I've completed all the requested changes",
-			expected: StateCompleted,
+			expected: StateWorking,
 		},
 		{
-			name:     "all done",
+			name:     "all done with X",
 			output:   "All done with the implementation",
-			expected: StateCompleted,
+			expected: StateWorking,
 		},
 		{
-			name:     "let me know if anything else",
-			output:   "Let me know if you need anything else",
-			expected: StateCompleted,
-		},
-		{
-			name:     "is there anything else",
+			name:     "is there anything else - detected as question",
 			output:   "Is there anything else I can help with?",
-			expected: StateCompleted,
+			expected: StateWaitingQuestion, // Questions still match question patterns
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Fix race condition where tasks were marked as failures before completion
- Text-based completion patterns matched casual phrases mid-task, triggering premature verification
- Sentinel file (`.claudio-task-complete.json`) is now the sole completion signal

## Changes
- Remove text-based completion patterns from detector
- Add tmux session check before treating StatusCompleted as real completion  
- Update tests to reflect new behavior

## Root Cause
Tasks failing with "no commits" despite actually completing because:
1. Detector matched "successfully" or "all done" mid-task
2. StatusCompleted triggered immediate verification
3. Verification found 0 commits (commit not made yet)
4. Task marked failed → retry → same thing → eventually exhausted retries

## Test plan
- [x] All existing tests pass
- [x] `go build ./...` succeeds
- [x] `go vet ./...` clean