### PR TITLE
feat: add gofmt enforcement via test

### DIFF
--- a/internal/cmd/cleanup.go
+++ b/internal/cmd/cleanup.go
@@ -16,18 +16,18 @@ import (
 
 // CleanupResult holds information about resources to be cleaned up
 type CleanupResult struct {
-	StaleWorktrees     []StaleWorktree
-	StaleBranches      []string
-	OrphanedTmuxSess   []string
-	ActiveInstanceIDs  map[string]bool // IDs of instances in active session
+	StaleWorktrees    []StaleWorktree
+	StaleBranches     []string
+	OrphanedTmuxSess  []string
+	ActiveInstanceIDs map[string]bool // IDs of instances in active session
 }
 
 // StaleWorktree represents a worktree that may need cleanup
 type StaleWorktree struct {
-	Path              string
-	Branch            string
-	HasUncommitted    bool
-	ExistsOnRemote    bool
+	Path           string
+	Branch         string
+	HasUncommitted bool
+	ExistsOnRemote bool
 }
 
 var cleanupCmd = &cobra.Command{
@@ -45,11 +45,11 @@ Use --dry-run to see what would be cleaned up without making changes.`,
 }
 
 var (
-	cleanupDryRun     bool
-	cleanupForce      bool
-	cleanupWorktrees  bool
-	cleanupBranches   bool
-	cleanupTmux       bool
+	cleanupDryRun    bool
+	cleanupForce     bool
+	cleanupWorktrees bool
+	cleanupBranches  bool
+	cleanupTmux      bool
 )
 
 func init() {

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -68,12 +68,12 @@ func init() {
 
 // logEntry represents a parsed JSON log line
 type logEntry struct {
-	Time       time.Time              `json:"time"`
-	Level      string                 `json:"level"`
-	Msg        string                 `json:"msg"`
-	SessionID  string                 `json:"session_id,omitempty"`
-	InstanceID string                 `json:"instance_id,omitempty"`
-	Phase      string                 `json:"phase,omitempty"`
+	Time       time.Time      `json:"time"`
+	Level      string         `json:"level"`
+	Msg        string         `json:"msg"`
+	SessionID  string         `json:"session_id,omitempty"`
+	InstanceID string         `json:"instance_id,omitempty"`
+	Phase      string         `json:"phase,omitempty"`
 	Extra      map[string]any `json:"-"` // Captures additional fields
 }
 

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -32,8 +32,8 @@ Multiple Claudio sessions can run simultaneously in different terminal windows.`
 }
 
 var (
-	forceNew       bool
-	attachSession  string // --session flag to attach to specific session
+	forceNew      bool
+	attachSession string // --session flag to attach to specific session
 )
 
 func init() {

--- a/internal/cmd/stats.go
+++ b/internal/cmd/stats.go
@@ -124,12 +124,12 @@ func printStatsText(session *orchestrator.Session, metrics *orchestrator.Session
 
 	// Sort instances by cost
 	type instData struct {
-		num     int
-		id      string
-		task    string
-		cost    float64
-		tokens  int64
-		status  string
+		num    int
+		id     string
+		task   string
+		cost   float64
+		tokens int64
+		status string
 	}
 	var instances []instData
 	for i, inst := range session.Instances {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -204,10 +204,10 @@ func Default() *Config {
 			KeepRemoteBranches: true,
 		},
 		Resources: ResourceConfig{
-			CostWarningThreshold:  5.00,  // Warn at $5
-			CostLimit:             0,     // No limit by default
-			TokenLimitPerInstance: 0,     // No limit by default
-			ShowMetricsInSidebar:  true,  // Show metrics by default
+			CostWarningThreshold:  5.00, // Warn at $5
+			CostLimit:             0,    // No limit by default
+			TokenLimitPerInstance: 0,    // No limit by default
+			ShowMetricsInSidebar:  true, // Show metrics by default
 		},
 		Ultraplan: UltraplanConfig{
 			MaxParallel: 3,

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -221,11 +221,11 @@ func TestConfig_Validate_Instance(t *testing.T) {
 			expectError   bool
 			field         string
 		}{
-			{79, 50, true, "instance.tmux_width"},   // width too small
-			{501, 50, true, "instance.tmux_width"},  // width too large
-			{200, 23, true, "instance.tmux_height"}, // height too small
+			{79, 50, true, "instance.tmux_width"},    // width too small
+			{501, 50, true, "instance.tmux_width"},   // width too large
+			{200, 23, true, "instance.tmux_height"},  // height too small
 			{200, 201, true, "instance.tmux_height"}, // height too large
-			{200, 50, false, ""},                    // valid
+			{200, 50, false, ""},                     // valid
 		}
 
 		for _, tt := range tests {
@@ -287,10 +287,10 @@ func TestConfig_Validate_Instance(t *testing.T) {
 
 func TestConfig_Validate_Branch(t *testing.T) {
 	tests := []struct {
-		name      string
-		prefix    string
-		hasError  bool
-		errorMsg  string
+		name     string
+		prefix   string
+		hasError bool
+		errorMsg string
 	}{
 		{"valid simple", "claudio", false, ""},
 		{"valid with hyphen", "Iron-Ham", false, ""},

--- a/internal/event/types.go
+++ b/internal/event/types.go
@@ -23,7 +23,7 @@ type baseEvent struct {
 	timestamp time.Time
 }
 
-func (e baseEvent) EventType() string  { return e.eventType }
+func (e baseEvent) EventType() string    { return e.eventType }
 func (e baseEvent) Timestamp() time.Time { return e.timestamp }
 
 // newBaseEvent creates a baseEvent with the current time.

--- a/internal/gofmt_test.go
+++ b/internal/gofmt_test.go
@@ -1,0 +1,91 @@
+package internal
+
+import (
+	"bytes"
+	"go/format"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestGofmtCompliance verifies that all Go source files in the project
+// are properly formatted according to gofmt standards.
+//
+// This test exists to catch formatting issues before code is committed.
+// If this test fails, run: gofmt -w ./internal/ ./cmd/
+func TestGofmtCompliance(t *testing.T) {
+	// Get the project root (parent of internal/)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+
+	// Navigate to project root from internal/
+	projectRoot := filepath.Dir(wd)
+	if filepath.Base(wd) != "internal" {
+		// We might be running from project root
+		projectRoot = wd
+	}
+
+	dirsToCheck := []string{
+		filepath.Join(projectRoot, "internal"),
+		filepath.Join(projectRoot, "cmd"),
+	}
+
+	var unformattedFiles []string
+
+	for _, dir := range dirsToCheck {
+		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			// Skip directories
+			if info.IsDir() {
+				// Skip vendor and hidden directories
+				if info.Name() == "vendor" || strings.HasPrefix(info.Name(), ".") {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+
+			// Only check .go files
+			if !strings.HasSuffix(path, ".go") {
+				return nil
+			}
+
+			// Read the file
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+
+			// Format the content
+			formatted, err := format.Source(content)
+			if err != nil {
+				// Skip files that don't parse (might be generated or have build tags)
+				return nil
+			}
+
+			// Compare
+			if !bytes.Equal(content, formatted) {
+				relPath, _ := filepath.Rel(projectRoot, path)
+				unformattedFiles = append(unformattedFiles, relPath)
+			}
+
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("Failed to walk directory %s: %v", dir, err)
+		}
+	}
+
+	if len(unformattedFiles) > 0 {
+		t.Errorf("The following files are not properly formatted:\n")
+		for _, f := range unformattedFiles {
+			t.Errorf("  - %s\n", f)
+		}
+		t.Errorf("\nRun 'gofmt -w ./internal/ ./cmd/' to fix formatting issues.")
+	}
+}

--- a/internal/instance/detect/state.go
+++ b/internal/instance/detect/state.go
@@ -100,12 +100,12 @@ var (
 		`(?i)do you want (?:me )?to (?:proceed|continue|run|execute|apply|make)`,
 		`(?i)(?:shall|should|can|may) I (?:proceed|continue|go ahead|run|execute|apply)`,
 		`(?i)(?:allow|permit|approve) (?:this|the) (?:action|change|operation)`,
-		`(?i)\[Y(?:es)?/[Nn](?:o)?\]`,                                     // [Y/N] or [Yes/No] prompts
-		`(?i)\(y(?:es)?/n(?:o)?\)`,                                        // (y/n) or (yes/no) prompts
-		`(?i)press (?:y|enter) to (?:confirm|continue|proceed|approve)`,   // Press y to confirm
-		`(?i)type ['"]?(?:yes|y)['"]? to (?:confirm|continue|proceed)`,    // Type yes to confirm
-		`(?i)waiting for (?:your )?(?:approval|confirmation|permission)`,  // Explicit waiting
-		`(?i)requires? (?:your )?(?:approval|confirmation|permission)`,    // Requires permission
+		`(?i)\[Y(?:es)?/[Nn](?:o)?\]`,                                    // [Y/N] or [Yes/No] prompts
+		`(?i)\(y(?:es)?/n(?:o)?\)`,                                       // (y/n) or (yes/no) prompts
+		`(?i)press (?:y|enter) to (?:confirm|continue|proceed|approve)`,  // Press y to confirm
+		`(?i)type ['"]?(?:yes|y)['"]? to (?:confirm|continue|proceed)`,   // Type yes to confirm
+		`(?i)waiting for (?:your )?(?:approval|confirmation|permission)`, // Explicit waiting
+		`(?i)requires? (?:your )?(?:approval|confirmation|permission)`,   // Requires permission
 	}
 
 	// QuestionPatterns detect Claude asking for information or clarification.
@@ -127,10 +127,10 @@ var (
 	// These are specific to Claude Code's terminal interface.
 	InputWaitingPatterns = []string{
 		// Claude Code prompt mode indicators (shown in status bar)
-		`⏵⏵\s*bypass permissions`,           // Bypass mode indicator
-		`⏵\s*(?:allow|approve|bypass)`,       // Single arrow prompt indicators
-		`↵\s*send`,                           // Send indicator at end of input line
-		`\(shift\+tab to cycle\)`,            // Mode cycling hint
+		`⏵⏵\s*bypass permissions`,      // Bypass mode indicator
+		`⏵\s*(?:allow|approve|bypass)`, // Single arrow prompt indicators
+		`↵\s*send`,                     // Send indicator at end of input line
+		`\(shift\+tab to cycle\)`,      // Mode cycling hint
 		// Input prompt line pattern (> followed by text and send indicator)
 		`>\s+.*↵`,
 	}

--- a/internal/instance/detect/timeout_test.go
+++ b/internal/instance/detect/timeout_test.go
@@ -48,7 +48,7 @@ func TestTimeoutDetector_CheckTimeout_NoTimeout(t *testing.T) {
 	detector := NewTimeoutDetector(cfg)
 
 	now := time.Now()
-	startTime := now.Add(-10 * time.Minute) // Started 10 minutes ago
+	startTime := now.Add(-10 * time.Minute)   // Started 10 minutes ago
 	lastActivity := now.Add(-1 * time.Minute) // Activity 1 minute ago
 
 	input := CheckInput{
@@ -98,7 +98,7 @@ func TestTimeoutDetector_CheckTimeout_ActivityTimeout(t *testing.T) {
 	detector := NewTimeoutDetector(cfg)
 
 	now := time.Now()
-	startTime := now.Add(-45 * time.Minute)   // Started 45 min ago (within 2h)
+	startTime := now.Add(-45 * time.Minute)    // Started 45 min ago (within 2h)
 	lastActivity := now.Add(-35 * time.Minute) // No activity for 35 min (exceeds 30m)
 
 	input := CheckInput{

--- a/internal/instance/facade_test.go
+++ b/internal/instance/facade_test.go
@@ -14,16 +14,16 @@ import (
 
 // mockProcess implements the process.Process interface for testing.
 type mockProcess struct {
-	running       bool
-	startError    error
-	stopError     error
-	sendError     error
-	waitError     error
-	output        []byte
-	mu            sync.Mutex
-	startCalled   bool
-	stopCalled    bool
-	sendInputs    []string
+	running     bool
+	startError  error
+	stopError   error
+	sendError   error
+	waitError   error
+	output      []byte
+	mu          sync.Mutex
+	startCalled bool
+	stopCalled  bool
+	sendInputs  []string
 }
 
 func newMockProcess() *mockProcess {

--- a/internal/instance/manager.go
+++ b/internal/instance/manager.go
@@ -64,8 +64,8 @@ func DefaultManagerConfig() ManagerConfig {
 		OutputBufferSize:         100000, // 100KB
 		CaptureIntervalMs:        100,
 		TmuxWidth:                200,
-		TmuxHeight:               30, // Shorter height so prompts scroll off and users see actual work
-		ActivityTimeoutMinutes:   30, // 30 minutes of no activity
+		TmuxHeight:               30,  // Shorter height so prompts scroll off and users see actual work
+		ActivityTimeoutMinutes:   30,  // 30 minutes of no activity
 		CompletionTimeoutMinutes: 120, // 2 hours max runtime
 		StaleDetection:           true,
 	}
@@ -101,12 +101,12 @@ type Manager struct {
 	startTime       *time.Time
 
 	// Timeout tracking
-	lastActivityTime    time.Time      // Last time output changed
-	lastOutputHash      string         // Hash of last output for change detection
-	repeatedOutputCount int            // Count of consecutive identical outputs (for stale detection)
+	lastActivityTime    time.Time // Last time output changed
+	lastOutputHash      string    // Hash of last output for change detection
+	repeatedOutputCount int       // Count of consecutive identical outputs (for stale detection)
 	timeoutCallback     TimeoutCallback
-	timedOut            bool           // Whether a timeout has been triggered
-	timeoutType         TimeoutType    // Type of timeout that was triggered
+	timedOut            bool        // Whether a timeout has been triggered
+	timeoutType         TimeoutType // Type of timeout that was triggered
 
 	// Bell tracking
 	bellCallback  BellCallback
@@ -260,9 +260,9 @@ func (m *Manager) Start() error {
 	// Create a new detached tmux session with color support
 	createCmd := exec.Command("tmux",
 		"new-session",
-		"-d",                                      // detached
-		"-s", m.sessionName,                       // session name
-		"-x", fmt.Sprintf("%d", m.config.TmuxWidth),  // width
+		"-d",                // detached
+		"-s", m.sessionName, // session name
+		"-x", fmt.Sprintf("%d", m.config.TmuxWidth), // width
 		"-y", fmt.Sprintf("%d", m.config.TmuxHeight), // height
 	)
 	createCmd.Dir = m.workdir

--- a/internal/instance/prworkflow.go
+++ b/internal/instance/prworkflow.go
@@ -13,11 +13,11 @@ import (
 
 // PRWorkflowConfig holds configuration for the PR workflow
 type PRWorkflowConfig struct {
-	UseAI       bool
-	Draft       bool
-	AutoRebase  bool
-	TmuxWidth   int
-	TmuxHeight  int
+	UseAI      bool
+	Draft      bool
+	AutoRebase bool
+	TmuxWidth  int
+	TmuxHeight int
 }
 
 // PRWorkflowCallback is called when the PR workflow completes

--- a/internal/logging/aggregate.go
+++ b/internal/logging/aggregate.go
@@ -17,12 +17,12 @@ import (
 
 // LogEntry represents a parsed log entry with all structured fields.
 type LogEntry struct {
-	Timestamp  time.Time              `json:"time"`
-	Level      string                 `json:"level"`
-	Message    string                 `json:"msg"`
-	SessionID  string                 `json:"session_id,omitempty"`
-	InstanceID string                 `json:"instance_id,omitempty"`
-	Phase      string                 `json:"phase,omitempty"`
+	Timestamp  time.Time      `json:"time"`
+	Level      string         `json:"level"`
+	Message    string         `json:"msg"`
+	SessionID  string         `json:"session_id,omitempty"`
+	InstanceID string         `json:"instance_id,omitempty"`
+	Phase      string         `json:"phase,omitempty"`
 	Attrs      map[string]any `json:"attrs,omitempty"`
 }
 

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -26,10 +26,10 @@ const (
 // It is safe for concurrent use.
 type Logger struct {
 	logger   *slog.Logger
-	file     *os.File           // For backward compatibility when not using rotation
-	rotation *RotatingWriter    // Used when rotation is enabled
-	mu       sync.Mutex         // Protects file operations
-	attrs    []slog.Attr        // Persistent attributes (session, instance, phase)
+	file     *os.File        // For backward compatibility when not using rotation
+	rotation *RotatingWriter // Used when rotation is enabled
+	mu       sync.Mutex      // Protects file operations
+	attrs    []slog.Attr     // Persistent attributes (session, instance, phase)
 }
 
 // NewLogger creates a new Logger that writes JSON-formatted logs to a file

--- a/internal/orchestrator/consolidation.go
+++ b/internal/orchestrator/consolidation.go
@@ -27,43 +27,43 @@ const (
 type ConsolidationPhase string
 
 const (
-	ConsolidationIdle            ConsolidationPhase = "idle"
-	ConsolidationDetecting       ConsolidationPhase = "detecting_conflicts"
+	ConsolidationIdle             ConsolidationPhase = "idle"
+	ConsolidationDetecting        ConsolidationPhase = "detecting_conflicts"
 	ConsolidationCreatingBranches ConsolidationPhase = "creating_branches"
-	ConsolidationMergingTasks    ConsolidationPhase = "merging_tasks"
-	ConsolidationPushing         ConsolidationPhase = "pushing"
-	ConsolidationCreatingPRs     ConsolidationPhase = "creating_prs"
-	ConsolidationPaused          ConsolidationPhase = "paused"
-	ConsolidationComplete        ConsolidationPhase = "complete"
-	ConsolidationFailed          ConsolidationPhase = "failed"
+	ConsolidationMergingTasks     ConsolidationPhase = "merging_tasks"
+	ConsolidationPushing          ConsolidationPhase = "pushing"
+	ConsolidationCreatingPRs      ConsolidationPhase = "creating_prs"
+	ConsolidationPaused           ConsolidationPhase = "paused"
+	ConsolidationComplete         ConsolidationPhase = "complete"
+	ConsolidationFailed           ConsolidationPhase = "failed"
 )
 
 // ConsolidationState tracks the progress of consolidation
 type ConsolidationState struct {
-	Phase             ConsolidationPhase `json:"phase"`
-	CurrentGroup      int                `json:"current_group"`
-	TotalGroups       int                `json:"total_groups"`
-	CurrentTask       string             `json:"current_task,omitempty"`
-	GroupBranches     []string           `json:"group_branches"`
-	PRUrls            []string           `json:"pr_urls"`
-	ConflictFiles     []string           `json:"conflict_files,omitempty"`
-	ConflictTaskID    string             `json:"conflict_task_id,omitempty"`
-	ConflictWorktree  string             `json:"conflict_worktree,omitempty"`
-	Error             string             `json:"error,omitempty"`
-	StartedAt         *time.Time         `json:"started_at,omitempty"`
-	CompletedAt       *time.Time         `json:"completed_at,omitempty"`
+	Phase            ConsolidationPhase `json:"phase"`
+	CurrentGroup     int                `json:"current_group"`
+	TotalGroups      int                `json:"total_groups"`
+	CurrentTask      string             `json:"current_task,omitempty"`
+	GroupBranches    []string           `json:"group_branches"`
+	PRUrls           []string           `json:"pr_urls"`
+	ConflictFiles    []string           `json:"conflict_files,omitempty"`
+	ConflictTaskID   string             `json:"conflict_task_id,omitempty"`
+	ConflictWorktree string             `json:"conflict_worktree,omitempty"`
+	Error            string             `json:"error,omitempty"`
+	StartedAt        *time.Time         `json:"started_at,omitempty"`
+	CompletedAt      *time.Time         `json:"completed_at,omitempty"`
 }
 
 // GroupConsolidationResult holds the result of consolidating one group
 type GroupConsolidationResult struct {
-	GroupIndex    int      `json:"group_index"`
-	TaskIDs       []string `json:"task_ids"`
-	BranchName    string   `json:"branch_name"`
-	CommitCount   int      `json:"commit_count"`
-	FilesChanged  []string `json:"files_changed"`
-	PRUrl         string   `json:"pr_url,omitempty"`
-	Success       bool     `json:"success"`
-	Error         string   `json:"error,omitempty"`
+	GroupIndex   int      `json:"group_index"`
+	TaskIDs      []string `json:"task_ids"`
+	BranchName   string   `json:"branch_name"`
+	CommitCount  int      `json:"commit_count"`
+	FilesChanged []string `json:"files_changed"`
+	PRUrl        string   `json:"pr_url,omitempty"`
+	Success      bool     `json:"success"`
+	Error        string   `json:"error,omitempty"`
 }
 
 // ConsolidationConfig holds configuration for branch consolidation
@@ -1085,10 +1085,10 @@ func (e *ConflictError) Error() string {
 // and aggregates the context for use in consolidation prompts and PR descriptions
 func (c *Consolidator) gatherTaskCompletionContext(taskIDs []string) *AggregatedTaskContext {
 	context := &AggregatedTaskContext{
-		TaskSummaries: make(map[string]string),
-		AllIssues:     make([]string, 0),
+		TaskSummaries:  make(map[string]string),
+		AllIssues:      make([]string, 0),
 		AllSuggestions: make([]string, 0),
-		Dependencies:  make([]string, 0),
+		Dependencies:   make([]string, 0),
 	}
 
 	seenDeps := make(map[string]bool)

--- a/internal/orchestrator/coordinator.go
+++ b/internal/orchestrator/coordinator.go
@@ -54,8 +54,8 @@ type Coordinator struct {
 	mu         sync.RWMutex
 
 	// Task tracking
-	runningTasks   map[string]string // taskID -> instanceID
-	runningCount   int
+	runningTasks map[string]string // taskID -> instanceID
+	runningCount int
 }
 
 // NewCoordinator creates a new coordinator for an ultra-plan session.
@@ -578,7 +578,6 @@ func (c *Coordinator) buildPlanComparisonSection() string {
 
 	return sb.String()
 }
-
 
 // SetPlan sets the plan for this ultra-plan session (used after planning completes)
 func (c *Coordinator) SetPlan(plan *PlanSpec) error {
@@ -1814,7 +1813,6 @@ func (c *Coordinator) TriggerConsolidation() error {
 	c.onSynthesisComplete()
 	return nil
 }
-
 
 // StartConsolidation begins the consolidation phase
 // This creates a Claude instance that performs branch consolidation and PR creation

--- a/internal/orchestrator/coordinator_test.go
+++ b/internal/orchestrator/coordinator_test.go
@@ -31,10 +31,10 @@ func TestGetMultiPassStrategyNames(t *testing.T) {
 // TestGetMultiPassPlanningPrompt verifies strategy prompts are correctly constructed
 func TestGetMultiPassPlanningPrompt(t *testing.T) {
 	tests := []struct {
-		name      string
-		strategy  string
-		objective string
-		wantParts []string // Strings that should appear in the prompt
+		name       string
+		strategy   string
+		objective  string
+		wantParts  []string // Strings that should appear in the prompt
 		wantAbsent []string // Strings that should NOT appear
 	}{
 		{
@@ -42,7 +42,7 @@ func TestGetMultiPassPlanningPrompt(t *testing.T) {
 			strategy:  "maximize-parallelism",
 			objective: "Add user authentication",
 			wantParts: []string{
-				"Add user authentication",            // Objective
+				"Add user authentication",               // Objective
 				"Strategic Focus: Maximize Parallelism", // Strategy header
 				"Minimize Dependencies",                 // Strategy-specific content
 				"Flatten the Dependency Graph",

--- a/internal/orchestrator/planeditor.go
+++ b/internal/orchestrator/planeditor.go
@@ -735,21 +735,21 @@ const (
 
 // ValidationMessage represents a single validation issue with structured information
 type ValidationMessage struct {
-	Severity    ValidationSeverity `json:"severity"`
-	Message     string             `json:"message"`
-	TaskID      string             `json:"task_id,omitempty"`      // The task this message relates to (empty for plan-level issues)
-	Field       string             `json:"field,omitempty"`        // The field causing the issue (e.g., "depends_on", "description")
-	Suggestion  string             `json:"suggestion,omitempty"`   // A suggested fix
-	RelatedIDs  []string           `json:"related_ids,omitempty"`  // Related task IDs (for cycles, conflicts, etc.)
+	Severity   ValidationSeverity `json:"severity"`
+	Message    string             `json:"message"`
+	TaskID     string             `json:"task_id,omitempty"`     // The task this message relates to (empty for plan-level issues)
+	Field      string             `json:"field,omitempty"`       // The field causing the issue (e.g., "depends_on", "description")
+	Suggestion string             `json:"suggestion,omitempty"`  // A suggested fix
+	RelatedIDs []string           `json:"related_ids,omitempty"` // Related task IDs (for cycles, conflicts, etc.)
 }
 
 // ValidationResult contains the complete validation results for a plan
 type ValidationResult struct {
-	IsValid   bool                `json:"is_valid"`   // True if there are no errors (warnings allowed)
-	Messages  []ValidationMessage `json:"messages"`
-	ErrorCount   int              `json:"error_count"`
-	WarningCount int              `json:"warning_count"`
-	InfoCount    int              `json:"info_count"`
+	IsValid      bool                `json:"is_valid"` // True if there are no errors (warnings allowed)
+	Messages     []ValidationMessage `json:"messages"`
+	ErrorCount   int                 `json:"error_count"`
+	WarningCount int                 `json:"warning_count"`
+	InfoCount    int                 `json:"info_count"`
 }
 
 // HasErrors returns true if there are any error-level messages

--- a/internal/orchestrator/planeditor_test.go
+++ b/internal/orchestrator/planeditor_test.go
@@ -1080,11 +1080,11 @@ func TestUpdateTaskTitle_TableDriven(t *testing.T) {
 			},
 		},
 		{
-			name:    "update non-existent task",
-			taskID:  "nonexistent",
+			name:     "update non-existent task",
+			taskID:   "nonexistent",
 			newTitle: "Title",
-			wantErr: true,
-			errType: ErrTaskNotFound{},
+			wantErr:  true,
+			errType:  ErrTaskNotFound{},
 		},
 	}
 

--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -23,12 +23,12 @@ const (
 
 // Metrics tracks resource usage and costs for an instance
 type Metrics struct {
-	InputTokens  int64   `json:"input_tokens"`
-	OutputTokens int64   `json:"output_tokens"`
-	CacheRead    int64   `json:"cache_read,omitempty"`
-	CacheWrite   int64   `json:"cache_write,omitempty"`
-	Cost         float64 `json:"cost"`
-	APICalls     int     `json:"api_calls"`
+	InputTokens  int64      `json:"input_tokens"`
+	OutputTokens int64      `json:"output_tokens"`
+	CacheRead    int64      `json:"cache_read,omitempty"`
+	CacheWrite   int64      `json:"cache_write,omitempty"`
+	Cost         float64    `json:"cost"`
+	APICalls     int        `json:"api_calls"`
 	StartTime    *time.Time `json:"start_time,omitempty"`
 	EndTime      *time.Time `json:"end_time,omitempty"`
 }

--- a/internal/orchestrator/session/types.go
+++ b/internal/orchestrator/session/types.go
@@ -22,16 +22,16 @@ type SessionData struct {
 
 // InstanceData represents instance information for persistence.
 type InstanceData struct {
-	ID            string         `json:"id"`
-	WorktreePath  string         `json:"worktree_path"`
-	Branch        string         `json:"branch"`
-	Task          string         `json:"task"`
-	Status        string         `json:"status"`
-	PID           int            `json:"pid,omitempty"`
-	FilesModified []string       `json:"files_modified,omitempty"`
-	Created       time.Time      `json:"created"`
-	TmuxSession   string         `json:"tmux_session,omitempty"`
-	Metrics       *MetricsData   `json:"metrics,omitempty"`
+	ID            string       `json:"id"`
+	WorktreePath  string       `json:"worktree_path"`
+	Branch        string       `json:"branch"`
+	Task          string       `json:"task"`
+	Status        string       `json:"status"`
+	PID           int          `json:"pid,omitempty"`
+	FilesModified []string     `json:"files_modified,omitempty"`
+	Created       time.Time    `json:"created"`
+	TmuxSession   string       `json:"tmux_session,omitempty"`
+	Metrics       *MetricsData `json:"metrics,omitempty"`
 }
 
 // MetricsData represents instance resource usage metrics for persistence.

--- a/internal/orchestrator/ultraplan.go
+++ b/internal/orchestrator/ultraplan.go
@@ -55,8 +55,8 @@ type PlannedTask struct {
 // PlanSpec represents the output of the planning phase
 type PlanSpec struct {
 	ID              string              `json:"id"`
-	Objective       string              `json:"objective"`        // Original user request
-	Summary         string              `json:"summary"`          // Executive summary of the plan
+	Objective       string              `json:"objective"` // Original user request
+	Summary         string              `json:"summary"`   // Executive summary of the plan
 	Tasks           []PlannedTask       `json:"tasks"`
 	DependencyGraph map[string][]string `json:"dependency_graph"` // task_id -> depends_on[]
 	ExecutionOrder  [][]string          `json:"execution_order"`  // Groups of parallelizable tasks
@@ -67,12 +67,12 @@ type PlanSpec struct {
 
 // UltraPlanConfig holds configuration for an ultra-plan session
 type UltraPlanConfig struct {
-	MaxParallel   int  `json:"max_parallel"`    // Maximum concurrent child sessions
-	DryRun        bool `json:"dry_run"`         // Run planning only, don't execute
-	NoSynthesis   bool `json:"no_synthesis"`    // Skip synthesis phase after execution
-	AutoApprove   bool `json:"auto_approve"`    // Auto-approve spawned tasks without confirmation
-	Review        bool `json:"review"`          // Force plan editor to open for review (overrides AutoApprove)
-	MultiPass     bool `json:"multi_pass"`      // Enable multi-pass planning with plan comparison
+	MaxParallel int  `json:"max_parallel"` // Maximum concurrent child sessions
+	DryRun      bool `json:"dry_run"`      // Run planning only, don't execute
+	NoSynthesis bool `json:"no_synthesis"` // Skip synthesis phase after execution
+	AutoApprove bool `json:"auto_approve"` // Auto-approve spawned tasks without confirmation
+	Review      bool `json:"review"`       // Force plan editor to open for review (overrides AutoApprove)
+	MultiPass   bool `json:"multi_pass"`   // Enable multi-pass planning with plan comparison
 
 	// Consolidation settings
 	ConsolidationMode ConsolidationMode `json:"consolidation_mode,omitempty"` // "stacked" or "single"
@@ -81,8 +81,8 @@ type UltraPlanConfig struct {
 	BranchPrefix      string            `json:"branch_prefix,omitempty"`      // Branch prefix for consolidated branches
 
 	// Task verification settings
-	MaxTaskRetries         int  `json:"max_task_retries,omitempty"`   // Max retry attempts for tasks with no commits (default: 3)
-	RequireVerifiedCommits bool `json:"require_verified_commits"`     // If true, tasks must produce commits to be marked successful (default: true)
+	MaxTaskRetries         int  `json:"max_task_retries,omitempty"` // Max retry attempts for tasks with no commits (default: 3)
+	RequireVerifiedCommits bool `json:"require_verified_commits"`   // If true, tasks must produce commits to be marked successful (default: true)
 }
 
 // DefaultUltraPlanConfig returns the default configuration
@@ -104,11 +104,11 @@ func DefaultUltraPlanConfig() UltraPlanConfig {
 
 // RevisionIssue represents an issue identified during synthesis that needs to be addressed
 type RevisionIssue struct {
-	TaskID      string   `json:"task_id"`               // Task ID that needs revision (empty for cross-cutting issues)
-	Description string   `json:"description"`           // Description of the issue
-	Files       []string `json:"files,omitempty"`       // Files affected by the issue
-	Severity    string   `json:"severity,omitempty"`    // "critical", "major", "minor"
-	Suggestion  string   `json:"suggestion,omitempty"`  // Suggested fix
+	TaskID      string   `json:"task_id"`              // Task ID that needs revision (empty for cross-cutting issues)
+	Description string   `json:"description"`          // Description of the issue
+	Files       []string `json:"files,omitempty"`      // Files affected by the issue
+	Severity    string   `json:"severity,omitempty"`   // "critical", "major", "minor"
+	Suggestion  string   `json:"suggestion,omitempty"` // Suggested fix
 }
 
 // PlanScore represents the evaluation of a single candidate plan
@@ -129,14 +129,14 @@ type PlanDecision struct {
 
 // RevisionState tracks the state of the revision phase
 type RevisionState struct {
-	Issues           []RevisionIssue `json:"issues"`                      // Issues identified during synthesis
-	RevisionRound    int             `json:"revision_round"`              // Current revision iteration (starts at 1)
-	MaxRevisions     int             `json:"max_revisions"`               // Maximum allowed revision rounds
-	TasksToRevise    []string        `json:"tasks_to_revise,omitempty"`   // Task IDs that need revision
-	RevisedTasks     []string        `json:"revised_tasks,omitempty"`     // Task IDs that have been revised
-	RevisionPrompts  map[string]string `json:"revision_prompts,omitempty"` // Task ID -> revision prompt
-	StartedAt        *time.Time      `json:"started_at,omitempty"`
-	CompletedAt      *time.Time      `json:"completed_at,omitempty"`
+	Issues          []RevisionIssue   `json:"issues"`                     // Issues identified during synthesis
+	RevisionRound   int               `json:"revision_round"`             // Current revision iteration (starts at 1)
+	MaxRevisions    int               `json:"max_revisions"`              // Maximum allowed revision rounds
+	TasksToRevise   []string          `json:"tasks_to_revise,omitempty"`  // Task IDs that need revision
+	RevisedTasks    []string          `json:"revised_tasks,omitempty"`    // Task IDs that have been revised
+	RevisionPrompts map[string]string `json:"revision_prompts,omitempty"` // Task ID -> revision prompt
+	StartedAt       *time.Time        `json:"started_at,omitempty"`
+	CompletedAt     *time.Time        `json:"completed_at,omitempty"`
 }
 
 // NewRevisionState creates a new revision state
@@ -271,19 +271,19 @@ type GroupDecisionState struct {
 
 // UltraPlanSession represents an ultra-plan orchestration session
 type UltraPlanSession struct {
-	ID              string            `json:"id"`
-	Objective       string            `json:"objective"`
-	Plan            *PlanSpec         `json:"plan,omitempty"`
-	Phase           UltraPlanPhase    `json:"phase"`
-	Config          UltraPlanConfig   `json:"config"`
-	CoordinatorID   string            `json:"coordinator_id,omitempty"`   // Instance ID of the planning coordinator
+	ID            string          `json:"id"`
+	Objective     string          `json:"objective"`
+	Plan          *PlanSpec       `json:"plan,omitempty"`
+	Phase         UltraPlanPhase  `json:"phase"`
+	Config        UltraPlanConfig `json:"config"`
+	CoordinatorID string          `json:"coordinator_id,omitempty"` // Instance ID of the planning coordinator
 
 	// Multi-pass planning state
-	CandidatePlans        []*PlanSpec    `json:"candidate_plans,omitempty"`         // Plans from each coordinator (multi-pass)
-	PlanCoordinatorIDs    []string       `json:"plan_coordinator_ids,omitempty"`    // Instance IDs of planning coordinators
-	ProcessedCoordinators map[int]bool   `json:"processed_coordinators,omitempty"`  // Tracks which coordinators have completed (index -> completed)
-	PlanManagerID         string         `json:"plan_manager_id,omitempty"`         // Instance ID of the coordinator-manager
-	SelectedPlanIndex     int            `json:"selected_plan_index,omitempty"`     // Index of selected plan (-1 if merged)
+	CandidatePlans        []*PlanSpec  `json:"candidate_plans,omitempty"`        // Plans from each coordinator (multi-pass)
+	PlanCoordinatorIDs    []string     `json:"plan_coordinator_ids,omitempty"`   // Instance IDs of planning coordinators
+	ProcessedCoordinators map[int]bool `json:"processed_coordinators,omitempty"` // Tracks which coordinators have completed (index -> completed)
+	PlanManagerID         string       `json:"plan_manager_id,omitempty"`        // Instance ID of the coordinator-manager
+	SelectedPlanIndex     int          `json:"selected_plan_index,omitempty"`    // Index of selected plan (-1 if merged)
 
 	SynthesisID     string            `json:"synthesis_id,omitempty"`     // Instance ID of the synthesis reviewer
 	RevisionID      string            `json:"revision_id,omitempty"`      // Instance ID of the current revision coordinator
@@ -291,7 +291,7 @@ type UltraPlanSession struct {
 	TaskToInstance  map[string]string `json:"task_to_instance"`           // PlannedTask.ID -> Instance.ID
 	CompletedTasks  []string          `json:"completed_tasks"`
 	FailedTasks     []string          `json:"failed_tasks"`
-	CurrentGroup    int               `json:"current_group"`      // Index into ExecutionOrder
+	CurrentGroup    int               `json:"current_group"` // Index into ExecutionOrder
 	Created         time.Time         `json:"created"`
 	StartedAt       *time.Time        `json:"started_at,omitempty"`
 	CompletedAt     *time.Time        `json:"completed_at,omitempty"`
@@ -1234,10 +1234,10 @@ const RevisionCompletionFileName = ".claudio-revision-complete.json"
 type RevisionCompletionFile struct {
 	TaskID          string   `json:"task_id"`
 	RevisionRound   int      `json:"revision_round"`
-	IssuesAddressed []string `json:"issues_addressed"`  // Issue descriptions that were fixed
-	Summary         string   `json:"summary"`           // What was changed
+	IssuesAddressed []string `json:"issues_addressed"` // Issue descriptions that were fixed
+	Summary         string   `json:"summary"`          // What was changed
 	FilesModified   []string `json:"files_modified"`
-	RemainingIssues []string `json:"remaining_issues"`  // Issues that couldn't be fixed
+	RemainingIssues []string `json:"remaining_issues"` // Issues that couldn't be fixed
 }
 
 // RevisionCompletionFilePath returns the full path to the revision completion file
@@ -1266,13 +1266,13 @@ const ConsolidationCompletionFileName = ".claudio-consolidation-complete.json"
 
 // ConsolidationCompletionFile represents the completion report from consolidation
 type ConsolidationCompletionFile struct {
-	Status           string                     `json:"status"` // "complete", "partial", "failed"
-	Mode             string                     `json:"mode"`   // "stacked" or "single"
-	GroupResults     []GroupConsolidationInfo   `json:"group_results"`
-	PRsCreated       []PRInfo                   `json:"prs_created"`
-	SynthesisContext *SynthesisCompletionFile   `json:"synthesis_context,omitempty"`
-	TotalCommits     int                        `json:"total_commits"`
-	FilesChanged     []string                   `json:"files_changed"`
+	Status           string                   `json:"status"` // "complete", "partial", "failed"
+	Mode             string                   `json:"mode"`   // "stacked" or "single"
+	GroupResults     []GroupConsolidationInfo `json:"group_results"`
+	PRsCreated       []PRInfo                 `json:"prs_created"`
+	SynthesisContext *SynthesisCompletionFile `json:"synthesis_context,omitempty"`
+	TotalCommits     int                      `json:"total_commits"`
+	FilesChanged     []string                 `json:"files_changed"`
 }
 
 // GroupConsolidationInfo holds info about a consolidated group
@@ -1324,10 +1324,10 @@ type ConflictResolution struct {
 // VerificationResult holds the results of build/lint/test verification
 // The consolidator determines appropriate commands based on project type
 type VerificationResult struct {
-	ProjectType  string             `json:"project_type,omitempty"` // Detected: "go", "node", "ios", "python", etc.
-	CommandsRun  []VerificationStep `json:"commands_run"`
-	OverallSuccess bool             `json:"overall_success"`
-	Summary      string             `json:"summary,omitempty"` // Brief summary of verification outcome
+	ProjectType    string             `json:"project_type,omitempty"` // Detected: "go", "node", "ios", "python", etc.
+	CommandsRun    []VerificationStep `json:"commands_run"`
+	OverallSuccess bool               `json:"overall_success"`
+	Summary        string             `json:"summary,omitempty"` // Brief summary of verification outcome
 }
 
 // VerificationStep represents a single verification command and its result
@@ -1348,7 +1348,7 @@ type GroupConsolidationCompletionFile struct {
 	ConflictsResolved  []ConflictResolution   `json:"conflicts_resolved,omitempty"`
 	Verification       VerificationResult     `json:"verification"`
 	AggregatedContext  *AggregatedTaskContext `json:"aggregated_context,omitempty"`
-	Notes              string                 `json:"notes,omitempty"`               // Consolidator's observations
+	Notes              string                 `json:"notes,omitempty"`                 // Consolidator's observations
 	IssuesForNextGroup []string               `json:"issues_for_next_group,omitempty"` // Warnings/concerns to pass forward
 }
 

--- a/internal/orchestrator/ultraplan_test.go
+++ b/internal/orchestrator/ultraplan_test.go
@@ -470,8 +470,8 @@ func TestUltraPlanSession_GetReadyTasks_AwaitingDecision(t *testing.T) {
 				{"task-3", "task-4"}, // Group 1
 			},
 		},
-		CompletedTasks: []string{"task-1"},       // task-1 succeeded
-		FailedTasks:    []string{"task-2"},       // task-2 failed - partial failure
+		CompletedTasks: []string{"task-1"}, // task-1 succeeded
+		FailedTasks:    []string{"task-2"}, // task-2 failed - partial failure
 		TaskToInstance: make(map[string]string),
 		CurrentGroup:   0, // Still at group 0 (not advanced)
 		GroupDecision: &GroupDecisionState{
@@ -787,8 +787,8 @@ That concludes my evaluation.`,
 			wantSelectedIndex: 1,
 		},
 		{
-			name: "valid decision with minimal fields",
-			output: `<plan_decision>{"action":"select","selected_index":0,"reasoning":"","plan_scores":[]}</plan_decision>`,
+			name:              "valid decision with minimal fields",
+			output:            `<plan_decision>{"action":"select","selected_index":0,"reasoning":"","plan_scores":[]}</plan_decision>`,
 			wantErr:           false,
 			wantAction:        "select",
 			wantSelectedIndex: 0,
@@ -819,4 +819,3 @@ That concludes my evaluation.`,
 		})
 	}
 }
-

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -242,10 +242,10 @@ func parsePlanFromOutput(output, objective string) (*orchestrator.PlanSpec, erro
 
 	// Parse the JSON
 	var rawPlan struct {
-		Summary     string                    `json:"summary"`
+		Summary     string                     `json:"summary"`
 		Tasks       []orchestrator.PlannedTask `json:"tasks"`
-		Insights    []string                  `json:"insights"`
-		Constraints []string                  `json:"constraints"`
+		Insights    []string                   `json:"insights"`
+		Constraints []string                   `json:"constraints"`
 	}
 
 	if err := json.Unmarshal([]byte(output), &rawPlan); err != nil {

--- a/internal/pr/pr.go
+++ b/internal/pr/pr.go
@@ -27,12 +27,12 @@ type PROptions struct {
 
 // Context holds all the information needed to generate PR content
 type Context struct {
-	Task          string
-	Branch        string
-	Diff          string
-	CommitLog     string
-	ChangedFiles  []string
-	InstanceID    string
+	Task         string
+	Branch       string
+	Diff         string
+	CommitLog    string
+	ChangedFiles []string
+	InstanceID   string
 }
 
 // Generator creates PR content using Claude

--- a/internal/tui/config/config.go
+++ b/internal/tui/config/config.go
@@ -742,9 +742,9 @@ func (m *Model) resetCurrentToDefault() {
 		"instance.completion_timeout_minutes": defaults.Instance.CompletionTimeoutMinutes,
 		"instance.stale_detection":            defaults.Instance.StaleDetection,
 		// Pull Request
-		"pr.draft":          defaults.PR.Draft,
-		"pr.auto_rebase":    defaults.PR.AutoRebase,
-		"pr.use_ai":         defaults.PR.UseAI,
+		"pr.draft":           defaults.PR.Draft,
+		"pr.auto_rebase":     defaults.PR.AutoRebase,
+		"pr.use_ai":          defaults.PR.UseAI,
 		"pr.auto_pr_on_stop": defaults.PR.AutoPROnStop,
 		// Branch
 		"branch.prefix":     defaults.Branch.Prefix,

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -58,19 +58,19 @@ type Model struct {
 	planEditor *PlanEditorState
 
 	// UI state
-	activeTab      int
-	width          int
-	height         int
-	ready          bool
-	quitting       bool
-	showHelp       bool
-	showConflicts  bool // When true, show detailed conflict view
+	activeTab       int
+	width           int
+	height          int
+	ready           bool
+	quitting        bool
+	showHelp        bool
+	showConflicts   bool // When true, show detailed conflict view
 	addingTask      bool
 	taskInput       string
 	taskInputCursor int // Cursor position within taskInput (0 = before first char)
-	errorMessage string
-	infoMessage  string // Non-error status message
-	inputMode    bool   // When true, all keys are forwarded to the active instance's tmux session
+	errorMessage    string
+	infoMessage     string // Non-error status message
+	inputMode       bool   // When true, all keys are forwarded to the active instance's tmux session
 
 	// Command mode state (vim-style ex commands with ':' prefix)
 	commandMode   bool   // When true, we're typing a command after ':'

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -105,11 +105,11 @@ func TestPlanEditorState_Initialization(t *testing.T) {
 
 func TestPlanEditorMoveSelection(t *testing.T) {
 	tests := []struct {
-		name           string
-		initialIdx     int
-		delta          int
-		numTasks       int
-		expectedIdx    int
+		name        string
+		initialIdx  int
+		delta       int
+		numTasks    int
+		expectedIdx int
 	}{
 		{
 			name:        "move down from first",
@@ -247,14 +247,14 @@ func TestPlanEditorEnsureVisible(t *testing.T) {
 
 func TestStartEditingField(t *testing.T) {
 	tests := []struct {
-		name          string
-		field         string
-		taskTitle     string
-		taskDesc      string
-		taskFiles     []string
-		taskPriority  int
-		taskDeps      []string
-		expectedBuf   string
+		name         string
+		field        string
+		taskTitle    string
+		taskDesc     string
+		taskFiles    []string
+		taskPriority int
+		taskDeps     []string
+		expectedBuf  string
 	}{
 		{
 			name:        "edit title",
@@ -384,11 +384,11 @@ func TestCancelFieldEdit(t *testing.T) {
 
 func TestConfirmFieldEdit(t *testing.T) {
 	tests := []struct {
-		name         string
-		field        string
-		editBuffer   string
-		wantErr      bool
-		checkResult  func(t *testing.T, plan *orchestrator.PlanSpec)
+		name        string
+		field       string
+		editBuffer  string
+		wantErr     bool
+		checkResult func(t *testing.T, plan *orchestrator.PlanSpec)
 	}{
 		{
 			name:       "confirm title edit",
@@ -829,12 +829,12 @@ func TestCycleTaskComplexity(t *testing.T) {
 
 func TestDeleteSelectedTask(t *testing.T) {
 	tests := []struct {
-		name            string
-		selectedIdx     int
-		numTasks        int
-		expectedRemain  int
-		expectedNewIdx  int
-		wantErr         bool
+		name           string
+		selectedIdx    int
+		numTasks       int
+		expectedRemain int
+		expectedNewIdx int
+		wantErr        bool
 	}{
 		{
 			name:           "delete first task",

--- a/internal/tui/styles/styles.go
+++ b/internal/tui/styles/styles.go
@@ -232,7 +232,7 @@ var (
 
 	SearchCurrentMatch = lipgloss.NewStyle().
 				Background(lipgloss.Color("#C2410C")). // Dark orange for current match
-				Foreground(lipgloss.Color("#FFF7ED")).  // Light orange-white text
+				Foreground(lipgloss.Color("#FFF7ED")). // Light orange-white text
 				Bold(true)
 
 	SearchInfo = lipgloss.NewStyle().

--- a/internal/tui/view/planeditor.go
+++ b/internal/tui/view/planeditor.go
@@ -12,30 +12,30 @@ import (
 // Validation panel styles (local to this file)
 var (
 	validationPanelStyle = lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("240")).
-		Padding(0, 1)
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(lipgloss.Color("240")).
+				Padding(0, 1)
 
 	validationErrorStyle = lipgloss.NewStyle().
-		Foreground(styles.RedColor).
-		Bold(true)
+				Foreground(styles.RedColor).
+				Bold(true)
 
 	validationWarningStyle = lipgloss.NewStyle().
-		Foreground(styles.YellowColor)
+				Foreground(styles.YellowColor)
 
 	validationInfoStyle = lipgloss.NewStyle().
-		Foreground(styles.BlueColor)
+				Foreground(styles.BlueColor)
 
 	validationHeaderStyle = lipgloss.NewStyle().
-		Bold(true).
-		Underline(true)
+				Bold(true).
+				Underline(true)
 
 	validationTaskStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("245"))
+				Foreground(lipgloss.Color("245"))
 
 	cyclicTaskStyle = lipgloss.NewStyle().
-		Foreground(styles.RedColor).
-		Bold(true)
+			Foreground(styles.RedColor).
+			Bold(true)
 )
 
 // PlanEditorState holds the rendering state for the plan editor view.

--- a/internal/tui/view/ultraplan.go
+++ b/internal/tui/view/ultraplan.go
@@ -30,15 +30,15 @@ type UltraPlanState struct {
 // This allows the view to access orchestrator and session state without
 // direct coupling to the Model struct.
 type RenderContext struct {
-	Orchestrator  *orchestrator.Orchestrator
-	Session       *orchestrator.Session
-	UltraPlan     *UltraPlanState
-	ActiveTab     int
-	Width         int
-	Height        int
-	Outputs       map[string]string
-	GetInstance   func(id string) *orchestrator.Instance
-	IsSelected    func(instanceID string) bool
+	Orchestrator *orchestrator.Orchestrator
+	Session      *orchestrator.Session
+	UltraPlan    *UltraPlanState
+	ActiveTab    int
+	Width        int
+	Height       int
+	Outputs      map[string]string
+	GetInstance  func(id string) *orchestrator.Instance
+	IsSelected   func(instanceID string) bool
 }
 
 // UltraplanView handles rendering of ultra-plan UI components including
@@ -1370,4 +1370,3 @@ func OpenURL(url string) error {
 
 	return cmd.Start()
 }
-

--- a/internal/ultraplan/consolidator/consolidator.go
+++ b/internal/ultraplan/consolidator/consolidator.go
@@ -150,13 +150,13 @@ type PRCreator interface {
 
 // Consolidator handles the consolidation of task branches into group branches and PR creation.
 type Consolidator struct {
-	session  *ultraplan.Session
-	config   Config
-	wt       WorktreeManager
-	pr       PRCreator
-	state    *State
-	results  []*GroupResult
-	logger   *logging.Logger
+	session *ultraplan.Session
+	config  Config
+	wt      WorktreeManager
+	pr      PRCreator
+	state   *State
+	results []*GroupResult
+	logger  *logging.Logger
 
 	// Task branch mapping: task ID -> branch name
 	taskBranches map[string]string

--- a/internal/ultraplan/executor/coordinator.go
+++ b/internal/ultraplan/executor/coordinator.go
@@ -67,15 +67,15 @@ type Coordinator struct {
 	eventHandler   EventHandler
 	worktreeGetter WorktreeGetter
 
-	mu             sync.RWMutex
-	progress       ExecutionProgress
-	runningTasks   map[string]*runningTask
-	taskExecutors  map[string]TaskExecutor
-	currentGroup   int
-	started        bool
-	stopped        bool
-	stopChan       chan struct{}
-	wg             sync.WaitGroup
+	mu            sync.RWMutex
+	progress      ExecutionProgress
+	runningTasks  map[string]*runningTask
+	taskExecutors map[string]TaskExecutor
+	currentGroup  int
+	started       bool
+	stopped       bool
+	stopChan      chan struct{}
+	wg            sync.WaitGroup
 }
 
 // WorktreeGetter provides worktree paths for tasks.

--- a/internal/ultraplan/executor/coordinator_test.go
+++ b/internal/ultraplan/executor/coordinator_test.go
@@ -54,9 +54,9 @@ func (m *mockTaskExecutor) GetStatus() ExecutionStatus {
 
 // mockTaskExecutorFactory provides a test implementation of TaskExecutorFactory.
 type mockTaskExecutorFactory struct {
-	executors    map[string]*mockTaskExecutor
-	createError  error
-	mu           sync.Mutex
+	executors   map[string]*mockTaskExecutor
+	createError error
+	mu          sync.Mutex
 }
 
 func newMockTaskExecutorFactory() *mockTaskExecutorFactory {

--- a/internal/ultraplan/session.go
+++ b/internal/ultraplan/session.go
@@ -10,12 +10,12 @@ import (
 
 // Config holds configuration for an ultra-plan session.
 type Config struct {
-	MaxParallel int  `json:"max_parallel"`   // Maximum concurrent child sessions
-	DryRun      bool `json:"dry_run"`        // Run planning only, don't execute
-	NoSynthesis bool `json:"no_synthesis"`   // Skip synthesis phase after execution
-	AutoApprove bool `json:"auto_approve"`   // Auto-approve spawned tasks without confirmation
-	Review      bool `json:"review"`         // Force plan editor to open for review (overrides AutoApprove)
-	MultiPass   bool `json:"multi_pass"`     // Enable multi-pass planning with plan comparison
+	MaxParallel int  `json:"max_parallel"` // Maximum concurrent child sessions
+	DryRun      bool `json:"dry_run"`      // Run planning only, don't execute
+	NoSynthesis bool `json:"no_synthesis"` // Skip synthesis phase after execution
+	AutoApprove bool `json:"auto_approve"` // Auto-approve spawned tasks without confirmation
+	Review      bool `json:"review"`       // Force plan editor to open for review (overrides AutoApprove)
+	MultiPass   bool `json:"multi_pass"`   // Enable multi-pass planning with plan comparison
 
 	// Consolidation settings
 	ConsolidationMode ConsolidationMode `json:"consolidation_mode,omitempty"` // "stacked" or "single"
@@ -24,8 +24,8 @@ type Config struct {
 	BranchPrefix      string            `json:"branch_prefix,omitempty"`      // Branch prefix for consolidated branches
 
 	// Task verification settings
-	MaxTaskRetries         int  `json:"max_task_retries,omitempty"`   // Max retry attempts for tasks with no commits (default: 3)
-	RequireVerifiedCommits bool `json:"require_verified_commits"`     // If true, tasks must produce commits to be marked successful (default: true)
+	MaxTaskRetries         int  `json:"max_task_retries,omitempty"` // Max retry attempts for tasks with no commits (default: 3)
+	RequireVerifiedCommits bool `json:"require_verified_commits"`   // If true, tasks must produce commits to be marked successful (default: true)
 }
 
 // DefaultConfig returns the default configuration.
@@ -47,12 +47,12 @@ func DefaultConfig() Config {
 
 // RevisionState tracks the state of the revision phase.
 type RevisionState struct {
-	Issues          []RevisionIssue   `json:"issues"`                       // Issues identified during synthesis
-	RevisionRound   int               `json:"revision_round"`               // Current revision iteration (starts at 1)
-	MaxRevisions    int               `json:"max_revisions"`                // Maximum allowed revision rounds
-	TasksToRevise   []string          `json:"tasks_to_revise,omitempty"`    // Task IDs that need revision
-	RevisedTasks    []string          `json:"revised_tasks,omitempty"`      // Task IDs that have been revised
-	RevisionPrompts map[string]string `json:"revision_prompts,omitempty"`   // Task ID -> revision prompt
+	Issues          []RevisionIssue   `json:"issues"`                     // Issues identified during synthesis
+	RevisionRound   int               `json:"revision_round"`             // Current revision iteration (starts at 1)
+	MaxRevisions    int               `json:"max_revisions"`              // Maximum allowed revision rounds
+	TasksToRevise   []string          `json:"tasks_to_revise,omitempty"`  // Task IDs that need revision
+	RevisedTasks    []string          `json:"revised_tasks,omitempty"`    // Task IDs that have been revised
+	RevisionPrompts map[string]string `json:"revision_prompts,omitempty"` // Task ID -> revision prompt
 	StartedAt       *time.Time        `json:"started_at,omitempty"`
 	CompletedAt     *time.Time        `json:"completed_at,omitempty"`
 }
@@ -97,13 +97,13 @@ type SynthesisCompletionFile struct {
 
 // GroupConsolidationCompletionFile represents context passed between group consolidations.
 type GroupConsolidationCompletionFile struct {
-	GroupIndex    int      `json:"group_index"`
-	BranchName    string   `json:"branch_name"`
-	TasksSummary  string   `json:"tasks_summary"`
-	FilesChanged  []string `json:"files_changed"`
-	CommitCount   int      `json:"commit_count"`
-	Notes         string   `json:"notes,omitempty"`
-	CompletedAt   string   `json:"completed_at"`
+	GroupIndex   int      `json:"group_index"`
+	BranchName   string   `json:"branch_name"`
+	TasksSummary string   `json:"tasks_summary"`
+	FilesChanged []string `json:"files_changed"`
+	CommitCount  int      `json:"commit_count"`
+	Notes        string   `json:"notes,omitempty"`
+	CompletedAt  string   `json:"completed_at"`
 }
 
 // Session represents an ultra-plan orchestration session.

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -14,9 +14,9 @@ func TestFindGitRoot(t *testing.T) {
 	testutil.SkipIfNoGit(t)
 
 	tests := []struct {
-		name      string
-		setup     func(t *testing.T) (startDir string, wantRoot string)
-		wantErr   bool
+		name    string
+		setup   func(t *testing.T) (startDir string, wantRoot string)
+		wantErr bool
 	}{
 		{
 			name: "from repository root",


### PR DESCRIPTION
## Summary

- Add `TestGofmtCompliance` test that verifies all Go files are properly formatted
- Fix existing gofmt issues across 36 files
- Test runs as part of `go test ./...`, blocking commits with formatting issues

## Test plan

- [x] `go test ./internal/ -run TestGofmtCompliance` passes
- [x] All existing tests pass
- [x] Build succeeds