### PR TITLE
feat(ultraplan): auto-close linked issues on task completion

### DIFF
--- a/internal/issue/service.go
+++ b/internal/issue/service.go
@@ -1,0 +1,145 @@
+// Package issue provides a provider-agnostic interface for closing issues
+// in external issue trackers (GitHub, Linear, Notion, etc.)
+package issue
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/Iron-Ham/claudio/internal/logging"
+)
+
+// Provider represents an issue tracking service
+type Provider string
+
+const (
+	ProviderGitHub  Provider = "github"
+	ProviderLinear  Provider = "linear"
+	ProviderNotion  Provider = "notion"
+	ProviderUnknown Provider = "unknown"
+)
+
+// URL parsing regexes
+var (
+	gitHubRegex = regexp.MustCompile(`github\.com/([^/]+)/([^/]+)/issues/(\d+)$`)
+	linearRegex = regexp.MustCompile(`linear\.app/[^/]+/issue/([A-Z]+-\d+)`)
+)
+
+// Service handles closing issues across different providers
+type Service struct {
+	logger *logging.Logger
+}
+
+// NewService creates a new issue service
+func NewService(logger *logging.Logger) *Service {
+	return &Service{logger: logger}
+}
+
+// Close closes an issue given its URL
+// Returns nil if the URL is empty or the provider is unsupported
+func (s *Service) Close(ctx context.Context, issueURL string) error {
+	if issueURL == "" {
+		return nil
+	}
+
+	provider, err := DetectProvider(issueURL)
+	if err != nil {
+		s.logger.Warn("failed to detect issue provider", "url", issueURL, "error", err)
+		return nil // Don't fail task completion for issue closing errors
+	}
+
+	switch provider {
+	case ProviderGitHub:
+		return s.closeGitHub(ctx, issueURL)
+	case ProviderLinear:
+		return s.closeLinear(ctx, issueURL)
+	case ProviderNotion:
+		return s.closeNotion(ctx, issueURL)
+	default:
+		s.logger.Debug("unsupported issue provider", "url", issueURL, "provider", provider)
+		return nil
+	}
+}
+
+// DetectProvider determines the issue provider from a URL
+func DetectProvider(issueURL string) (Provider, error) {
+	parsed, err := url.Parse(issueURL)
+	if err != nil {
+		return ProviderUnknown, fmt.Errorf("invalid URL: %w", err)
+	}
+
+	host := strings.ToLower(parsed.Host)
+
+	switch {
+	case strings.Contains(host, "github.com"):
+		return ProviderGitHub, nil
+	case strings.Contains(host, "linear.app"):
+		return ProviderLinear, nil
+	case strings.Contains(host, "notion.so") || strings.Contains(host, "notion.site"):
+		return ProviderNotion, nil
+	default:
+		return ProviderUnknown, nil
+	}
+}
+
+// closeGitHub closes a GitHub issue using the gh CLI
+func (s *Service) closeGitHub(ctx context.Context, issueURL string) error {
+	// Extract owner/repo and issue number from URL
+	// Format: https://github.com/owner/repo/issues/123
+	matches := gitHubRegex.FindStringSubmatch(issueURL)
+	if len(matches) != 4 {
+		return fmt.Errorf("invalid GitHub issue URL: %s", issueURL)
+	}
+
+	owner, repo, number := matches[1], matches[2], matches[3]
+	repoPath := fmt.Sprintf("%s/%s", owner, repo)
+
+	s.logger.Info("closing GitHub issue", "repo", repoPath, "issue", number)
+
+	cmd := exec.CommandContext(ctx, "gh", "issue", "close", number, "--repo", repoPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to close GitHub issue #%s: %w\noutput: %s", number, err, string(output))
+	}
+
+	s.logger.Info("closed GitHub issue", "repo", repoPath, "issue", number)
+	return nil
+}
+
+// closeLinear closes a Linear issue using the linear CLI (if available)
+func (s *Service) closeLinear(ctx context.Context, issueURL string) error {
+	// Linear URL format: https://linear.app/team/issue/TEAM-123/title
+	matches := linearRegex.FindStringSubmatch(issueURL)
+	if len(matches) != 2 {
+		return fmt.Errorf("invalid Linear issue URL: %s", issueURL)
+	}
+
+	issueID := matches[1]
+	s.logger.Info("closing Linear issue", "issue", issueID)
+
+	// Try using linear CLI if available
+	cmd := exec.CommandContext(ctx, "linear", "issue", "close", issueID)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// Linear CLI might not be installed - log and continue
+		s.logger.Warn("failed to close Linear issue (linear CLI may not be installed)",
+			"issue", issueID, "error", err, "output", string(output))
+		return nil
+	}
+
+	s.logger.Info("closed Linear issue", "issue", issueID)
+	return nil
+}
+
+// closeNotion marks a Notion page/task as complete
+// Note: Notion doesn't have a CLI, so this is a placeholder for API integration
+func (s *Service) closeNotion(ctx context.Context, issueURL string) error {
+	s.logger.Debug("Notion issue closing not yet implemented", "url", issueURL)
+	// Future: Use Notion API to update page status
+	// Would require NOTION_API_KEY and database-specific property names
+	return nil
+}

