### PR TITLE
fix(ultraplan): handle parse errors gracefully in group consolidation monitor

### DIFF
--- a/internal/orchestrator/coordinator.go
+++ b/internal/orchestrator/coordinator.go
@@ -2836,7 +2836,9 @@ func (c *Coordinator) monitorGroupConsolidator(groupIndex int, instanceID string
 					// Parse the completion file
 					completion, err := ParseGroupConsolidationCompletionFile(inst.WorktreePath)
 					if err != nil {
-						return fmt.Errorf("failed to parse group consolidation completion file: %w", err)
+						// File exists but is invalid/incomplete - might still be writing
+						// Continue monitoring and try again on next tick
+						continue
 					}
 
 					// Check status


### PR DESCRIPTION
## Summary
- Fix race condition in `monitorGroupConsolidator` where partial file writes caused fatal errors
- Changed error handling to retry on next tick instead of failing immediately
- Matches pattern used by other completion file monitors (`checkForTaskCompletionFile`, `checkForSynthesisCompletionFile`)

## Test plan
- [x] Verified build compiles successfully
- [x] Ran group/consolidation tests - all pass
- [ ] Manual testing with multi-group ultraplan execution