### PR TITLE
fix(ultraplan): use file-based detection for multi-pass plan completion

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -276,6 +276,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.updateOutputs()
 		// Check for plan file during planning phase (proactive detection)
 		m.checkForPlanFile()
+		// Check for multi-pass plan files (most reliable detection for multi-pass mode)
+		m.checkForMultiPassPlanFiles()
 		// Check for phase changes that need notification (synthesis, consolidation pause)
 		m.checkForPhaseNotification()
 


### PR DESCRIPTION
## Summary
- Fixes coordinator-manager not firing in multi-pass mode when planning coordinators complete
- Adds `checkForMultiPassPlanFiles()` to poll for plan files on every tick
- Uses file-based detection (`.claudio-plan.json`) which is more reliable than instance state transitions

## Problem
The completion handler relied on instance state transitions, but `updateInstanceStatus` only processed instances with `StatusWorking`. When a coordinator was in `StatusWaitingInput` (e.g., waiting for file permission) and completed directly, the handler was never invoked.

## Solution
Poll for plan files in each coordinator's worktree during every tick. When all 3 plan files are detected and parsed successfully, trigger `RunPlanManager()` automatically.

## Test plan
- [x] Build passes
- [x] All existing tests pass
- [ ] Manual test: Run `ultraplan --multi-pass` and verify coordinator-manager fires after all 3 plans are written