### PR TITLE
feat(plan): add plan-only mode for structured GitHub Issue creation

### DIFF
--- a/internal/cmd/plan.go
+++ b/internal/cmd/plan.go
@@ -1,0 +1,238 @@
+package cmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/plan"
+	"github.com/spf13/cobra"
+)
+
+var planCmd = &cobra.Command{
+	Use:   "plan [objective]",
+	Short: "Create structured plans from an objective",
+	Long: `Plan mode analyzes your objective and creates a structured execution plan.
+
+Output formats:
+  --output-format=json    Create .claudio-plan.json for use with 'claudio ultraplan --plan'
+  --output-format=issues  Create GitHub Issues with parent epic and linked sub-issues (default)
+  --output-format=both    Create both JSON file and GitHub Issues
+
+Examples:
+  # Dry-run: show plan without creating output
+  claudio plan --dry-run "Add user authentication"
+
+  # Create GitHub Issues (default)
+  claudio plan "Add user authentication"
+
+  # Create JSON file for ultraplan
+  claudio plan --output-format=json "Add user authentication"
+
+  # Use multi-pass planning for complex objectives
+  claudio plan --multi-pass "Refactor database layer"
+
+  # Add labels to GitHub Issues
+  claudio plan --labels "enhancement,v2" "Add caching layer"
+
+  # Run the generated plan with ultraplan
+  claudio plan --output-format=json "Build new module"
+  claudio ultraplan --plan .claudio-plan.json`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runPlan,
+}
+
+var (
+	planDryRun       bool
+	planMultiPass    bool
+	planLabels       []string
+	planOutputFile   string
+	planNoConfirm    bool
+	planOutputFormat string
+)
+
+func init() {
+	rootCmd.AddCommand(planCmd)
+
+	planCmd.Flags().BoolVar(&planDryRun, "dry-run", false, "Show plan without creating output")
+	planCmd.Flags().BoolVar(&planMultiPass, "multi-pass", false, "Use 3-strategy planning for complex tasks")
+	planCmd.Flags().StringSliceVar(&planLabels, "labels", nil, "Labels to add to GitHub Issues")
+	planCmd.Flags().StringVar(&planOutputFile, "output", "", "Write plan JSON to specific file path")
+	planCmd.Flags().BoolVar(&planNoConfirm, "no-confirm", false, "Skip confirmation prompt")
+	planCmd.Flags().StringVar(&planOutputFormat, "output-format", "issues",
+		"Output format: 'json' (for ultraplan), 'issues' (GitHub Issues), or 'both'")
+}
+
+func runPlan(cmd *cobra.Command, args []string) error {
+	// Get objective from args or prompt
+	var objective string
+	if len(args) > 0 {
+		objective = args[0]
+	} else {
+		var err error
+		objective, err = promptForObjective()
+		if err != nil {
+			return err
+		}
+	}
+
+	// Validate output format
+	switch planOutputFormat {
+	case "json", "issues", "both":
+		// Valid
+	default:
+		return fmt.Errorf("invalid output format: %s (use 'json', 'issues', or 'both')", planOutputFormat)
+	}
+
+	fmt.Println("Planning...")
+	if planMultiPass {
+		fmt.Println("Using multi-pass planning (3 strategies)...")
+	}
+
+	// Run planning phase
+	planSpec, err := plan.RunPlanningSync(objective, planMultiPass)
+	if err != nil {
+		return fmt.Errorf("planning failed: %w", err)
+	}
+
+	// Display plan for review
+	fmt.Println()
+	fmt.Println(plan.FormatPlanForDisplay(planSpec))
+
+	// Handle dry-run: still save JSON if requested
+	if planDryRun {
+		if shouldSaveJSON() {
+			outputPath := getOutputPath()
+			if err := plan.SavePlanToFile(planSpec, outputPath); err != nil {
+				return fmt.Errorf("failed to save plan: %w", err)
+			}
+			fmt.Printf("Plan saved to %s\n", outputPath)
+			fmt.Printf("Run with: claudio ultraplan --plan %s\n", outputPath)
+		}
+		return nil
+	}
+
+	// Confirm before creating output
+	if !planNoConfirm {
+		confirmed, err := confirmCreation()
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			fmt.Println("Cancelled.")
+			return nil
+		}
+	}
+
+	// Create output based on format
+	switch planOutputFormat {
+	case "json":
+		return createJSONOutput(planSpec)
+	case "issues":
+		return createIssuesOutput(planSpec)
+	case "both":
+		if err := createJSONOutput(planSpec); err != nil {
+			return err
+		}
+		return createIssuesOutput(planSpec)
+	}
+
+	return nil
+}
+
+func promptForObjective() (string, error) {
+	fmt.Println()
+	fmt.Println("Plan Mode")
+	fmt.Println("=========")
+	fmt.Println("Enter a high-level objective for Claude to plan.")
+	fmt.Println()
+	fmt.Print("Objective: ")
+
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("failed to read input: %w", err)
+	}
+
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "", fmt.Errorf("objective cannot be empty")
+	}
+
+	return input, nil
+}
+
+func shouldSaveJSON() bool {
+	return planOutputFormat == "json" || planOutputFormat == "both" || planOutputFile != ""
+}
+
+func getOutputPath() string {
+	if planOutputFile != "" {
+		return planOutputFile
+	}
+	return ".claudio-plan.json"
+}
+
+func confirmCreation() (bool, error) {
+	var action string
+	switch planOutputFormat {
+	case "json":
+		action = "save plan to " + getOutputPath()
+	case "issues":
+		action = "create GitHub Issues"
+	case "both":
+		action = "save plan to " + getOutputPath() + " and create GitHub Issues"
+	}
+
+	fmt.Printf("Proceed to %s? [y/N] ", action)
+
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return false, fmt.Errorf("failed to read input: %w", err)
+	}
+
+	input = strings.TrimSpace(strings.ToLower(input))
+	return input == "y" || input == "yes", nil
+}
+
+func createJSONOutput(planSpec *orchestrator.PlanSpec) error {
+	outputPath := getOutputPath()
+	if err := plan.SavePlanToFile(planSpec, outputPath); err != nil {
+		return fmt.Errorf("failed to save plan: %w", err)
+	}
+	fmt.Printf("Plan saved to %s\n", outputPath)
+	fmt.Printf("Run with: claudio ultraplan --plan %s\n", outputPath)
+	return nil
+}
+
+func createIssuesOutput(planSpec *orchestrator.PlanSpec) error {
+	result, err := plan.CreateIssuesFromPlan(planSpec, planLabels)
+	if err != nil {
+		return fmt.Errorf("failed to create issues: %w", err)
+	}
+
+	fmt.Println()
+	fmt.Printf("Created parent issue: %s\n", result.ParentIssueURL)
+	fmt.Printf("Created %d sub-issues\n", len(result.SubIssueNumbers))
+
+	return nil
+}
+
+// LoadPlanFromFile loads a plan from a JSON file (for use by other commands)
+func LoadPlanFromFile(path string) (*orchestrator.PlanSpec, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	var planSpec orchestrator.PlanSpec
+	if err := json.Unmarshal(data, &planSpec); err != nil {
+		return nil, fmt.Errorf("failed to parse plan JSON: %w", err)
+	}
+
+	return &planSpec, nil
+}

