### PR TITLE
feat(ultraplan): add max_parallel to config file

### DIFF
--- a/docs/guide/ultra-plan.md
+++ b/docs/guide/ultra-plan.md
@@ -50,7 +50,7 @@ claudio ultraplan [objective] [flags]
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--max-parallel` | Maximum concurrent child sessions | 3 |
+| `--max-parallel` | Maximum concurrent child sessions (0 = unlimited) | 3 |
 | `--plan` | Use existing plan file instead of planning phase | - |
 | `--dry-run` | Run planning only, output plan without executing | false |
 | `--no-synthesis` | Skip synthesis phase after execution | false |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -208,6 +208,34 @@ resources:
 
 ---
 
+### ultraplan
+
+Controls ultra-plan mode behavior.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `ultraplan.max_parallel` | int | `3` | Maximum concurrent child sessions (0 = unlimited) |
+| `ultraplan.notifications.enabled` | bool | `true` | Play notifications when user input needed |
+| `ultraplan.notifications.use_sound` | bool | `false` | Use system sound (macOS only) |
+| `ultraplan.notifications.sound_path` | string | `""` | Custom sound file path (macOS only) |
+
+**Why limit parallelism?**
+- Anthropic API rate limits can throttle many parallel requests
+- Each parallel session incurs API costs
+- More sessions = higher merge conflict risk during consolidation
+- Easier to monitor fewer concurrent sessions
+
+```yaml
+ultraplan:
+  max_parallel: 3
+  notifications:
+    enabled: true
+    use_sound: false
+    sound_path: ""
+```
+
+---
+
 ## Environment Variables
 
 All options can be set via environment variables:
@@ -224,6 +252,7 @@ Replace dots with underscores and use uppercase:
 | `pr.draft` | `CLAUDIO_PR_DRAFT` |
 | `pr.use_ai` | `CLAUDIO_PR_USE_AI` |
 | `resources.cost_limit` | `CLAUDIO_RESOURCES_COST_LIMIT` |
+| `ultraplan.max_parallel` | `CLAUDIO_ULTRAPLAN_MAX_PARALLEL` |
 
 **Priority:** Environment variables override config file values.
 
@@ -280,6 +309,13 @@ resources:
   cost_limit: 0
   token_limit_per_instance: 0
   show_metrics_in_sidebar: true
+
+# Ultra-plan settings
+ultraplan:
+  max_parallel: 3
+  notifications:
+    enabled: true
+    use_sound: false
 ```
 
 ---

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,6 +118,8 @@ type ResourceConfig struct {
 
 // UltraplanConfig controls ultraplan behavior
 type UltraplanConfig struct {
+	// MaxParallel is the maximum number of concurrent child sessions (default: 3)
+	MaxParallel int `mapstructure:"max_parallel"`
 	// Notifications controls audio notifications for user input
 	Notifications NotificationConfig `mapstructure:"notifications"`
 }
@@ -179,6 +181,7 @@ func Default() *Config {
 			ShowMetricsInSidebar:  true,  // Show metrics by default
 		},
 		Ultraplan: UltraplanConfig{
+			MaxParallel: 3,
 			Notifications: NotificationConfig{
 				Enabled:   true,
 				UseSound:  false,
@@ -250,6 +253,7 @@ func SetDefaults() {
 	viper.SetDefault("resources.show_metrics_in_sidebar", defaults.Resources.ShowMetricsInSidebar)
 
 	// Ultraplan defaults
+	viper.SetDefault("ultraplan.max_parallel", defaults.Ultraplan.MaxParallel)
 	viper.SetDefault("ultraplan.notifications.enabled", defaults.Ultraplan.Notifications.Enabled)
 	viper.SetDefault("ultraplan.notifications.use_sound", defaults.Ultraplan.Notifications.UseSound)
 	viper.SetDefault("ultraplan.notifications.sound_path", defaults.Ultraplan.Notifications.SoundPath)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -255,3 +255,27 @@ func TestConfig_ResourceConfig_Values(t *testing.T) {
 		t.Errorf("TokenLimitPerInstance should not be negative, got %d", cfg.Resources.TokenLimitPerInstance)
 	}
 }
+
+func TestConfig_UltraplanConfig_Values(t *testing.T) {
+	cfg := Default()
+
+	// MaxParallel should default to 3
+	if cfg.Ultraplan.MaxParallel != 3 {
+		t.Errorf("Ultraplan.MaxParallel = %d, want 3", cfg.Ultraplan.MaxParallel)
+	}
+
+	// Notifications should be enabled by default
+	if !cfg.Ultraplan.Notifications.Enabled {
+		t.Error("Ultraplan.Notifications.Enabled should be true by default")
+	}
+
+	// UseSound should be disabled by default
+	if cfg.Ultraplan.Notifications.UseSound {
+		t.Error("Ultraplan.Notifications.UseSound should be false by default")
+	}
+
+	// SoundPath should be empty by default
+	if cfg.Ultraplan.Notifications.SoundPath != "" {
+		t.Errorf("Ultraplan.Notifications.SoundPath should be empty, got %q", cfg.Ultraplan.Notifications.SoundPath)
+	}
+}

--- a/internal/orchestrator/coordinator.go
+++ b/internal/orchestrator/coordinator.go
@@ -299,15 +299,15 @@ func (c *Coordinator) executionLoop() {
 				return
 			}
 
-			// Check if we can start more tasks
-			if runningCount < config.MaxParallel {
+			// Check if we can start more tasks (MaxParallel <= 0 means unlimited)
+			if config.MaxParallel <= 0 || runningCount < config.MaxParallel {
 				readyTasks := session.GetReadyTasks()
 				for _, taskID := range readyTasks {
 					c.mu.RLock()
 					currentRunning := c.runningCount
 					c.mu.RUnlock()
 
-					if currentRunning >= config.MaxParallel {
+					if config.MaxParallel > 0 && currentRunning >= config.MaxParallel {
 						break
 					}
 


### PR DESCRIPTION
## Summary
- Add `ultraplan.max_parallel` to the configuration file, allowing users to set the maximum concurrent child sessions without using CLI flags
- Setting the value to 0 means unlimited parallelism
- CLI flag `--max-parallel` overrides config when explicitly set

## Test plan
- [x] Build passes
- [x] All tests pass
- [x] Verified config precedence: code defaults → config file → CLI flags