### PR TITLE
ultraplan: group 5 - CLI --review flag

### DIFF
--- a/internal/cmd/ultraplan.go
+++ b/internal/cmd/ultraplan.go
@@ -24,9 +24,19 @@ sessions for execution, and manages the overall workflow.
 
 The ultra-plan process has four phases:
 1. PLANNING: Claude explores the codebase and creates an execution plan
-2. CONTEXT REFRESH: The plan is compacted for efficient execution
+2. REVIEW: (optional) Interactive plan editor to review and modify the plan
 3. EXECUTION: Child sessions execute tasks in parallel (respecting dependencies)
 4. SYNTHESIS: Results are reviewed and integrated
+
+Plan Editor:
+  When the plan is ready, an interactive editor opens allowing you to:
+  - Review task dependencies and execution order
+  - Add, edit, or remove tasks
+  - Modify task priorities and complexity estimates
+  - Validate the plan for dependency cycles before execution
+
+  Use --review to always open the plan editor, even with --auto-approve.
+  Use --auto-approve without --review to skip the editor entirely.
 
 Examples:
   # Start ultra-plan with an objective
@@ -35,8 +45,14 @@ Examples:
   # Start with a pre-existing plan file
   claudio ultraplan --plan plan.json
 
+  # Review and edit a plan before execution
+  claudio ultraplan --plan plan.json --review
+
   # Dry run - only generate the plan, don't execute
   claudio ultraplan --dry-run "Refactor the API layer"
