### PR TITLE
feat: integrate event bus into TUI for decoupled communication

### DIFF
--- a/internal/event/types.go
+++ b/internal/event/types.go
@@ -263,3 +263,43 @@ func NewMetricsUpdateEvent(instanceID string, inputTokens, outputTokens, cacheRe
 func (e MetricsUpdateEvent) TotalTokens() int64 {
 	return e.InputTokens + e.OutputTokens
 }
+
+// -----------------------------------------------------------------------------
+// Bell Events (Terminal Notification)
+// -----------------------------------------------------------------------------
+
+// BellEvent is emitted when a terminal bell is detected in an instance.
+// Used to forward audio notifications from tmux sessions to the parent terminal.
+type BellEvent struct {
+	baseEvent
+	InstanceID string // Instance that triggered the bell
+}
+
+// NewBellEvent creates a BellEvent.
+func NewBellEvent(instanceID string) BellEvent {
+	return BellEvent{
+		baseEvent:  newBaseEvent("instance.bell"),
+		InstanceID: instanceID,
+	}
+}
+
+// -----------------------------------------------------------------------------
+// PR Opened Events (Inline PR Detection)
+// -----------------------------------------------------------------------------
+
+// PROpenedEvent is emitted when a PR URL is detected in instance output.
+// This indicates an inline PR was created during task execution (via gh pr create).
+type PROpenedEvent struct {
+	baseEvent
+	InstanceID string // Instance that opened the PR
+	PRURL      string // Reserved for future use - currently not populated
+}
+
+// NewPROpenedEvent creates a PROpenedEvent.
+func NewPROpenedEvent(instanceID string, prURL string) PROpenedEvent {
+	return PROpenedEvent{
+		baseEvent:  newBaseEvent("pr.opened"),
+		InstanceID: instanceID,
+		PRURL:      prURL,
+	}
+}


### PR DESCRIPTION
## Summary

- Replace direct callback-based communication between orchestrator and TUI with event bus pub-sub pattern
- Add new event types (`BellEvent`, `PROpenedEvent`) to the event package
- Publish events from orchestrator handlers while maintaining callback fallback for backwards compatibility
- Subscribe to events in TUI using proper subscription tracking for cleanup

## Benefits

- **Loose coupling**: Components communicate through events rather than direct callbacks
- **Multiple subscribers**: Any number of components can subscribe to the same events
- **Runtime flexibility**: Subscriptions can be added/removed at runtime
- **Clean cleanup**: Subscription IDs are tracked for proper unsubscription on exit

## Changes

### `internal/event/types.go`
- Add `BellEvent` for terminal bell notifications
- Add `PROpenedEvent` for inline PR detection

### `internal/orchestrator/orchestrator.go`
- Publish events in handler functions (`handlePRWorkflowComplete`, `handleInstancePROpened`, `handleInstanceTimeout`, `handleInstanceBell`)
- Maintain callback invocation for backwards compatibility
- Add default case with logging for unknown timeout types

### `internal/tui/app.go`
- Replace callback setup with event bus subscriptions
- Track subscription IDs for proper cleanup
- Unsubscribe individual handlers on exit instead of clearing entire bus

## Test plan

- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./internal/event/... ./internal/tui/... ./internal/orchestrator/...`)
- [x] Linter passes (`golangci-lint run ./...`)
- [x] PR Review Toolkit analysis completed with fixes applied

Closes #198, closes #199, closes #207