### PR TITLE
feat(ultraplan): prefer small session-completable tasks in planning

### DIFF
--- a/internal/orchestrator/ultraplan.go
+++ b/internal/orchestrator/ultraplan.go
@@ -1063,6 +1063,9 @@ Write a JSON file with this structure:
 
 ## Guidelines
 
+- **Prefer many small tasks over fewer large ones** - 10 small tasks are better than 3 medium/large tasks
+- Each task should be completable within a single session without context exhaustion
+- Target "low" complexity tasks; split "medium" or "high" complexity work into multiple smaller tasks
 - Prefer granular tasks that can run in parallel over large sequential ones
 - Assign clear file ownership to avoid merge conflicts
 - Each task description should be complete enough for independent execution


### PR DESCRIPTION
## Summary
- Update planning guidelines to emphasize creating many small tasks over fewer large ones
- Add guidance that 10 small tasks are better than 3 medium/large tasks
- Recommend targeting "low" complexity tasks and splitting larger work

This helps avoid context exhaustion during task execution, ensuring each task completes cleanly within a single session.

## Test plan
- [ ] Run ultraplan on a complex task and verify the generated plan contains more granular tasks
- [ ] Verify tasks are marked as "low" complexity where possible