+
+  # Auto-approve but still review the plan first
+  claudio ultraplan --auto-approve --review "Add comprehensive test coverage"
 
   # Increase parallelism
   claudio ultraplan --max-parallel 5 "Add comprehensive test coverage"`,
@@ -50,6 +66,7 @@ var (
 	ultraplanDryRun      bool
 	ultraplanNoSynthesis bool
 	ultraplanAutoApprove bool
+	ultraplanReview      bool
 )
 
 func init() {
@@ -60,6 +77,7 @@ func init() {
 	ultraplanCmd.Flags().BoolVar(&ultraplanDryRun, "dry-run", false, "Run planning only, output plan without executing")
 	ultraplanCmd.Flags().BoolVar(&ultraplanNoSynthesis, "no-synthesis", false, "Skip synthesis phase after execution")
 	ultraplanCmd.Flags().BoolVar(&ultraplanAutoApprove, "auto-approve", false, "Auto-approve spawned tasks without confirmation")
+	ultraplanCmd.Flags().BoolVar(&ultraplanReview, "review", false, "Review and edit plan before execution (opens plan editor)")
 }
 
 func runUltraplan(cmd *cobra.Command, args []string) error {
@@ -112,6 +130,7 @@ func runUltraplan(cmd *cobra.Command, args []string) error {
 	config.DryRun = ultraplanDryRun
 	config.NoSynthesis = ultraplanNoSynthesis
 	config.AutoApprove = ultraplanAutoApprove
+	config.Review = ultraplanReview
 
 	// Create or load the plan
 	var plan *orchestrator.PlanSpec

--- a/internal/orchestrator/ultraplan.go
+++ b/internal/orchestrator/ultraplan.go
@@ -65,6 +65,7 @@ type UltraPlanConfig struct {
 	DryRun        bool `json:"dry_run"`         // Run planning only, don't execute
 	NoSynthesis   bool `json:"no_synthesis"`    // Skip synthesis phase after execution
 	AutoApprove   bool `json:"auto_approve"`    // Auto-approve spawned tasks without confirmation
+	Review        bool `json:"review"`          // Force plan editor to open for review (overrides AutoApprove)
 
 	// Consolidation settings
 	ConsolidationMode ConsolidationMode `json:"consolidation_mode,omitempty"` // "stacked" or "single"

--- a/internal/tui/ultraplan.go
+++ b/internal/tui/ultraplan.go
@@ -1507,15 +1507,9 @@ func (m *Model) handleUltraPlanCoordinatorCompletion(inst *orchestrator.Instance
 		return true
 	}
 
-	// Auto-start execution if configured
-	if session.Config.AutoApprove {
-		if err := m.ultraPlan.coordinator.StartExecution(); err != nil {
-			m.errorMessage = fmt.Sprintf("Plan ready but failed to auto-start: %v", err)
-		} else {
-			m.infoMessage = fmt.Sprintf("Plan ready: %d tasks in %d groups. Auto-starting execution...",
-				len(plan.Tasks), len(plan.ExecutionOrder))
-		}
-	} else {
+	// Determine whether to open plan editor or auto-start execution
+	// Review flag forces plan editor open, even if AutoApprove is also set
+	if session.Config.Review || !session.Config.AutoApprove {
 		// Enter plan editor for interactive review
 		m.enterPlanEditor()
 		m.infoMessage = fmt.Sprintf("Plan ready: %d tasks in %d groups. Review and press [enter] to execute, or [esc] to cancel.",
@@ -1523,6 +1517,14 @@ func (m *Model) handleUltraPlanCoordinatorCompletion(inst *orchestrator.Instance
 		// Notify user that input is needed
 		m.ultraPlan.needsNotification = true
 		m.ultraPlan.lastNotifiedPhase = orchestrator.PhaseRefresh
+	} else {
+		// Auto-start execution (AutoApprove is true and Review is false)
+		if err := m.ultraPlan.coordinator.StartExecution(); err != nil {
+			m.errorMessage = fmt.Sprintf("Plan ready but failed to auto-start: %v", err)
+		} else {
+			m.infoMessage = fmt.Sprintf("Plan ready: %d tasks in %d groups. Auto-starting execution...",
+				len(plan.Tasks), len(plan.ExecutionOrder))
+		}
 	}
 
 	return true
@@ -1588,15 +1590,9 @@ func (m *Model) checkForPlanFile() bool {
 	// Plan detected - stop the coordinator instance (it's done its job)
 	_ = m.orchestrator.StopInstance(inst)
 
-	// Auto-start execution if configured
-	if session.Config.AutoApprove {
-		if err := m.ultraPlan.coordinator.StartExecution(); err != nil {
-			m.errorMessage = fmt.Sprintf("Plan detected but failed to auto-start: %v", err)
-		} else {
-			m.infoMessage = fmt.Sprintf("Plan detected: %d tasks in %d groups. Auto-starting execution...",
-				len(plan.Tasks), len(plan.ExecutionOrder))
-		}
-	} else {
+	// Determine whether to open plan editor or auto-start execution
+	// Review flag forces plan editor open, even if AutoApprove is also set
+	if session.Config.Review || !session.Config.AutoApprove {
 		// Enter plan editor for interactive review
 		m.enterPlanEditor()
 		m.infoMessage = fmt.Sprintf("Plan detected: %d tasks in %d groups. Review and press [enter] to execute, or [esc] to cancel.",
@@ -1604,6 +1600,14 @@ func (m *Model) checkForPlanFile() bool {
 		// Notify user that input is needed
 		m.ultraPlan.needsNotification = true
 		m.ultraPlan.lastNotifiedPhase = orchestrator.PhaseRefresh
+	} else {
+		// Auto-start execution (AutoApprove is true and Review is false)
+		if err := m.ultraPlan.coordinator.StartExecution(); err != nil {
+			m.errorMessage = fmt.Sprintf("Plan detected but failed to auto-start: %v", err)
+		} else {
+			m.infoMessage = fmt.Sprintf("Plan detected: %d tasks in %d groups. Auto-starting execution...",
+				len(plan.Tasks), len(plan.ExecutionOrder))
+		}
 	}
 
 	return true


### PR DESCRIPTION
## Summary

This is **Group 5 of 5** (final) in the stacked PR series implementing issue #93 - Interactive Plan Editor for Ultraplan.

### Tasks Included
- **Add --review CLI flag for ultraplan** (task-7-review-flag): CLI flag to force plan editor open even with --auto-approve; properly documented in help text

### Changes
- Adds `--review` flag to the ultraplan command
- When `--review` is set, the plan editor opens regardless of `--auto-approve`
- Properly integrated into CLI help text

### Usage
```bash
# Normal mode: plan editor opens unless --auto-approve is set
claudio ultraplan "implement feature X"

# Force review: plan editor always opens, even with auto-approve
claudio ultraplan --review "implement feature X"
claudio ultraplan --review --auto-approve "implement feature X"
```

### Stacked PR Note
This PR is based on `claudio/ultraplan-856577e3-group-4`. This is the final PR in the series.

### Merge Order
1. Group 1 - State and mutations ✓
2. Group 2 - View rendering ✓
3. Group 3 - Keyboard handling and validation UI ✓
4. Group 4 - TUI integration and tests ✓ (base of this PR)
5. **This PR** - CLI --review flag (final)

Closes #93