### PR TITLE
fix(ultraplan): gracefully shutdown consolidator after completion file detection

### DIFF
--- a/internal/orchestrator/coordinator.go
+++ b/internal/orchestrator/coordinator.go
@@ -2545,6 +2545,8 @@ func (c *Coordinator) monitorGroupConsolidator(groupIndex int, instanceID string
 
 					// Check status
 					if completion.Status == "failed" {
+						// Stop the consolidator instance even on failure
+						_ = c.orch.StopInstance(inst)
 						return fmt.Errorf("group %d consolidation failed: %s", groupIndex+1, completion.Notes)
 					}
 
@@ -2564,6 +2566,9 @@ func (c *Coordinator) monitorGroupConsolidator(groupIndex int, instanceID string
 
 					// Persist state
 					_ = c.orch.SaveSession()
+
+					// Stop the consolidator instance to free up resources
+					_ = c.orch.StopInstance(inst)
 
 					// Emit success event
 					c.manager.emitEvent(CoordinatorEvent{


### PR DESCRIPTION
## Summary
- Add `StopInstance()` call when group consolidator completes successfully
- Add `StopInstance()` call when group consolidator reports failure
- Ensures consolidator Claude sessions are properly terminated after writing their completion file

## Test plan
- [ ] Run ultraplan with multiple groups
- [ ] Verify consolidator sessions terminate after writing completion files
- [ ] Verify no orphaned tmux sessions remain after consolidation