### PR TITLE
feat(tui): improve /plan template UX with suffix field

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -488,14 +488,17 @@ func (m Model) handleKeypress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.addingTask = false
 			m.taskInput = ""
 			m.taskInputCursor = 0
+			m.templateSuffix = "" // Clear suffix on cancel
 			return m, nil
 		case tea.KeyEnter:
 			if m.taskInput != "" {
 				// Capture task and clear input state first
-				task := m.taskInput
+				// Append template suffix if one was set (e.g., /plan instructions)
+				task := m.taskInput + m.templateSuffix
 				m.addingTask = false
 				m.taskInput = ""
 				m.taskInputCursor = 0
+				m.templateSuffix = "" // Clear suffix after use
 				m.infoMessage = "Adding task..."
 				// Add instance asynchronously to avoid blocking UI during git worktree creation
 				return m, addTaskAsync(m.orchestrator, m.session, task)
@@ -503,6 +506,7 @@ func (m Model) handleKeypress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.addingTask = false
 			m.taskInput = ""
 			m.taskInputCursor = 0
+			m.templateSuffix = "" // Clear suffix on cancel
 			return m, nil
 		case tea.KeyBackspace:
 			m.taskInputDeleteBack(1)
@@ -1498,6 +1502,8 @@ func (m Model) handleTemplateDropdown(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.taskInput = m.taskInput[:lastNewline+1] + selected.Description
 			}
 			m.taskInputCursor = len([]rune(m.taskInput))
+			// Store the suffix to append on submission
+			m.templateSuffix = selected.Suffix
 		}
 		m.showTemplates = false
 		m.templateFilter = ""

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -80,6 +80,7 @@ type Model struct {
 	showTemplates    bool   // Whether the template dropdown is visible
 	templateFilter   string // Current filter text (after the "/")
 	templateSelected int    // Currently highlighted template index
+	templateSuffix   string // Suffix to append on submission (from selected template)
 
 	// File conflict tracking
 	conflicts []conflict.FileConflict

--- a/internal/tui/templates.go
+++ b/internal/tui/templates.go
@@ -4,7 +4,8 @@ package tui
 type TaskTemplate struct {
 	Command     string // The slash command (e.g., "test", "docs")
 	Name        string // Display name (e.g., "Run Tests")
-	Description string // Full task description that gets expanded
+	Description string // Task description shown to user (what they edit)
+	Suffix      string // Optional suffix appended on submission (not shown during editing)
 }
 
 // TaskTemplates defines the available task templates
@@ -60,11 +61,10 @@ var TaskTemplates = []TaskTemplate{
 		Description: "Perform a security audit and fix any vulnerabilities found.",
 	},
 	{
-		Command: "plan",
-		Name:    "Create Issue Plan",
-		Description: `Create a structured plan for the following objective:
-
-[Your objective here]
+		Command:     "plan",
+		Name:        "Create Issue Plan",
+		Description: "Create a structured plan for the following objective:\n\n",
+		Suffix: `
 
 Instructions:
 1. Explore the codebase to understand its structure and patterns


### PR DESCRIPTION
## Summary

- Add `Suffix` field to `TaskTemplate` that gets appended on submission but isn't shown during editing
- Fix poor UX where users had to arrow back through 30+ lines of instructions to find the objective placeholder
- Now users see just the objective prompt and can type directly at cursor

## Problem

When selecting `/plan`, users saw the entire template including 30+ lines of instructions, with the cursor at the end. They had to navigate back to find and replace `[Your objective here]`.

## Solution

Split templates into `Description` (shown to user) and `Suffix` (appended on submission). For `/plan`:
- **Shown**: `Create a structured plan for the following objective:\n\n`
- **Appended**: All the instructions about exploring codebase, JSON format, etc.

## Test plan

- [x] Build passes
- [x] Tests pass
- [ ] Manual test: Select `/plan`, verify only objective prompt is shown
- [ ] Manual test: Submit task, verify instructions are appended