--- a/internal/issue/service_test.go
+++ b/internal/issue/service_test.go
@@ -1,0 +1,204 @@
+package issue
+
+import (
+	"testing"
+)
+
+func TestDetectProvider(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected Provider
+		wantErr  bool
+	}{
+		{
+			name:     "GitHub issue URL",
+			url:      "https://github.com/Iron-Ham/claudio/issues/163",
+			expected: ProviderGitHub,
+		},
+		{
+			name:     "GitHub PR URL",
+			url:      "https://github.com/owner/repo/pull/42",
+			expected: ProviderGitHub,
+		},
+		{
+			name:     "Linear issue URL",
+			url:      "https://linear.app/myteam/issue/ENG-123/some-title",
+			expected: ProviderLinear,
+		},
+		{
+			name:     "Linear issue URL without title",
+			url:      "https://linear.app/myteam/issue/ENG-456",
+			expected: ProviderLinear,
+		},
+		{
+			name:     "Notion page URL",
+			url:      "https://notion.so/workspace/Page-Title-abc123",
+			expected: ProviderNotion,
+		},
+		{
+			name:     "Notion site URL",
+			url:      "https://myteam.notion.site/Task-abc123",
+			expected: ProviderNotion,
+		},
+		{
+			name:     "Unknown provider",
+			url:      "https://jira.atlassian.com/browse/PROJ-123",
+			expected: ProviderUnknown,
+		},
+		{
+			name:     "Empty URL",
+			url:      "",
+			expected: ProviderUnknown,
+			wantErr:  false, // Empty URL parses but returns unknown
+		},
+		{
+			name:     "Invalid URL",
+			url:      "not a url at all",
+			expected: ProviderUnknown,
+			wantErr:  false, // url.Parse is lenient
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DetectProvider(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DetectProvider() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("DetectProvider() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseGitHubURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		wantOwner string
+		wantRepo  string
+		wantNum   string
+		wantErr   bool
+	}{
+		{
+			name:      "valid issue URL",
+			url:       "https://github.com/Iron-Ham/claudio/issues/163",
+			wantOwner: "Iron-Ham",
+			wantRepo:  "claudio",
+			wantNum:   "163",
+		},
+		{
+			name:      "issue URL with trailing slash",
+			url:       "https://github.com/owner/repo/issues/42/",
+			wantOwner: "",
+			wantRepo:  "",
+			wantNum:   "",
+			wantErr:   true,
+		},
+		{
+			name:    "PR URL (not an issue)",
+			url:     "https://github.com/owner/repo/pull/42",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format",
+			url:     "https://github.com/owner",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test the regex used in closeGitHub
+			re := gitHubIssueRegex
+			matches := re.FindStringSubmatch(tt.url)
+
+			if tt.wantErr {
+				if len(matches) == 4 {
+					t.Errorf("expected no match for %q, got %v", tt.url, matches)
+				}
+				return
+			}
+
+			if len(matches) != 4 {
+				t.Errorf("expected match for %q, got %v", tt.url, matches)
+				return
+			}
+
+			if matches[1] != tt.wantOwner {
+				t.Errorf("owner = %q, want %q", matches[1], tt.wantOwner)
+			}
+			if matches[2] != tt.wantRepo {
+				t.Errorf("repo = %q, want %q", matches[2], tt.wantRepo)
+			}
+			if matches[3] != tt.wantNum {
+				t.Errorf("number = %q, want %q", matches[3], tt.wantNum)
+			}
+		})
+	}
+}
+
+func TestParseLinearURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		wantID    string
+		wantMatch bool
+	}{
+		{
+			name:      "valid Linear URL with title",
+			url:       "https://linear.app/myteam/issue/ENG-123/some-task-title",
+			wantID:    "ENG-123",
+			wantMatch: true,
+		},
+		{
+			name:      "valid Linear URL without title",
+			url:       "https://linear.app/myteam/issue/PROJ-456",
+			wantID:    "PROJ-456",
+			wantMatch: true,
+		},
+		{
+			name:      "Linear URL with long ID",
+			url:       "https://linear.app/workspace/issue/ABC-99999/title",
+			wantID:    "ABC-99999",
+			wantMatch: true,
+		},
+		{
+			name:      "not a Linear issue URL",
+			url:       "https://linear.app/myteam/project/123",
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			re := linearIssueRegex
+			matches := re.FindStringSubmatch(tt.url)
+
+			if !tt.wantMatch {
+				if len(matches) >= 2 {
+					t.Errorf("expected no match for %q, got %v", tt.url, matches)
+				}
+				return
+			}
+
+			if len(matches) < 2 {
+				t.Errorf("expected match for %q, got none", tt.url)
+				return
+			}
+
+			if matches[1] != tt.wantID {
+				t.Errorf("issue ID = %q, want %q", matches[1], tt.wantID)
+			}
+		})
+	}
+}
+
+// Exported regexes for testing (defined in service.go)
+var (
+	gitHubIssueRegex = gitHubRegex
+	linearIssueRegex = linearRegex
+)

