### PR TITLE
fix(tui): detect completion for instances in WaitingInput status

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1832,8 +1832,8 @@ func (m *Model) updateOutputs() {
 			}
 
 			// Update instance status based on detected waiting state
-			// Only update if the instance is currently working (not paused, completed, etc.)
-			if inst.Status == orchestrator.StatusWorking {
+			// Check when working OR waiting for input (to detect completion after waiting)
+			if inst.Status == orchestrator.StatusWorking || inst.Status == orchestrator.StatusWaitingInput {
 				m.updateInstanceStatus(inst, mgr)
 			}
 		}

--- a/internal/tui/ultraplan.go
+++ b/internal/tui/ultraplan.go
@@ -2136,7 +2136,8 @@ func (m *Model) checkForPlanManagerPlanFile() bool {
 	// Parse the plan from the file
 	plan, err := orchestrator.ParsePlanFromFile(planPath, session.Objective)
 	if err != nil {
-		// File might be partially written, skip for now
+		// Show error if file exists but can't be parsed (helps debug)
+		m.errorMessage = fmt.Sprintf("Plan file found but parse error: %v", err)
 		return false
 	}
 


### PR DESCRIPTION
## Summary
- Expand status update guard to also check `StatusWaitingInput` instances
- This fixes completion detection for instances that complete after being in a waiting state

## Problem
The status update guard at `app.go:1836` only allowed checking instances with `StatusWorking`. But instances often transition:
1. `Working` → `WaitingInput` (Claude writes a file or asks a question)
2. `WaitingInput` → `Completed`

When this happens, the guard prevents `updateInstanceStatus()` from detecting the completion, so `handleInstanceCompleted()` never fires.

This affected:
- Planning coordinators in multi-pass mode
- Plan Manager after selecting/merging plans
- Any instance that completed after being in a waiting state

## Solution
Expand the guard to:
```go
if inst.Status == orchestrator.StatusWorking || inst.Status == orchestrator.StatusWaitingInput {
```

Also adds error visibility when plan file parsing fails.

## Test plan
- [ ] Run multi-pass ultraplan mode  
- [ ] Verify Plan Manager completion properly triggers plan review/auto-start
- [ ] Verify single-pass mode still works