### PR TITLE
feat(tui): add :exit command and improve session management

### DIFF
--- a/internal/tui/command_test.go
+++ b/internal/tui/command_test.go
@@ -506,6 +506,7 @@ func TestCommandAliasesRequiringInstance(t *testing.T) {
 		// Instance control
 		"s", "start",
 		"x", "stop",
+		"e", "exit",
 		"p", "pause",
 		"R", "reconnect",
 		"restart",


### PR DESCRIPTION
## Summary

- Disables auto-removal of instances when a PR URL is detected in output, allowing users to continue using the instance for review tools or other post-PR actions
- Adds new `:exit` / `:e` command that stops an instance without triggering the auto-PR workflow (`:stop` / `:x` will still trigger auto-PR if configured)
- Reorganizes help panel documentation into clear categories (Instance, View, Session commands) with descriptions explaining what each command does

## Test plan

- [ ] Run `go test ./internal/tui/... -run Command` to verify command tests pass
- [ ] Start a session and verify `:h` shows the new documentation format with `:exit` command
- [ ] Test `:exit` stops an instance without triggering PR workflow
- [ ] Test `:stop` still triggers auto-PR workflow when configured
- [ ] Verify PR detection shows notification instead of auto-removing instance