--- a/refactor-plan.json
+++ b/refactor-plan.json
@@ -1,0 +1,774 @@
+{
+  "id": "claudio-refactor-plan",
+  "objective": "We want to refactor the project to be more maintainable, with strong separation of concerns",
+  "summary": "Refactor Claudio into subpackages with strong separation of concerns. The codebase has ~27,745 LOC with major coupling issues in three areas: Ultra-Plan execution (9.8k LOC scattered across 5 files), TUI-Orchestrator bidirectional dependencies, and Instance Manager scope creep (1k LOC mixing concerns). The refactoring will extract dedicated subpackages, introduce event-based communication, and establish clear interface boundaries.",
+  "tasks": [
+    {
+      "id": "task-1",
+      "title": "Define event types package",
+      "description": "Create internal/event/types.go with all event type definitions. These events will be used for decoupling TUI from Orchestrator. Define: PRCompleteEvent, InstanceStartedEvent, InstanceStoppedEvent, ConflictDetectedEvent, TimeoutEvent, TaskCompletedEvent, PhaseChangeEvent, MetricsUpdateEvent. Each event struct should have necessary fields and implement a common Event interface. Keep this file focused only on type definitions - no logic.",
+      "files": [
+        "internal/event/types.go"
+      ],
+      "depends_on": [],
+      "priority": 1,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/163"
+    },
+    {
+      "id": "task-2",
+      "title": "Extract RingBuffer to capture subpackage",
+      "description": "Move RingBuffer from internal/instance/ringbuffer.go to internal/instance/capture/buffer.go. Update package declaration. Add documentation explaining the circular buffer behavior. The interface should remain the same: Write([]byte), Read() []byte, ReadString() string, Clear(), Len() int. Update internal imports. Do NOT change the implementation logic.",
+      "files": [
+        "internal/instance/capture/buffer.go"
+      ],
+      "depends_on": [],
+      "priority": 2,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/164"
+    },
+    {
+      "id": "task-3",
+      "title": "Extract state detection to detect subpackage",
+      "description": "Create internal/instance/detect/state.go. Move the Detector type and WaitingState enum from internal/instance/detector.go. Extract all regex patterns used for state detection. Define interface: StateDetector with Detect(output []byte) WaitingState. Keep the existing regex-based implementation but in the new location. Update documentation to explain each waiting state.",
+      "files": [
+        "internal/instance/detect/state.go"
+      ],
+      "depends_on": [],
+      "priority": 3,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/165"
+    },
+    {
+      "id": "task-4",
+      "title": "Extract timeout detection to detect subpackage",
+      "description": "Create internal/instance/detect/timeout.go. Extract timeout detection logic from Manager. Define TimeoutDetector struct with configurable thresholds for: activity timeout, completion timeout, stale output timeout. Methods: CheckTimeout(lastActivity time.Time, state WaitingState) (TimeoutType, bool). TimeoutType enum: None, Activity, Completion, Stale. Keep logic simple and testable.",
+      "files": [
+        "internal/instance/detect/timeout.go"
+      ],
+      "depends_on": [],
+      "priority": 4,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/166"
+    },
+    {
+      "id": "task-5",
+      "title": "Extract metrics to metrics subpackage",
+      "description": "Create internal/instance/metrics/parser.go. Move ParsedMetrics struct and MetricsParser from internal/instance/metrics.go and parser.go. Keep the same parsing logic for extracting token counts and cost from Claude output. Interface: MetricsParser with Parse(output []byte) (*ParsedMetrics, error). ParsedMetrics should have InputTokens, OutputTokens, CacheReadTokens, CacheWriteTokens, Cost fields.",
+      "files": [
+        "internal/instance/metrics/parser.go"
+      ],
+      "depends_on": [],
+      "priority": 5,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/167"
+    },
+    {
+      "id": "task-6",
+      "title": "Define process management interface",
+      "description": "Create internal/instance/process/interface.go defining the Process interface and related types. Interface: Process with Start(ctx context.Context) error, Stop() error, IsRunning() bool, Wait() error, SendInput(input string) error. Also define ProcessConfig struct with TmuxSession, WorkDir, InitialPrompt fields. This is interface-only, implementation comes next.",
+      "files": [
+        "internal/instance/process/interface.go"
+      ],
+      "depends_on": [],
+      "priority": 6,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/168"
+    },
+    {
+      "id": "task-7",
+      "title": "Define ultraplan package types",
+      "description": "Create internal/ultraplan/types.go with all ultraplan-related type definitions. Move from orchestrator: PlanSpec, TaskSpec, ValidationResult, PlanPhase, ExecutionPhase enums, ConsolidationResult. Add documentation for each type. These are pure data types with no methods beyond basic getters/setters.",
+      "files": [
+        "internal/ultraplan/types.go"
+      ],
+      "depends_on": [],
+      "priority": 7,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/169"
+    },
+    {
+      "id": "task-8",
+      "title": "Extract session management from orchestrator",
+      "description": "Create internal/orchestrator/session/manager.go. Extract session lifecycle from orchestrator/orchestrator.go: LoadSession, SaveSession, CreateSession, DeleteSession, AcquireLock, ReleaseLock. SessionManager struct holds config and logger. Methods operate on Session objects. This reduces orchestrator.go size and creates clear session boundary.",
+      "files": [
+        "internal/orchestrator/session/manager.go"
+      ],
+      "depends_on": [],
+      "priority": 8,
+      "est_complexity": "medium",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/170"
+    },
+    {
+      "id": "task-9",
+      "title": "Extract dashboard view component",
+      "description": "Create internal/tui/view/dashboard.go. Extract the instance list/dashboard rendering from app.go View() method. DashboardView struct with Render(model *Model) string. Handles: instance tabs, status indicators, instance list. Receives model state, returns rendered string. App.go calls DashboardView.Render() instead of inline rendering.",
+      "files": [
+        "internal/tui/view/dashboard.go"
+      ],
+      "depends_on": [],
+      "priority": 9,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/171"
+    },
+    {
+      "id": "task-10",
+      "title": "Extract instance detail view component",
+      "description": "Create internal/tui/view/instance.go. Extract single-instance detail rendering from app.go. InstanceView struct with Render(instance *Instance, output string, metrics *Metrics) string. Handles: instance header, output display, metrics display, waiting state indicator. Clean separation of instance rendering logic.",
+      "files": [
+        "internal/tui/view/instance.go"
+      ],
+      "depends_on": [],
+      "priority": 10,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/172"
+    },
+    {
+      "id": "task-11",
+      "title": "Extract conflicts view component",
+      "description": "Create internal/tui/view/conflicts.go. Extract conflict display from app.go. ConflictsView struct with Render(conflicts []FileConflict) string. Handles: conflict list, file details, instance associations. Simple extraction of existing rendering logic.",
+      "files": [
+        "internal/tui/view/conflicts.go"
+      ],
+      "depends_on": [],
+      "priority": 11,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/173"
+    },
+    {
+      "id": "task-12",
+      "title": "Extract input dialog view component",
+      "description": "Create internal/tui/view/input.go. Extract task input dialog rendering from app.go. InputView struct with Render(inputState *InputState) string. Handles: text input field, template dropdown (if visible), submit/cancel hints. Keep state in model, view only renders.",
+      "files": [
+        "internal/tui/view/input.go"
+      ],
+      "depends_on": [],
+      "priority": 12,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/174"
+    },
+    {
+      "id": "task-13",
+      "title": "Move ultraplan view to view subpackage",
+      "description": "Move internal/tui/ultraplan.go to internal/tui/view/ultraplan.go. Update package and imports. UltraplanView struct with Render(state *UltraPlanState) string. Handles: phase display, task graph visualization, progress indicators. This is already somewhat isolated, mainly needs package move and interface alignment.",
+      "files": [
+        "internal/tui/view/ultraplan.go"
+      ],
+      "depends_on": [],
+      "priority": 13,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/175"
+    },
+    {
+      "id": "task-14",
+      "title": "Move plan editor view to view subpackage",
+      "description": "Move internal/tui/planeditor.go to internal/tui/view/planeditor.go. Update package and imports. PlanEditorView struct with Render(state *PlanEditorState) string. Handles: task list, dependency visualization, editing UI. Already somewhat isolated, needs package move.",
+      "files": [
+        "internal/tui/view/planeditor.go"
+      ],
+      "depends_on": [],
+      "priority": 14,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/176"
+    },
+    {
+      "id": "task-15",
+      "title": "Add config validation",
+      "description": "Create internal/config/validator.go. Add validation logic for Config. Validate: timeout values are positive, buffer sizes are reasonable, branch prefix is valid, paths exist where required. Define ValidationError with field, value, message. Validate() method returns []ValidationError. Call validation in LoadConfig() and return clear error messages.",
+      "files": [
+        "internal/config/validator.go"
+      ],
+      "depends_on": [],
+      "priority": 15,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/177"
+    },
+    {
+      "id": "task-16",
+      "title": "Implement event bus",
+      "description": "Create internal/event/bus.go implementing a simple pub-sub event bus. Implement: Bus struct with Subscribe(eventType string, handler func(Event)), Publish(event Event), and Unsubscribe(id string). Use sync.RWMutex for thread safety. Handlers should be stored in a map[string][]handler slice. Add unique IDs to subscriptions for unsubscribe support. Keep it simple - no channels or async dispatch for now, synchronous dispatch is fine.",
+      "files": [
+        "internal/event/bus.go"
+      ],
+      "depends_on": [
+        "task-1"
+      ],
+      "priority": 16,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/178"
+    },
+    {
+      "id": "task-17",
+      "title": "Extract output capture to capture subpackage",
+      "description": "Create internal/instance/capture/output.go with the OutputCapture interface and TmuxCapture implementation. Extract the tmux output polling logic from Manager in instance/manager.go - specifically the readOutput, readTmuxPane methods and related constants. Define interface: OutputCapture with ReadOutput() ([]byte, error), Start(), Stop(), Clear(). TmuxCapture implements this using tmux capture-pane. This should NOT include state detection - only raw output capture.",
+      "files": [
+        "internal/instance/capture/output.go"
+      ],
+      "depends_on": [
+        "task-2"
+      ],
+      "priority": 17,
+      "est_complexity": "medium",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/179"
+    },
+    {
+      "id": "task-18",
+      "title": "Add state and timeout detection tests",
+      "description": "Create internal/instance/detect/state_test.go and internal/instance/detect/timeout_test.go. For state detection: test each WaitingState regex with sample outputs from Claude (permission prompts, question prompts, input waiting, errors, PR opened). For timeout: test each timeout type triggers correctly based on time deltas and states.",
+      "files": [
+        "internal/instance/detect/state_test.go",
+        "internal/instance/detect/timeout_test.go"
+      ],
+      "depends_on": [
+        "task-3",
+        "task-4"
+      ],
+      "priority": 18,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/180"
+    },
+    {
+      "id": "task-19",
+      "title": "Add metrics parser tests",
+      "description": "Create internal/instance/metrics/parser_test.go. Test parsing of various Claude output formats with token counts and costs. Include edge cases: missing fields, malformed output, partial metrics. Use real-world examples from Claude output.",
+      "files": [
+        "internal/instance/metrics/parser_test.go"
+      ],
+      "depends_on": [
+        "task-5"
+      ],
+      "priority": 19,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/181"
+    },
+    {
+      "id": "task-20",
+      "title": "Implement tmux process manager",
+      "description": "Create internal/instance/process/tmux.go implementing the Process interface using tmux. Extract tmux session creation, process spawning, and lifecycle management from internal/instance/manager.go. TmuxProcess struct implements Process. Methods handle: creating tmux session, running claude command, sending keys, capturing exit. Keep only process lifecycle here - no output capture or state detection.",
+      "files": [
+        "internal/instance/process/tmux.go"
+      ],
+      "depends_on": [
+        "task-6"
+      ],
+      "priority": 20,
+      "est_complexity": "medium",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/182"
+    },
+    {
+      "id": "task-21",
+      "title": "Extract plan validation logic",
+      "description": "Create internal/ultraplan/validation.go. Extract plan validation from orchestrator/planeditor.go. Implement: ValidatePlan(spec *PlanSpec) (*ValidationResult, error), ValidateTaskDependencies(tasks []TaskSpec) error, ValidateTaskFiles(tasks []TaskSpec) error. Check for: circular dependencies, missing dependencies, file conflicts between tasks. Keep validation stateless and testable.",
+      "files": [
+        "internal/ultraplan/validation.go"
+      ],
+      "depends_on": [
+        "task-7"
+      ],
+      "priority": 21,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/183"
+    },
+    {
+      "id": "task-22",
+      "title": "Define execution interface",
+      "description": "Create internal/ultraplan/executor/interface.go. Define interfaces for execution coordination. TaskExecutor interface: Execute(ctx context.Context, task *TaskSpec) error, GetStatus() ExecutionStatus. ExecutionCoordinator interface: Start(plan *PlanSpec) error, Stop() error, GetProgress() ExecutionProgress. ExecutionProgress struct with: TotalTasks, CompletedTasks, RunningTasks, FailedTasks, TaskStatuses map.",
+      "files": [
+        "internal/ultraplan/executor/interface.go"
+      ],
+      "depends_on": [
+        "task-7"
+      ],
+      "priority": 22,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/184"
+    },
+    {
+      "id": "task-23",
+      "title": "Refactor TUI app to use view components",
+      "description": "Refactor internal/tui/app.go to use the extracted view components. Replace inline View() rendering with calls to view subpackage components. App.go View() becomes a dispatcher that selects the appropriate view based on current mode. This should significantly reduce app.go size (from 3,100 LOC).",
+      "files": [
+        "internal/tui/app.go"
+      ],
+      "depends_on": [
+        "task-9",
+        "task-10",
+        "task-11",
+        "task-12",
+        "task-13",
+        "task-14"
+      ],
+      "priority": 23,
+      "est_complexity": "medium",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/185"
+    },
+    {
+      "id": "task-24",
+      "title": "Add config validation tests",
+      "description": "Create internal/config/validator_test.go. Test: valid configs pass, invalid timeouts caught, invalid buffer sizes caught, invalid branch prefixes caught. Use table-driven tests. Test edge cases: zero values, negative values, empty strings where required.",
+      "files": [
+        "internal/config/validator_test.go"
+      ],
+      "depends_on": [
+        "task-15"
+      ],
+      "priority": 24,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/186"
+    },
+    {
+      "id": "task-25",
+      "title": "Add event bus tests",
+      "description": "Create internal/event/bus_test.go with comprehensive tests for the event bus. Test: basic publish/subscribe, multiple subscribers to same event, unsubscribe functionality, thread safety with concurrent publish/subscribe, publishing to event with no subscribers (should not panic).",
+      "files": [
+        "internal/event/bus_test.go"
+      ],
+      "depends_on": [
+        "task-16"
+      ],
+      "priority": 25,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/187"
+    },
+    {
+      "id": "task-26",
+      "title": "Refactor instance Manager to use subpackages",
+      "description": "Refactor internal/instance/manager.go to compose the extracted subpackages. Manager should now hold: process.Process, capture.OutputCapture, detect.StateDetector, detect.TimeoutDetector, metrics.MetricsParser. Remove the extracted code and replace with calls to subpackage interfaces. The Manager becomes a coordinator that wires together the subcomponents. Keep the public API identical.",
+      "files": [
+        "internal/instance/manager.go"
+      ],
+      "depends_on": [
+        "task-17",
+        "task-3",
+        "task-4",
+        "task-5",
+        "task-20"
+      ],
+      "priority": 26,
+      "est_complexity": "medium",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/188"
+    },
+    {
+      "id": "task-27",
+      "title": "Add plan validation tests",
+      "description": "Create internal/ultraplan/validation_test.go. Test: valid plans pass, circular dependencies detected, missing dependencies detected, file conflicts detected, empty plans handled. Use table-driven tests for comprehensive coverage.",
+      "files": [
+        "internal/ultraplan/validation_test.go"
+      ],
+      "depends_on": [
+        "task-21"
+      ],
+      "priority": 27,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/189"
+    },
+    {
+      "id": "task-28",
+      "title": "Extract UltraPlanManager to ultraplan package",
+      "description": "Create internal/ultraplan/manager.go. Move UltraPlanManager from orchestrator/ultraplan.go. Manager handles: plan lifecycle (create, load, save), phase transitions (planning, execution, consolidation), high-level orchestration. Should depend on event.Bus for publishing phase change events. Keep orchestrator integration minimal - manager should be mostly standalone.",
+      "files": [
+        "internal/ultraplan/manager.go"
+      ],
+      "depends_on": [
+        "task-7",
+        "task-16"
+      ],
+      "priority": 28,
+      "est_complexity": "medium",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/190"
+    },
+    {
+      "id": "task-29",
+      "title": "Extract planning phase logic",
+      "description": "Create internal/ultraplan/planner.go. Extract the planning phase from coordinator - the part that generates the task graph via Claude. Define Planner struct with Plan(ctx context.Context, objective string) (*PlanSpec, error). This handles: constructing the planning prompt, invoking Claude, parsing the JSON response, validating the result. Should use the validation from task-16.",
+      "files": [
+        "internal/ultraplan/planner.go"
+      ],
+      "depends_on": [
+        "task-21"
+      ],
+      "priority": 29,
+      "est_complexity": "medium",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/191"
+    },
+    {
+      "id": "task-30",
+      "title": "Implement execution coordinator",
+      "description": "Create internal/ultraplan/executor/coordinator.go. Extract execution coordination logic from orchestrator/coordinator.go. Implement ExecutionCoordinator interface. Handle: scheduling tasks respecting dependencies, managing parallel execution, tracking task completion, publishing progress events. This is the largest extraction - coordinator.go is 3,151 LOC. Focus on core scheduling/coordination, delegate instance management to orchestrator.",
+      "files": [
+        "internal/ultraplan/executor/coordinator.go"
+      ],
+      "depends_on": [
+        "task-22",
+        "task-16"
+      ],
+      "priority": 30,
+      "est_complexity": "high",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/192"
+    },
+    {
+      "id": "task-31",
+      "title": "Extract consolidation logic",
+      "description": "Create internal/ultraplan/consolidator.go. Move consolidation logic from orchestrator/consolidation.go (1,217 LOC). Consolidator handles: merging branches from completed tasks, conflict resolution strategy, creating final PR, cleanup. Define Consolidator struct with Consolidate(ctx context.Context, results []TaskResult) (*ConsolidationResult, error). Use event.Bus for progress updates.",
+      "files": [
+        "internal/ultraplan/consolidator.go"
+      ],
+      "depends_on": [
+        "task-7",
+        "task-16"
+      ],
+      "priority": 31,
+      "est_complexity": "medium",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/193"
+    },
+    {
+      "id": "task-32",
+      "title": "Extract instance lifecycle from orchestrator",
+      "description": "Create internal/orchestrator/lifecycle/manager.go. Extract instance lifecycle operations: AddInstance, RemoveInstance, StartInstance, StopInstance, PauseInstance, ResumeInstance. LifecycleManager coordinates with worktree.Manager and instance.Manager. Should publish events via event.Bus for instance state changes. Orchestrator will delegate to this.",
+      "files": [
+        "internal/orchestrator/lifecycle/manager.go"
+      ],
+      "depends_on": [
+        "task-16"
+      ],
+      "priority": 32,
+      "est_complexity": "medium",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/194"
+    },
+    {
+      "id": "task-33",
+      "title": "Remove deprecated instance files",
+      "description": "After task-13 is complete, remove the old files that have been replaced by subpackages: internal/instance/ringbuffer.go (moved to capture/), internal/instance/detector.go (moved to detect/), internal/instance/metrics.go and parser.go (moved to metrics/). Ensure no dangling imports. Run tests to verify nothing broke.",
+      "files": [
+        "internal/instance/ringbuffer.go",
+        "internal/instance/detector.go",
+        "internal/instance/metrics.go",
+        "internal/instance/parser.go"
+      ],
+      "depends_on": [
+        "task-26"
+      ],
+      "priority": 33,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/195"
+    },
+    {
+      "id": "task-34",
+      "title": "Add ultraplan package tests",
+      "description": "Create internal/ultraplan/manager_test.go, planner_test.go, consolidator_test.go. Test manager phase transitions, planner prompt generation and JSON parsing (with mock Claude responses), consolidator merge logic. Use interfaces to mock dependencies where possible.",
+      "files": [
+        "internal/ultraplan/manager_test.go",
+        "internal/ultraplan/planner_test.go",
+        "internal/ultraplan/consolidator_test.go"
+      ],
+      "depends_on": [
+        "task-28",
+        "task-29",
+        "task-31"
+      ],
+      "priority": 34,
+      "est_complexity": "medium",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/196"
+    },
+    {
+      "id": "task-35",
+      "title": "Refactor orchestrator to use subpackages",
+      "description": "Refactor internal/orchestrator/orchestrator.go to compose the extracted managers: session.SessionManager, lifecycle.LifecycleManager, and ultraplan.Manager. Orchestrator becomes a thin facade that delegates to these managers. Remove extracted code, replace with delegation. Keep public API identical for backwards compatibility. Wire up event.Bus for inter-component communication.",
+      "files": [
+        "internal/orchestrator/orchestrator.go"
+      ],
+      "depends_on": [
+        "task-8",
+        "task-32",
+        "task-28"
+      ],
+      "priority": 35,
+      "est_complexity": "medium",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/197"
+    },
+    {
+      "id": "task-36",
+      "title": "Remove deprecated orchestrator files",
+      "description": "After task-26, remove or significantly reduce: orchestrator/ultraplan.go (moved to internal/ultraplan/), orchestrator/coordinator.go (moved to internal/ultraplan/executor/), orchestrator/consolidation.go (moved to internal/ultraplan/), orchestrator/planeditor.go (validation moved). Update imports throughout codebase. Run tests to verify.",
+      "files": [
+        "internal/orchestrator/ultraplan.go",
+        "internal/orchestrator/coordinator.go",
+        "internal/orchestrator/consolidation.go",
+        "internal/orchestrator/planeditor.go"
+      ],
+      "depends_on": [
+        "task-35",
+        "task-30",
+        "task-31"
+      ],
+      "priority": 36,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/198"
+    },
+    {
+      "id": "task-37",
+      "title": "Integrate event bus into TUI",
+      "description": "Refactor internal/tui/app.go to use event.Bus instead of direct callbacks. Replace orchestrator callback registration (SetPRCompleteCallback, SetTimeoutCallback, SetBellCallback) with event.Bus subscriptions. Event handlers should send Bubbletea messages as before, but subscription is via bus. This decouples TUI from orchestrator callback interface.",
+      "files": [
+        "internal/tui/app.go"
+      ],
+      "depends_on": [
+        "task-16",
+        "task-35"
+      ],
+      "priority": 37,
+      "est_complexity": "medium",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/199"
+    },
+    {
+      "id": "task-38",
+      "title": "Update cmd package imports",
+      "description": "Update all files in internal/cmd/ to use new subpackage imports after refactoring. Update: start.go, add.go, stop.go, ultraplan.go, etc. to import from new locations (internal/ultraplan/, internal/orchestrator/session/, etc.). Ensure all commands still work correctly. Run full test suite.",
+      "files": [
+        "internal/cmd/start.go",
+        "internal/cmd/add.go",
+        "internal/cmd/stop.go",
+        "internal/cmd/ultraplan.go",
+        "internal/cmd/plan.go",
+        "internal/cmd/pr.go",
+        "internal/cmd/status.go",
+        "internal/cmd/sessions.go"
+      ],
+      "depends_on": [
+        "task-35",
+        "task-37"
+      ],
+      "priority": 38,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/200"
+    },
+    {
+      "id": "task-39",
+      "title": "Add integration tests for refactored packages",
+      "description": "Create internal/integration_test.go with integration tests that verify the refactored packages work together. Test: creating orchestrator with all subcomponents, starting/stopping instances, event bus communication between TUI and orchestrator. These tests ensure the refactoring didn't break the overall system.",
+      "files": [
+        "internal/integration_test.go"
+      ],
+      "depends_on": [
+        "task-38"
+      ],
+      "priority": 39,
+      "est_complexity": "medium",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/201"
+    },
+    {
+      "id": "task-40",
+      "title": "Update package documentation",
+      "description": "Add or update doc.go files for each new subpackage: internal/event/doc.go, internal/ultraplan/doc.go, internal/instance/capture/doc.go, internal/instance/detect/doc.go, internal/instance/metrics/doc.go, internal/instance/process/doc.go, internal/orchestrator/session/doc.go, internal/orchestrator/lifecycle/doc.go, internal/tui/view/doc.go. Each doc.go should explain the package's purpose and main types.",
+      "files": [
+        "internal/event/doc.go",
+        "internal/ultraplan/doc.go",
+        "internal/instance/capture/doc.go",
+        "internal/instance/detect/doc.go",
+        "internal/instance/metrics/doc.go",
+        "internal/instance/process/doc.go",
+        "internal/orchestrator/session/doc.go",
+        "internal/orchestrator/lifecycle/doc.go",
+        "internal/tui/view/doc.go"
+      ],
+      "depends_on": [
+        "task-39"
+      ],
+      "priority": 40,
+      "est_complexity": "low",
+      "issue_url": "https://github.com/Iron-Ham/claudio/issues/202"
+    }
+  ],
+  "dependency_graph": {
+    "task-1": [],
+    "task-2": [],
+    "task-3": [],
+    "task-4": [],
+    "task-5": [],
+    "task-6": [],
+    "task-7": [],
+    "task-8": [],
+    "task-9": [],
+    "task-10": [],
+    "task-11": [],
+    "task-12": [],
+    "task-13": [],
+    "task-14": [],
+    "task-15": [],
+    "task-16": [
+      "task-1"
+    ],
+    "task-17": [
+      "task-2"
+    ],
+    "task-18": [
+      "task-3",
+      "task-4"
+    ],
+    "task-19": [
+      "task-5"
+    ],
+    "task-20": [
+      "task-6"
+    ],
+    "task-21": [
+      "task-7"
+    ],
+    "task-22": [
+      "task-7"
+    ],
+    "task-23": [
+      "task-9",
+      "task-10",
+      "task-11",
+      "task-12",
+      "task-13",
+      "task-14"
+    ],
+    "task-24": [
+      "task-15"
+    ],
+    "task-25": [
+      "task-16"
+    ],
+    "task-26": [
+      "task-17",
+      "task-3",
+      "task-4",
+      "task-5",
+      "task-20"
+    ],
+    "task-27": [
+      "task-21"
+    ],
+    "task-28": [
+      "task-7",
+      "task-16"
+    ],
+    "task-29": [
+      "task-21"
+    ],
+    "task-30": [
+      "task-22",
+      "task-16"
+    ],
+    "task-31": [
+      "task-7",
+      "task-16"
+    ],
+    "task-32": [
+      "task-16"
+    ],
+    "task-33": [
+      "task-26"
+    ],
+    "task-34": [
+      "task-28",
+      "task-29",
+      "task-31"
+    ],
+    "task-35": [
+      "task-8",
+      "task-32",
+      "task-28"
+    ],
+    "task-36": [
+      "task-35",
+      "task-30",
+      "task-31"
+    ],
+    "task-37": [
+      "task-16",
+      "task-35"
+    ],
+    "task-38": [
+      "task-35",
+      "task-37"
+    ],
+    "task-39": [
+      "task-38"
+    ],
+    "task-40": [
+      "task-39"
+    ]
+  },
+  "execution_order": [
+    [
+      "task-1",
+      "task-2",
+      "task-3",
+      "task-4",
+      "task-5",
+      "task-6",
+      "task-7",
+      "task-8",
+      "task-9",
+      "task-10",
+      "task-11",
+      "task-12",
+      "task-13",
+      "task-14",
+      "task-15"
+    ],
+    [
+      "task-16",
+      "task-17",
+      "task-18",
+      "task-19",
+      "task-20",
+      "task-21",
+      "task-22",
+      "task-23",
+      "task-24"
+    ],
+    [
+      "task-25",
+      "task-26",
+      "task-27",
+      "task-28",
+      "task-29",
+      "task-30",
+      "task-31",
+      "task-32"
+    ],
+    [
+      "task-33",
+      "task-34",
+      "task-35"
+    ],
+    [
+      "task-36",
+      "task-37"
+    ],
+    [
+      "task-38"
+    ],
+    [
+      "task-39"
+    ],
+    [
+      "task-40"
+    ]
+  ],
+  "insights": [
+    "Ultra-Plan execution is the largest coupling issue: 9,882 LOC scattered across 5 files (orchestrator/ultraplan.go, orchestrator/coordinator.go at 3,151 LOC, orchestrator/consolidation.go at 1,217 LOC, tui/ultraplan.go at 2,821 LOC, orchestrator/planeditor.go)",
+    "TUI and Orchestrator have bidirectional dependencies via callbacks - TUI registers callbacks on Orchestrator which then send Bubbletea messages back to TUI, creating tight coupling",
+    "Instance Manager (1,000+ LOC) mixes orthogonal concerns: process lifecycle, output capture, state detection, metrics parsing, timeout detection, PR workflow",
+    "The codebase has good foundational architecture in logging (standalone, no dependencies), session management (clean file-based locking), and worktree isolation",
+    "23 test files exist showing testing discipline, but tight coupling limits testability - many components cannot be tested in isolation",
+    "Configuration system is well-designed with Viper but lacks validation logic at load time",
+    "orchestrator/coordinator.go at 3,151 LOC is the single largest file and handles too many responsibilities",
+    "The callback pattern is used extensively but creates implicit dependencies that are hard to trace and test"
+  ],
+  "constraints": [
+    "Public APIs must remain backwards compatible during refactoring - internal restructuring should not change how cmd/ uses orchestrator or TUI",
+    "File ownership must be carefully assigned - orchestrator/coordinator.go touches many files and its extraction must be done carefully to avoid conflicts",
+    "Event bus introduction requires careful ordering - must be done before components can use it, but component refactoring depends on it",
+    "The TUI event integration (task-28) is a critical path item that touches app.go and requires orchestrator refactoring first",
+    "Ultraplan extraction is complex due to tight integration with orchestrator instance management - executor must coordinate with orchestrator for actual instance spawning",
+    "Test coverage must be maintained or improved - each extraction should include corresponding test file moves/updates",
+    "Some tasks marked as high complexity (task-21) may need further decomposition during implementation if they prove too large",
+    "Git worktree operations in consolidation are sensitive - consolidator extraction must preserve exact git behavior"
+  ],
+  "created_at": "2026-01-10T08:56:17Z"
+}


### PR DESCRIPTION
## Summary

- Add `issue_url` field to `PlannedTask` schema for provider-agnostic issue tracking
- Create `internal/issue` package with provider detection and closing logic
- Hook issue closing into `MarkTaskComplete` (async, non-blocking with 30s timeout)
- Include `refactor-plan.json` with 40 tasks linked to GitHub issues #163-#202

## Supported Providers

| Provider | CLI | Status |
|----------|-----|--------|
| GitHub | `gh` | ✅ Fully working |
| Linear | `linear` | ✅ Works if CLI installed |
| Notion | API | 🔜 Placeholder (needs API integration) |

## Design Decisions

- **URL-based dispatch**: Provider detected from hostname (`github.com`, `linear.app`, `notion.so`)
- **Async closing**: Runs in goroutine to avoid blocking task completion
- **Graceful degradation**: Unknown providers and missing CLIs log warnings instead of failing

## Test plan

- [x] Unit tests for provider detection and URL parsing
- [x] Full test suite passes
- [ ] Manual test: run ultraplan with linked issues and verify they close