### PR TITLE
fix(ultraplan): use file-based detection for plan manager completion

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -278,6 +278,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.checkForPlanFile()
 		// Check for multi-pass plan files (most reliable detection for multi-pass mode)
 		m.checkForMultiPassPlanFiles()
+		// Check for plan manager plan file during plan selection phase (most reliable detection)
+		m.checkForPlanManagerPlanFile()
 		// Check for phase changes that need notification (synthesis, consolidation pause)
 		m.checkForPhaseNotification()
 


### PR DESCRIPTION
## Summary
- Add `checkForPlanManagerPlanFile()` to detect plan manager completion by polling for its `.claudio-plan.json` file
- Wire up the new function in the tick handler alongside existing file-based detection functions
- Fixes issue where plan manager completion wasn't detected when instance was in `StatusWaitingInput` state

## Problem
When the Plan Manager completes, `updateInstanceStatus()` in `app.go:1834` only runs when `inst.Status == StatusWorking`. If the Plan Manager transitions through `StatusWaitingInput` before completing, the guard prevents `handleInstanceCompleted()` from being called, leaving the user stuck at plan selection.

## Solution
Follow the same pattern as `checkForMultiPassPlanFiles()` (added in cfb1c59) - poll for the plan file directly rather than relying on instance state transitions. Files are the ground truth.

## Test plan
- [ ] Run multi-pass ultraplan mode
- [ ] Verify plan manager completion triggers plan review/auto-start
- [ ] Verify the fix works when plan manager was in waiting state