### PR TITLE
feat(ultraplan): pause synthesis for user approval before advancing

### DIFF
--- a/internal/orchestrator/ultraplan.go
+++ b/internal/orchestrator/ultraplan.go
@@ -297,6 +297,10 @@ type UltraPlanSession struct {
 	// Synthesis completion context (populated from sentinel file)
 	SynthesisCompletion *SynthesisCompletionFile `json:"synthesis_completion,omitempty"`
 
+	// SynthesisAwaitingApproval is true when synthesis is complete but waiting for user review
+	// User must press [s] to approve and proceed to revision/consolidation
+	SynthesisAwaitingApproval bool `json:"synthesis_awaiting_approval,omitempty"`
+
 	// Task worktree information for consolidation context
 	TaskWorktrees []TaskWorktreeInfo `json:"task_worktrees,omitempty"`
 

--- a/internal/tui/ultraplan.go
+++ b/internal/tui/ultraplan.go
@@ -323,6 +323,24 @@ func (m Model) renderUltraPlanSidebar(width int, height int) string {
 			b.WriteString(line)
 			b.WriteString("\n")
 			lineCount++
+
+			// Show synthesis findings when awaiting approval
+			if session.SynthesisAwaitingApproval && session.SynthesisCompletion != nil && lineCount < availableLines {
+				issueCount := len(session.SynthesisCompletion.IssuesFound)
+				if issueCount > 0 {
+					issueText := fmt.Sprintf("  ⚠ %d issue(s) found", issueCount)
+					b.WriteString(styles.Warning.Render(issueText))
+				} else {
+					b.WriteString(styles.SuccessMsg.Render("  ✓ No issues found"))
+				}
+				b.WriteString("\n")
+				lineCount++
+
+				// Show prompt to approve
+				b.WriteString(styles.Warning.Render("  Press [s] to approve"))
+				b.WriteString("\n")
+				lineCount++
+			}
 		} else if !synthesisStarted && lineCount < availableLines {
 			b.WriteString(styles.Muted.Render("  ○ Pending"))
 			b.WriteString("\n")
@@ -1175,7 +1193,11 @@ func (m Model) renderUltraPlanHelp() string {
 	case orchestrator.PhaseSynthesis:
 		keys = append(keys, "[i] input mode")
 		keys = append(keys, "[v] toggle plan view")
-		keys = append(keys, "[s] done → consolidate")
+		if session.SynthesisAwaitingApproval {
+			keys = append(keys, "[s] approve → proceed")
+		} else {
+			keys = append(keys, "[s] skip → consolidate")
+		}
 
 	case orchestrator.PhaseRevision:
 		keys = append(keys, "[tab] next instance")


### PR DESCRIPTION
## Summary
- Add `SynthesisAwaitingApproval` flag to `UltraPlanSession`
- When synthesis writes completion file, set flag instead of auto-advancing
- TUI shows synthesis findings (issue count) and prompts user to press `[s]` to approve
- Help bar shows context-aware action: `[s] approve → proceed` when awaiting vs `[s] skip → consolidate`

This addresses the UX gap where users couldn't review synthesis findings before the system auto-advanced to revision/consolidation.

## Test plan
- [x] Build succeeds
- [x] All tests pass
- [ ] Manual test: Run ultraplan, let synthesis complete, verify it pauses and shows findings before user presses [s]