### PR TITLE
feat(plan): add config file support for plan command

### DIFF
--- a/internal/cmd/plan.go
+++ b/internal/cmd/plan.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Iron-Ham/claudio/internal/config"
 	"github.com/Iron-Ham/claudio/internal/orchestrator"
 	"github.com/Iron-Ham/claudio/internal/plan"
 	"github.com/spf13/cobra"
@@ -67,6 +68,35 @@ func init() {
 }
 
 func runPlan(cmd *cobra.Command, args []string) error {
+	cfg := config.Get()
+
+	// Apply config file settings, CLI flags override
+	outputFormat := cfg.Plan.OutputFormat
+	if cmd.Flags().Changed("output-format") {
+		outputFormat = planOutputFormat
+	}
+
+	multiPass := cfg.Plan.MultiPass
+	if cmd.Flags().Changed("multi-pass") {
+		multiPass = planMultiPass
+	}
+
+	labels := cfg.Plan.Labels
+	if cmd.Flags().Changed("labels") {
+		labels = planLabels
+	}
+
+	outputFile := cfg.Plan.OutputFile
+	if cmd.Flags().Changed("output") {
+		outputFile = planOutputFile
+	}
+
+	// Update module-level vars so helper functions work correctly
+	planOutputFormat = outputFormat
+	planMultiPass = multiPass
+	planLabels = labels
+	planOutputFile = outputFile
+
 	// Get objective from args or prompt
 	var objective string
 	if len(args) > 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Cleanup    CleanupConfig    `mapstructure:"cleanup"`
 	Resources  ResourceConfig   `mapstructure:"resources"`
 	Ultraplan  UltraplanConfig  `mapstructure:"ultraplan"`
+	Plan       PlanConfig       `mapstructure:"plan"`
 }
 
 // CompletionConfig controls what happens when an instance completes
@@ -137,6 +138,18 @@ type NotificationConfig struct {
 	SoundPath string `mapstructure:"sound_path"`
 }
 
+// PlanConfig controls plan-only mode behavior
+type PlanConfig struct {
+	// OutputFormat is the default output format: "json", "issues", or "both" (default: "issues")
+	OutputFormat string `mapstructure:"output_format"`
+	// MultiPass enables multi-pass planning by default (default: false)
+	MultiPass bool `mapstructure:"multi_pass"`
+	// Labels are default labels to add to GitHub Issues
+	Labels []string `mapstructure:"labels"`
+	// OutputFile is the default output file path for JSON output (default: ".claudio-plan.json")
+	OutputFile string `mapstructure:"output_file"`
+}
+
 // Default returns a Config with sensible default values
 func Default() *Config {
 	return &Config{
@@ -191,6 +204,12 @@ func Default() *Config {
 				UseSound:  false,
 				SoundPath: "",
 			},
+		},
+		Plan: PlanConfig{
+			OutputFormat: "issues",
+			MultiPass:    false,
+			Labels:       []string{},
+			OutputFile:   ".claudio-plan.json",
 		},
 	}
 }
@@ -262,6 +281,12 @@ func SetDefaults() {
 	viper.SetDefault("ultraplan.notifications.enabled", defaults.Ultraplan.Notifications.Enabled)
 	viper.SetDefault("ultraplan.notifications.use_sound", defaults.Ultraplan.Notifications.UseSound)
 	viper.SetDefault("ultraplan.notifications.sound_path", defaults.Ultraplan.Notifications.SoundPath)
+
+	// Plan defaults
+	viper.SetDefault("plan.output_format", defaults.Plan.OutputFormat)
+	viper.SetDefault("plan.multi_pass", defaults.Plan.MultiPass)
+	viper.SetDefault("plan.labels", defaults.Plan.Labels)
+	viper.SetDefault("plan.output_file", defaults.Plan.OutputFile)
 }
 
 // Load reads the configuration from viper into a Config struct


### PR DESCRIPTION
## Summary

Add config file support for the plan command so users can set defaults in `~/.config/claudio/config.yaml`.

## Configuration Options

```yaml
plan:
  # Default output format: "json", "issues", or "both"
  output_format: "issues"
  
  # Enable multi-pass planning by default
  multi_pass: false
  
  # Default labels for GitHub Issues
  labels: []
  
  # Default JSON output file path
  output_file: ".claudio-plan.json"
```

## Behavior

- Config file settings are used as defaults
- CLI flags override config file settings
- Example: `claudio plan "objective"` uses config defaults
- Example: `claudio plan --output-format=json "objective"` overrides config

## Test Plan

- [x] Build succeeds
- [x] Tests pass
- [ ] Manual test with config file