--- a/internal/plan/issue.go
+++ b/internal/plan/issue.go
@@ -1,0 +1,84 @@
+package plan
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// IssueOptions contains options for issue creation
+type IssueOptions struct {
+	Title  string
+	Body   string
+	Labels []string
+}
+
+// IssueCreationResult holds the results of creating all issues
+type IssueCreationResult struct {
+	ParentIssueNumber int
+	ParentIssueURL    string
+	SubIssueNumbers   map[string]int    // task_id -> issue_number
+	SubIssueURLs      map[string]string // task_id -> issue_url
+}
+
+// CreateIssue creates a GitHub issue using the gh CLI
+// Returns the issue number and URL on success
+func CreateIssue(opts IssueOptions) (int, string, error) {
+	args := []string{"issue", "create",
+		"--title", opts.Title,
+		"--body", opts.Body,
+	}
+
+	for _, label := range opts.Labels {
+		args = append(args, "--label", label)
+	}
+
+	cmd := exec.Command("gh", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to create issue: %w\n%s", err, string(output))
+	}
+
+	url := strings.TrimSpace(string(output))
+	num, err := parseIssueNumber(url)
+	if err != nil {
+		return 0, url, err
+	}
+
+	return num, url, nil
+}
+
+// parseIssueNumber extracts issue number from gh output URL
+// e.g., https://github.com/owner/repo/issues/123
+func parseIssueNumber(output string) (int, error) {
+	re := regexp.MustCompile(`/issues/(\d+)`)
+	matches := re.FindStringSubmatch(output)
+	if len(matches) < 2 {
+		return 0, fmt.Errorf("could not parse issue number from: %s", output)
+	}
+
+	num, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, fmt.Errorf("invalid issue number: %w", err)
+	}
+
+	return num, nil
+}
+
+// UpdateIssueBody updates an existing issue's body
+// This is used to update the parent issue after all sub-issues are created
+func UpdateIssueBody(issueNumber int, newBody string) error {
+	cmd := exec.Command("gh", "issue", "edit",
+		strconv.Itoa(issueNumber),
+		"--body", newBody,
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to update issue: %w\n%s", err, string(output))
+	}
+
+	return nil
+}

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -1,0 +1,436 @@
+package plan
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+)
+
+// Config holds configuration for plan-only mode
+type Config struct {
+	MultiPass    bool
+	Labels       []string
+	DryRun       bool
+	OutputFile   string
+	OutputFormat string // "json", "issues", or "both"
+}
+
+// DefaultConfig returns the default configuration
+func DefaultConfig() Config {
+	return Config{
+		MultiPass:    false,
+		Labels:       nil,
+		DryRun:       false,
+		OutputFile:   "",
+		OutputFormat: "issues",
+	}
+}
+
+// PlanningPrompt is the prompt template for CLI-based planning
+// This is a simplified version of ultraplan's prompt for synchronous execution
+const PlanningPrompt = `You are a senior software architect planning a complex task.
+
+## Objective
+{{.Objective}}
+
+## Instructions
+
+1. **Explore** the codebase to understand its structure and patterns
+2. **Decompose** the objective into discrete, parallelizable tasks
+3. **Output your plan** as a JSON object
+
+## Plan JSON Schema
+
+Output a JSON object with this structure:
+- "summary": Brief executive summary (string)
+- "tasks": Array of task objects, each with:
+  - "id": Unique identifier like "task-1-setup" (string)
+  - "title": Short title (string)
+  - "description": Detailed instructions for another developer to execute independently (string)
+  - "files": Files this task will modify (array of strings)
+  - "depends_on": IDs of tasks that must complete first (array of strings, empty for independent tasks)
+  - "priority": Lower = higher priority within dependency level (number)
+  - "est_complexity": "low", "medium", or "high" (string)
+- "insights": Key findings about the codebase (array of strings)
+- "constraints": Risks or constraints to consider (array of strings)
+
+## Guidelines
+
+- **Prefer many small tasks over fewer large ones** - 10 small tasks are better than 3 medium/large tasks
+- Each task should be completable within a single focused session
+- Target "low" complexity tasks; split "medium" or "high" complexity work into multiple smaller tasks
+- Prefer granular tasks that can run in parallel over large sequential ones
+- Assign clear file ownership to avoid merge conflicts
+- Each task description should be complete enough for independent execution
+
+## Response Format
+
+Respond ONLY with valid JSON. Do not include any text before or after the JSON object.
+Do not wrap the JSON in markdown code blocks.
+`
+
+// MultiPassStrategy defines a strategic approach for planning
+type MultiPassStrategy struct {
+	Name        string
+	Description string
+	ExtraPrompt string
+}
+
+// MultiPassStrategies are the three planning strategies
+var MultiPassStrategies = []MultiPassStrategy{
+	{
+		Name:        "maximize-parallelism",
+		Description: "Optimize for maximum parallel execution",
+		ExtraPrompt: `
+## Strategic Focus: Maximize Parallelism
+
+Prioritize these principles:
+1. Minimize Dependencies: Structure tasks to have as few inter-task dependencies as possible
+2. Prefer Smaller Tasks: Break work into many small, independent units
+3. Isolate File Ownership: Assign each file to exactly one task where possible
+4. Flatten the Dependency Graph: Aim for a wide, shallow execution graph
+`,
+	},
+	{
+		Name:        "minimize-complexity",
+		Description: "Optimize for simplicity and clarity",
+		ExtraPrompt: `
+## Strategic Focus: Minimize Complexity
+
+Prioritize these principles:
+1. Single Responsibility: Each task should do exactly one thing well
+2. Clear Boundaries: Tasks should have well-defined inputs and outputs
+3. Natural Code Boundaries: Align task boundaries with codebase structure
+4. Explicit Over Implicit: Make dependencies explicit even if it reduces parallelism
+`,
+	},
+	{
+		Name:        "balanced-approach",
+		Description: "Balance parallelism, complexity, and dependencies",
+		ExtraPrompt: `
+## Strategic Focus: Balanced Approach
+
+Balance these concerns:
+1. Respect Natural Structure: Follow the codebase's existing architecture
+2. Pragmatic Dependencies: Include dependencies that reflect genuine execution order
+3. Right-Sized Tasks: Tasks should be large enough to be meaningful but small enough to complete quickly
+4. Consider Integration: Group changes that will need to be tested together
+`,
+	},
+}
+
+// RunPlanningSync runs the planning phase synchronously using claude --print
+func RunPlanningSync(objective string, multiPass bool) (*orchestrator.PlanSpec, error) {
+	if multiPass {
+		return runMultiPassPlanningSync(objective)
+	}
+	return runSinglePassPlanningSync(objective)
+}
+
+func runSinglePassPlanningSync(objective string) (*orchestrator.PlanSpec, error) {
+	prompt, err := buildPlanningPrompt(objective, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to build planning prompt: %w", err)
+	}
+
+	output, err := runClaude(prompt)
+	if err != nil {
+		return nil, fmt.Errorf("planning failed: %w", err)
+	}
+
+	return parsePlanFromOutput(output, objective)
+}
+
+func runMultiPassPlanningSync(objective string) (*orchestrator.PlanSpec, error) {
+	// Run all three strategies and collect plans
+	var plans []*orchestrator.PlanSpec
+
+	for _, strategy := range MultiPassStrategies {
+		fmt.Printf("Planning with %s strategy...\n", strategy.Name)
+
+		prompt, err := buildPlanningPrompt(objective, strategy.ExtraPrompt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build planning prompt for %s: %w", strategy.Name, err)
+		}
+
+		output, err := runClaude(prompt)
+		if err != nil {
+			fmt.Printf("Warning: %s strategy failed: %v\n", strategy.Name, err)
+			continue
+		}
+
+		plan, err := parsePlanFromOutput(output, objective)
+		if err != nil {
+			fmt.Printf("Warning: failed to parse %s plan: %v\n", strategy.Name, err)
+			continue
+		}
+
+		plans = append(plans, plan)
+	}
+
+	if len(plans) == 0 {
+		return nil, fmt.Errorf("all planning strategies failed")
+	}
+
+	// For simplicity in CLI mode, select the plan with the most tasks
+	// (In TUI mode, we would use the plan manager to evaluate and select)
+	best := plans[0]
+	for _, p := range plans[1:] {
+		if len(p.Tasks) > len(best.Tasks) {
+			best = p
+		}
+	}
+
+	return best, nil
+}
+
+func buildPlanningPrompt(objective, extraPrompt string) (string, error) {
+	tmpl, err := template.New("planning").Parse(PlanningPrompt)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, map[string]string{"Objective": objective}); err != nil {
+		return "", err
+	}
+
+	prompt := buf.String()
+	if extraPrompt != "" {
+		prompt += "\n" + extraPrompt
+	}
+
+	return prompt, nil
+}
+
+func runClaude(prompt string) (string, error) {
+	cmd := exec.Command("claude", "--print", prompt)
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("claude command failed: %w\nstderr: %s", err, string(exitErr.Stderr))
+		}
+		return "", fmt.Errorf("failed to run claude: %w", err)
+	}
+
+	return string(output), nil
+}
+
+func parsePlanFromOutput(output, objective string) (*orchestrator.PlanSpec, error) {
+	// Clean up the output - remove any markdown code blocks
+	output = strings.TrimSpace(output)
+	output = strings.TrimPrefix(output, "```json")
+	output = strings.TrimPrefix(output, "```")
+	output = strings.TrimSuffix(output, "```")
+	output = strings.TrimSpace(output)
+
+	// Find JSON boundaries
+	start := strings.Index(output, "{")
+	end := strings.LastIndex(output, "}")
+	if start == -1 || end == -1 || end <= start {
+		return nil, fmt.Errorf("no JSON object found in output")
+	}
+	output = output[start : end+1]
+
+	// Parse the JSON
+	var rawPlan struct {
+		Summary     string                    `json:"summary"`
+		Tasks       []orchestrator.PlannedTask `json:"tasks"`
+		Insights    []string                  `json:"insights"`
+		Constraints []string                  `json:"constraints"`
+	}
+
+	if err := json.Unmarshal([]byte(output), &rawPlan); err != nil {
+		return nil, fmt.Errorf("failed to parse plan JSON: %w\nraw output: %s", err, output)
+	}
+
+	// Build the full PlanSpec
+	plan := &orchestrator.PlanSpec{
+		ID:              orchestrator.GenerateID(),
+		Objective:       objective,
+		Summary:         rawPlan.Summary,
+		Tasks:           rawPlan.Tasks,
+		Insights:        rawPlan.Insights,
+		Constraints:     rawPlan.Constraints,
+		DependencyGraph: make(map[string][]string),
+		CreatedAt:       time.Now(),
+	}
+
+	// Build dependency graph
+	for _, task := range plan.Tasks {
+		plan.DependencyGraph[task.ID] = task.DependsOn
+	}
+
+	// Calculate execution order using topological sort
+	plan.ExecutionOrder = calculateExecutionOrder(plan.Tasks, plan.DependencyGraph)
+
+	return plan, nil
+}
+
+// calculateExecutionOrder creates groups of tasks that can run in parallel
+// This is a simplified version of orchestrator.calculateExecutionOrder
+func calculateExecutionOrder(tasks []orchestrator.PlannedTask, _ map[string][]string) [][]string {
+	// Build in-degree map
+	inDegree := make(map[string]int)
+	for _, task := range tasks {
+		inDegree[task.ID] = len(task.DependsOn)
+	}
+
+	var groups [][]string
+	completed := make(map[string]bool)
+
+	for len(completed) < len(tasks) {
+		var currentGroup []string
+
+		// Find all tasks with in-degree 0
+		for _, task := range tasks {
+			if !completed[task.ID] && inDegree[task.ID] == 0 {
+				currentGroup = append(currentGroup, task.ID)
+			}
+		}
+
+		if len(currentGroup) == 0 {
+			// Cycle detected or invalid graph - add remaining tasks
+			for _, task := range tasks {
+				if !completed[task.ID] {
+					currentGroup = append(currentGroup, task.ID)
+				}
+			}
+			groups = append(groups, currentGroup)
+			break
+		}
+
+		groups = append(groups, currentGroup)
+
+		// Mark as completed and update in-degrees
+		for _, taskID := range currentGroup {
+			completed[taskID] = true
+			for _, task := range tasks {
+				for _, depID := range task.DependsOn {
+					if depID == taskID {
+						inDegree[task.ID]--
+					}
+				}
+			}
+		}
+	}
+
+	return groups
+}
+
+// SavePlanToFile saves a plan to a JSON file
+func SavePlanToFile(plan *orchestrator.PlanSpec, filePath string) error {
+	data, err := json.MarshalIndent(plan, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal plan: %w", err)
+	}
+
+	// Ensure directory exists
+	dir := filepath.Dir(filePath)
+	if dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory: %w", err)
+		}
+	}
+
+	if err := os.WriteFile(filePath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write plan file: %w", err)
+	}
+
+	return nil
+}
+
+// CreateIssuesFromPlan creates GitHub issues from a plan
+func CreateIssuesFromPlan(plan *orchestrator.PlanSpec, labels []string) (*IssueCreationResult, error) {
+	result := &IssueCreationResult{
+		SubIssueNumbers: make(map[string]int),
+		SubIssueURLs:    make(map[string]string),
+	}
+
+	// First, create a placeholder parent issue (we'll update it after sub-issues are created)
+	parentNum, parentURL, err := CreateIssue(IssueOptions{
+		Title:  fmt.Sprintf("Plan: %s", truncateTitle(plan.Objective, 60)),
+		Body:   fmt.Sprintf("## Summary\n\n%s\n\n*Creating sub-issues...*", plan.Summary),
+		Labels: labels,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create parent issue: %w", err)
+	}
+	result.ParentIssueNumber = parentNum
+	result.ParentIssueURL = parentURL
+
+	fmt.Printf("Created parent issue: #%d\n", parentNum)
+
+	// Create sub-issues in dependency order
+	// We need to track created issues to resolve dependency references
+	dependencyInfo := make(map[string]DependencyInfo)
+
+	for groupIdx, group := range plan.ExecutionOrder {
+		fmt.Printf("Creating issues for group %d...\n", groupIdx+1)
+
+		for _, taskID := range group {
+			// Find the task
+			var task orchestrator.PlannedTask
+			for _, t := range plan.Tasks {
+				if t.ID == taskID {
+					task = t
+					break
+				}
+			}
+
+			// Render sub-issue body
+			body, err := RenderSubIssueBody(task, parentNum, dependencyInfo)
+			if err != nil {
+				return nil, fmt.Errorf("failed to render body for task %s: %w", taskID, err)
+			}
+
+			// Create the sub-issue
+			subNum, subURL, err := CreateIssue(IssueOptions{
+				Title:  task.Title,
+				Body:   body,
+				Labels: labels,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to create sub-issue for task %s: %w", taskID, err)
+			}
+
+			result.SubIssueNumbers[taskID] = subNum
+			result.SubIssueURLs[taskID] = subURL
+			dependencyInfo[taskID] = DependencyInfo{
+				IssueNumber: subNum,
+				Title:       task.Title,
+			}
+
+			fmt.Printf("  Created sub-issue #%d: %s\n", subNum, task.Title)
+		}
+	}
+
+	// Now update the parent issue with links to all sub-issues
+	parentBody, err := RenderParentIssueBody(plan, result.SubIssueNumbers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to render parent issue body: %w", err)
+	}
+
+	if err := UpdateIssueBody(parentNum, parentBody); err != nil {
+		return nil, fmt.Errorf("failed to update parent issue: %w", err)
+	}
+
+	fmt.Printf("Updated parent issue #%d with sub-issue links\n", parentNum)
+
+	return result, nil
+}
+
+func truncateTitle(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -1,0 +1,178 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+)
+
+func TestParseIssueNumber(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int
+		wantErr bool
+	}{
+		{
+			name:    "standard github url",
+			input:   "https://github.com/owner/repo/issues/123",
+			want:    123,
+			wantErr: false,
+		},
+		{
+			name:    "url with trailing newline",
+			input:   "https://github.com/owner/repo/issues/456\n",
+			want:    456,
+			wantErr: false,
+		},
+		{
+			name:    "url with extra path",
+			input:   "https://github.com/owner/repo/issues/789/comments",
+			want:    789,
+			wantErr: false,
+		},
+		{
+			name:    "invalid url - no issues path",
+			input:   "https://github.com/owner/repo/pull/123",
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name:    "invalid url - no number",
+			input:   "https://github.com/owner/repo/issues/",
+			want:    0,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseIssueNumber(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseIssueNumber() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseIssueNumber() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCalculateExecutionOrder(t *testing.T) {
+	tests := []struct {
+		name  string
+		tasks []orchestrator.PlannedTask
+		want  int // number of groups expected
+	}{
+		{
+			name: "no dependencies - single group",
+			tasks: []orchestrator.PlannedTask{
+				{ID: "task-1"},
+				{ID: "task-2"},
+				{ID: "task-3"},
+			},
+			want: 1,
+		},
+		{
+			name: "linear dependencies - 3 groups",
+			tasks: []orchestrator.PlannedTask{
+				{ID: "task-1", DependsOn: []string{}},
+				{ID: "task-2", DependsOn: []string{"task-1"}},
+				{ID: "task-3", DependsOn: []string{"task-2"}},
+			},
+			want: 3,
+		},
+		{
+			name: "diamond dependencies - 3 groups",
+			tasks: []orchestrator.PlannedTask{
+				{ID: "task-1", DependsOn: []string{}},
+				{ID: "task-2a", DependsOn: []string{"task-1"}},
+				{ID: "task-2b", DependsOn: []string{"task-1"}},
+				{ID: "task-3", DependsOn: []string{"task-2a", "task-2b"}},
+			},
+			want: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deps := make(map[string][]string)
+			for _, task := range tt.tasks {
+				deps[task.ID] = task.DependsOn
+			}
+
+			got := calculateExecutionOrder(tt.tasks, deps)
+			if len(got) != tt.want {
+				t.Errorf("calculateExecutionOrder() got %d groups, want %d", len(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatPlanForDisplay(t *testing.T) {
+	plan := &orchestrator.PlanSpec{
+		Summary: "Test plan summary",
+		Tasks: []orchestrator.PlannedTask{
+			{ID: "task-1", Title: "Setup", EstComplexity: "low", Files: []string{"main.go"}},
+			{ID: "task-2", Title: "Implement", EstComplexity: "medium", DependsOn: []string{"task-1"}},
+		},
+		ExecutionOrder: [][]string{{"task-1"}, {"task-2"}},
+		Insights:       []string{"Codebase uses standard patterns"},
+		Constraints:    []string{"Must maintain backwards compatibility"},
+	}
+
+	output := FormatPlanForDisplay(plan)
+
+	// Check that key sections are present
+	if output == "" {
+		t.Error("FormatPlanForDisplay() returned empty string")
+	}
+
+	// Should contain summary
+	if !containsString(output, "Test plan summary") {
+		t.Error("FormatPlanForDisplay() missing summary")
+	}
+
+	// Should contain task count
+	if !containsString(output, "2 total") {
+		t.Error("FormatPlanForDisplay() missing task count")
+	}
+
+	// Should contain insights
+	if !containsString(output, "Codebase uses standard patterns") {
+		t.Error("FormatPlanForDisplay() missing insights")
+	}
+}
+
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && findSubstring(s, substr) >= 0
+}
+
+func findSubstring(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestTruncateTitle(t *testing.T) {
+	tests := []struct {
+		input  string
+		maxLen int
+		want   string
+	}{
+		{"short", 10, "short"},
+		{"exactly 10", 10, "exactly 10"},
+		{"this is a longer title", 10, "this is..."},
+	}
+
+	for _, tt := range tests {
+		got := truncateTitle(tt.input, tt.maxLen)
+		if got != tt.want {
+			t.Errorf("truncateTitle(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
+		}
+	}
+}

--- a/internal/plan/template.go
+++ b/internal/plan/template.go
@@ -1,0 +1,232 @@
+package plan
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+)
+
+// SubIssueData holds data for rendering a sub-issue body
+type SubIssueData struct {
+	Title             string
+	Description       string
+	Files             []string
+	Complexity        string
+	Dependencies      []DependencyInfo
+	ParentIssueNumber int
+}
+
+// DependencyInfo holds info about a dependency for template rendering
+type DependencyInfo struct {
+	IssueNumber int
+	Title       string
+}
+
+// GroupedTask holds task info with its issue number for parent template
+type GroupedTask struct {
+	TaskID      string
+	Title       string
+	IssueNumber int
+}
+
+// ParentIssueData holds data for rendering the parent issue body
+type ParentIssueData struct {
+	Objective    string
+	Summary      string
+	Insights     []string
+	Constraints  []string
+	GroupedTasks [][]GroupedTask // tasks grouped by execution order
+}
+
+const parentIssueBodyTemplate = `## Summary
+
+{{.Summary}}
+
+{{if .Insights}}## Analysis
+
+{{range .Insights}}- {{.}}
+{{end}}
+{{end}}
+{{if .Constraints}}## Constraints
+
+{{range .Constraints}}- {{.}}
+{{end}}
+{{end}}
+## Sub-Issues
+{{range $groupIdx, $group := .GroupedTasks}}
+### Group {{add $groupIdx 1}}{{if eq $groupIdx 0}} (can start immediately){{else}} (depends on previous groups){{end}}
+{{range $group}}- [ ] #{{.IssueNumber}} - **{{.Title}}**
+{{end}}
+{{end}}
+## Execution Order
+
+Tasks are grouped by dependencies. All tasks within a group can be worked on in parallel.
+Complete each group before starting the next.
+
+## Acceptance Criteria
+
+- [ ] All sub-issues completed
+- [ ] Integration verified
+`
+
+const subIssueBodyTemplate = `## Task
+
+{{.Description}}
+{{if .Files}}
+## Files to Modify
+
+{{range .Files}}- ` + "`{{.}}`" + `
+{{end}}{{end}}
+{{if .Dependencies}}## Dependencies
+
+Complete these issues first:
+{{range .Dependencies}}- #{{.IssueNumber}} - {{.Title}}
+{{end}}
+{{end}}## Complexity
+
+Estimated: **{{.Complexity}}**
+
+---
+*Part of #{{.ParentIssueNumber}}*
+`
+
+// Template helper functions
+var templateFuncs = template.FuncMap{
+	"add": func(a, b int) int {
+		return a + b
+	},
+}
+
+// RenderParentIssueBody renders the parent issue body from plan data
+func RenderParentIssueBody(plan *orchestrator.PlanSpec, subIssueNumbers map[string]int) (string, error) {
+	// Build grouped tasks from execution order
+	groupedTasks := make([][]GroupedTask, len(plan.ExecutionOrder))
+	for groupIdx, group := range plan.ExecutionOrder {
+		groupedTasks[groupIdx] = make([]GroupedTask, 0, len(group))
+		for _, taskID := range group {
+			// Find the task
+			for _, task := range plan.Tasks {
+				if task.ID == taskID {
+					groupedTasks[groupIdx] = append(groupedTasks[groupIdx], GroupedTask{
+						TaskID:      taskID,
+						Title:       task.Title,
+						IssueNumber: subIssueNumbers[taskID],
+					})
+					break
+				}
+			}
+		}
+	}
+
+	data := ParentIssueData{
+		Objective:    plan.Objective,
+		Summary:      plan.Summary,
+		Insights:     plan.Insights,
+		Constraints:  plan.Constraints,
+		GroupedTasks: groupedTasks,
+	}
+
+	tmpl, err := template.New("parent-issue").Funcs(templateFuncs).Parse(parentIssueBodyTemplate)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse parent issue template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("failed to render parent issue template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// RenderSubIssueBody renders a sub-issue body from task data
+func RenderSubIssueBody(task orchestrator.PlannedTask, parentIssueNumber int, dependencyInfo map[string]DependencyInfo) (string, error) {
+	// Build dependencies list
+	var deps []DependencyInfo
+	for _, depID := range task.DependsOn {
+		if info, ok := dependencyInfo[depID]; ok {
+			deps = append(deps, info)
+		}
+	}
+
+	data := SubIssueData{
+		Title:             task.Title,
+		Description:       task.Description,
+		Files:             task.Files,
+		Complexity:        string(task.EstComplexity),
+		Dependencies:      deps,
+		ParentIssueNumber: parentIssueNumber,
+	}
+
+	tmpl, err := template.New("sub-issue").Parse(subIssueBodyTemplate)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse sub-issue template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("failed to render sub-issue template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// FormatPlanForDisplay formats a plan for terminal display
+func FormatPlanForDisplay(plan *orchestrator.PlanSpec) string {
+	var sb strings.Builder
+
+	sb.WriteString("Plan Summary\n")
+	sb.WriteString("============\n\n")
+
+	if plan.Summary != "" {
+		sb.WriteString(plan.Summary)
+		sb.WriteString("\n\n")
+	}
+
+	// Tasks by execution group
+	sb.WriteString(fmt.Sprintf("Tasks: %d total in %d execution groups\n\n", len(plan.Tasks), len(plan.ExecutionOrder)))
+
+	for groupIdx, group := range plan.ExecutionOrder {
+		if groupIdx == 0 {
+			sb.WriteString(fmt.Sprintf("Group %d (can start immediately):\n", groupIdx+1))
+		} else {
+			sb.WriteString(fmt.Sprintf("Group %d (depends on previous):\n", groupIdx+1))
+		}
+
+		for _, taskID := range group {
+			for _, task := range plan.Tasks {
+				if task.ID == taskID {
+					sb.WriteString(fmt.Sprintf("  - [%s] %s (%s)\n", task.ID, task.Title, task.EstComplexity))
+					if len(task.Files) > 0 {
+						sb.WriteString(fmt.Sprintf("    Files: %s\n", strings.Join(task.Files, ", ")))
+					}
+					break
+				}
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	// Insights
+	if len(plan.Insights) > 0 {
+		sb.WriteString("Key Insights:\n")
+		for _, insight := range plan.Insights {
+			sb.WriteString(fmt.Sprintf("  - %s\n", insight))
+		}
+		sb.WriteString("\n")
+	}
+
+	// Constraints
+	if len(plan.Constraints) > 0 {
+		sb.WriteString("Constraints:\n")
+		for _, constraint := range plan.Constraints {
+			sb.WriteString(fmt.Sprintf("  - %s\n", constraint))
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}

--- a/internal/plan/template_test.go
+++ b/internal/plan/template_test.go
@@ -1,0 +1,139 @@
+package plan
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+)
+
+func TestRenderSubIssueBody(t *testing.T) {
+	task := orchestrator.PlannedTask{
+		ID:            "task-1",
+		Title:         "Test Task",
+		Description:   "This is a test task description",
+		Files:         []string{"main.go", "utils.go"},
+		EstComplexity: "low",
+		DependsOn:     []string{},
+	}
+
+	body, err := RenderSubIssueBody(task, 42, nil)
+	if err != nil {
+		t.Fatalf("RenderSubIssueBody() error = %v", err)
+	}
+
+	// Check required sections
+	if !strings.Contains(body, "This is a test task description") {
+		t.Error("Body missing description")
+	}
+	if !strings.Contains(body, "`main.go`") {
+		t.Error("Body missing file")
+	}
+	if !strings.Contains(body, "**low**") {
+		t.Error("Body missing complexity")
+	}
+	if !strings.Contains(body, "#42") {
+		t.Error("Body missing parent issue reference")
+	}
+}
+
+func TestRenderSubIssueBodyWithDependencies(t *testing.T) {
+	task := orchestrator.PlannedTask{
+		ID:            "task-2",
+		Title:         "Dependent Task",
+		Description:   "This task depends on another",
+		Files:         []string{"api.go"},
+		EstComplexity: "medium",
+		DependsOn:     []string{"task-1"},
+	}
+
+	depInfo := map[string]DependencyInfo{
+		"task-1": {IssueNumber: 100, Title: "First Task"},
+	}
+
+	body, err := RenderSubIssueBody(task, 42, depInfo)
+	if err != nil {
+		t.Fatalf("RenderSubIssueBody() error = %v", err)
+	}
+
+	if !strings.Contains(body, "Complete these issues first") {
+		t.Error("Body missing dependency section")
+	}
+	if !strings.Contains(body, "#100") {
+		t.Error("Body missing dependency issue number")
+	}
+	if !strings.Contains(body, "First Task") {
+		t.Error("Body missing dependency title")
+	}
+}
+
+func TestRenderParentIssueBody(t *testing.T) {
+	plan := &orchestrator.PlanSpec{
+		Objective: "Test objective",
+		Summary:   "Test summary for the parent issue",
+		Tasks: []orchestrator.PlannedTask{
+			{ID: "task-1", Title: "First Task"},
+			{ID: "task-2", Title: "Second Task", DependsOn: []string{"task-1"}},
+		},
+		ExecutionOrder: [][]string{{"task-1"}, {"task-2"}},
+		Insights:       []string{"Key insight about codebase"},
+		Constraints:    []string{"Important constraint"},
+	}
+
+	subIssueNumbers := map[string]int{
+		"task-1": 101,
+		"task-2": 102,
+	}
+
+	body, err := RenderParentIssueBody(plan, subIssueNumbers)
+	if err != nil {
+		t.Fatalf("RenderParentIssueBody() error = %v", err)
+	}
+
+	// Check required sections
+	if !strings.Contains(body, "Test summary for the parent issue") {
+		t.Error("Body missing summary")
+	}
+	if !strings.Contains(body, "Key insight about codebase") {
+		t.Error("Body missing insights")
+	}
+	if !strings.Contains(body, "Important constraint") {
+		t.Error("Body missing constraints")
+	}
+	if !strings.Contains(body, "#101") || !strings.Contains(body, "#102") {
+		t.Error("Body missing sub-issue references")
+	}
+	if !strings.Contains(body, "Group 1") {
+		t.Error("Body missing execution groups")
+	}
+	if !strings.Contains(body, "can start immediately") {
+		t.Error("Body missing group annotation")
+	}
+}
+
+func TestRenderParentIssueBodyEmptySections(t *testing.T) {
+	plan := &orchestrator.PlanSpec{
+		Objective: "Test objective",
+		Summary:   "Test summary",
+		Tasks: []orchestrator.PlannedTask{
+			{ID: "task-1", Title: "Only Task"},
+		},
+		ExecutionOrder: [][]string{{"task-1"}},
+		Insights:       nil,
+		Constraints:    nil,
+	}
+
+	subIssueNumbers := map[string]int{
+		"task-1": 101,
+	}
+
+	body, err := RenderParentIssueBody(plan, subIssueNumbers)
+	if err != nil {
+		t.Fatalf("RenderParentIssueBody() error = %v", err)
+	}
+
+	// Should still render without insights/constraints sections
+	if !strings.Contains(body, "Test summary") {
+		t.Error("Body missing summary")
+	}
+}

--- a/internal/tui/templates.go
+++ b/internal/tui/templates.go
@@ -60,6 +60,45 @@ var TaskTemplates = []TaskTemplate{
 		Description: "Perform a security audit and fix any vulnerabilities found.",
 	},
 	{
+		Command: "plan",
+		Name:    "Create Issue Plan",
+		Description: `Create a structured plan for the following objective:
+
+[Your objective here]
+
+Instructions:
+1. Explore the codebase to understand its structure and patterns
+2. Decompose the objective into discrete, parallelizable tasks
+3. Create a detailed execution plan with:
+   - Task breakdown with clear titles and descriptions
+   - File ownership for each task
+   - Dependencies between tasks
+   - Execution order (groups of parallelizable tasks)
+   - Key insights about the codebase
+   - Constraints and risks to consider
+
+4. Output the plan as a JSON object with this structure:
+{
+  "summary": "Brief executive summary",
+  "tasks": [
+    {
+      "id": "task-1-setup",
+      "title": "Short title",
+      "description": "Detailed instructions",
+      "files": ["file1.go", "file2.go"],
+      "depends_on": [],
+      "priority": 1,
+      "est_complexity": "low"
+    }
+  ],
+  "insights": ["Key findings about the codebase"],
+  "constraints": ["Risks or constraints to consider"]
+}
+
+Target "low" complexity tasks. Split larger tasks into multiple smaller ones.
+Prefer many small tasks over fewer large ones - 10 small tasks are better than 3 medium/large tasks.`,
+	},
+	{
 		Command: "megamerge",
 		Name:    "Mega Merge PRs",
 		Description: `Merge all of my open PRs to main. Follow these steps:


### PR DESCRIPTION
## Summary

Add new `claudio plan` command that uses ultraplan's planning capabilities to produce structured output instead of spawning agents. This enables project planning workflows where the output is a trackable GitHub Issue hierarchy or a JSON file for later ultraplan execution.

## Features

- **CLI command**: `claudio plan <objective>` with flexible output formats
- **Output formats**:
  - `--output-format=json` - Creates `.claudio-plan.json` for use with `claudio ultraplan --plan`
  - `--output-format=issues` - Creates GitHub Issues with parent epic and linked sub-issues (default)
  - `--output-format=both` - Creates both
- **Multi-pass planning**: `--multi-pass` flag for 3-strategy planning on complex objectives
- **Dry-run mode**: `--dry-run` to preview plan without creating output
- **TUI template**: `/plan` template for in-session planning

## Usage Examples

```bash
# Dry-run: preview the plan
claudio plan --dry-run "Add user authentication"

# Create JSON file for ultraplan execution
claudio plan --output-format=json "Refactor API layer"
claudio ultraplan --plan .claudio-plan.json

# Create GitHub Issues directly (default)
claudio plan "Add caching layer"

# Multi-pass planning for complex objectives
claudio plan --multi-pass "Implement microservices architecture"
```

## Test Plan

- [x] Unit tests pass (`go test ./internal/plan/...`)
- [x] Build succeeds (`go build ./...`)
- [x] `claudio plan --help` shows correct usage
- [ ] Manual test: `claudio plan --dry-run "test"` shows plan output
- [ ] Manual test: `claudio plan --output-format=json "test"` creates valid JSON