### PR TITLE
refactor(cmd): update imports to use orchestrator/session subpackage

### DIFF
--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Iron-Ham/claudio/internal/config"
 	"github.com/Iron-Ham/claudio/internal/logging"
 	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	orchsession "github.com/Iron-Ham/claudio/internal/orchestrator/session"
 	"github.com/Iron-Ham/claudio/internal/session"
 	"github.com/Iron-Ham/claudio/internal/tui"
 	"github.com/spf13/cobra"
@@ -168,7 +169,7 @@ func attachToSession(cwd, sessionID string, cfg *config.Config) error {
 // startNewSession creates and starts a new session
 func startNewSession(cwd, sessionName string, cfg *config.Config) error {
 	// Generate a new session ID
-	sessionID := orchestrator.GenerateID()
+	sessionID := orchsession.GenerateID()
 
 	// Create logger if enabled - we need session dir which requires session ID
 	sessionDir := session.GetSessionDir(cwd, sessionID)
@@ -214,7 +215,7 @@ func migrateAndStartLegacySession(cwd, sessionName string, cfg *config.Config) e
 	// Use the existing session ID or generate a new one
 	sessionID := legacySession.ID
 	if sessionID == "" {
-		sessionID = orchestrator.GenerateID()
+		sessionID = orchsession.GenerateID()
 	}
 
 	// Create the new session directory

--- a/internal/cmd/ultraplan.go
+++ b/internal/cmd/ultraplan.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Iron-Ham/claudio/internal/config"
 	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	orchsession "github.com/Iron-Ham/claudio/internal/orchestrator/session"
 	sessutil "github.com/Iron-Ham/claudio/internal/session"
 	"github.com/Iron-Ham/claudio/internal/tui"
 	"github.com/spf13/cobra"
@@ -122,7 +123,7 @@ func runUltraplan(cmd *cobra.Command, args []string) error {
 	}
 
 	// Generate a new session ID for this ultraplan
-	sessionID := orchestrator.GenerateID()
+	sessionID := orchsession.GenerateID()
 	cfg := config.Get()
 
 	// Create ultra-plan configuration from defaults, then override with config file, then flags


### PR DESCRIPTION
## Summary

- Update `cmd/start.go` to import `GenerateID()` from `orchestrator/session` subpackage
- Update `cmd/ultraplan.go` to import `GenerateID()` from `orchestrator/session` subpackage
- Aligns with the orchestrator refactoring done in #197 to use subpackages

## Test plan

- [x] Build passes (`go build ./...`)
- [x] Lint passes (`golangci-lint run ./...`)
- [x] All tests pass (`go test ./...`)
- [x] PR review toolkit run (3 rounds - all issues addressed)

Closes #200
Closes #208