### PR TITLE
chore: remove MIT license reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,10 +313,6 @@ git worktree remove .claudio/worktrees/<id>
 git worktree prune
 ```
 
-## License
-
-MIT
-
 ## Contributing
 
 Contributions welcome! Please open an issue or PR.


### PR DESCRIPTION
## Summary
- Removes the leftover MIT license reference from README.md

This is a follow-up to #136 which removed the MIT license file but left the reference in the README.

## Test plan
- [x] Verify README no longer references MIT license