### PR TITLE
feat: add task chaining support for normal claudio mode

### DIFF
--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/Iron-Ham/claudio/internal/orchestrator"
 	"github.com/spf13/cobra"
@@ -12,16 +13,30 @@ var addCmd = &cobra.Command{
 	Use:   "add [task description]",
 	Short: "Add a new Claude instance with a task",
 	Long: `Add a new Claude Code instance to the current session.
-The instance will be created in its own worktree and start working on the specified task.`,
+The instance will be created in its own worktree and start working on the specified task.
+
+Task Chaining:
+  Use --depends-on to create task chains where one instance starts after another completes.
+  Dependencies can be specified by instance ID or by task name substring.
+
+Examples:
+  claudio add "Write tests for auth"
+  claudio add "Write docs" --depends-on abc123
+  claudio add "Write docs" --depends-on "Write tests"
+  claudio add "Run integration tests" --depends-on abc123,def456`,
 	Args: cobra.ExactArgs(1),
 	RunE: runAdd,
 }
 
-var autoStart bool
+var (
+	autoStart bool
+	dependsOn string
+)
 
 func init() {
 	rootCmd.AddCommand(addCmd)
-	addCmd.Flags().BoolVarP(&autoStart, "start", "s", false, "Automatically start the instance after adding")
+	addCmd.Flags().BoolVarP(&autoStart, "start", "s", false, "Automatically start the instance after adding (ignored if --depends-on is set)")
+	addCmd.Flags().StringVarP(&dependsOn, "depends-on", "d", "", "Instance ID(s) or task name(s) that must complete before this instance starts (comma-separated)")
 }
 
 func runAdd(cmd *cobra.Command, args []string) error {
@@ -44,23 +59,70 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no active session found. Run 'claudio start' first: %w", err)
 	}
 
-	// Add instance
-	instance, err := orch.AddInstance(session, task)
-	if err != nil {
-		return fmt.Errorf("failed to add instance: %w", err)
-	}
+	var instance *orchestrator.Instance
 
-	fmt.Printf("Added instance %s\n", instance.ID)
-	fmt.Printf("Task: %s\n", instance.Task)
-	fmt.Printf("Worktree: %s\n", instance.WorktreePath)
+	// Check if this instance has dependencies
+	if dependsOn != "" {
+		// Parse comma-separated dependencies
+		deps := parseDependencies(dependsOn)
 
-	// Auto-start if requested
-	if autoStart {
-		if err := orch.StartInstance(instance); err != nil {
-			return fmt.Errorf("failed to start instance: %w", err)
+		// Add instance with dependencies - auto-start when dependencies complete
+		instance, err = orch.AddInstanceWithDependencies(session, task, deps, true)
+		if err != nil {
+			return fmt.Errorf("failed to add instance: %w", err)
 		}
-		fmt.Println("Instance started")
+
+		fmt.Printf("Added instance %s (waiting for dependencies)\n", instance.ID)
+		fmt.Printf("Task: %s\n", instance.Task)
+		fmt.Printf("Worktree: %s\n", instance.WorktreePath)
+		fmt.Printf("Depends on: %s\n", strings.Join(instance.DependsOn, ", "))
+
+		// Check if dependencies are already met
+		if session.AreDependenciesMet(instance) {
+			fmt.Println("All dependencies already completed!")
+			if err := orch.StartInstance(instance); err != nil {
+				return fmt.Errorf("failed to start instance: %w", err)
+			}
+			fmt.Println("Instance started")
+		} else {
+			fmt.Println("Instance will auto-start when all dependencies complete")
+		}
+	} else {
+		// Add instance without dependencies
+		instance, err = orch.AddInstance(session, task)
+		if err != nil {
+			return fmt.Errorf("failed to add instance: %w", err)
+		}
+
+		fmt.Printf("Added instance %s\n", instance.ID)
+		fmt.Printf("Task: %s\n", instance.Task)
+		fmt.Printf("Worktree: %s\n", instance.WorktreePath)
+
+		// Auto-start if requested
+		if autoStart {
+			if err := orch.StartInstance(instance); err != nil {
+				return fmt.Errorf("failed to start instance: %w", err)
+			}
+			fmt.Println("Instance started")
+		}
 	}
 
 	return nil
+}
+
+// parseDependencies splits a comma-separated list of dependencies and trims whitespace
+func parseDependencies(deps string) []string {
+	if deps == "" {
+		return nil
+	}
+
+	parts := strings.Split(deps, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2165,7 +2165,7 @@ func (m Model) renderInstance(inst *orchestrator.Instance, width int) string {
 	}
 
 	instanceView := view.NewInstanceView(width, m.getOutputMaxLines())
-	return instanceView.Render(inst, renderState)
+	return instanceView.RenderWithSession(inst, renderState, m.session)
 }
 
 // renderFilterPanel renders the filter configuration panel

--- a/internal/tui/view/dashboard.go
+++ b/internal/tui/view/dashboard.go
@@ -133,13 +133,25 @@ func (dv *DashboardView) renderSidebarInstance(
 	statusColor := styles.StatusColor(string(inst.Status))
 	dot := lipgloss.NewStyle().Foreground(statusColor).Render("●")
 
-	// Instance number and truncated task
-	maxTaskLen := max(width-8, 10) // Account for number, dot, padding
-	label := fmt.Sprintf("%d %s", i+1, truncate(inst.Task, maxTaskLen))
+	// Build prefix icons
+	prefix := ""
+	prefixLen := 0
+
 	// Add conflict indicator if instance has conflicts
 	if conflictingInstances[inst.ID] {
-		label = fmt.Sprintf("%d ⚠ %s", i+1, truncate(inst.Task, maxTaskLen-2))
+		prefix += "⚠ "
+		prefixLen += 2
 	}
+
+	// Add chain indicator if instance has dependencies (waiting for others)
+	if len(inst.DependsOn) > 0 && inst.Status == orchestrator.StatusPending {
+		prefix += "⛓ " // Chain icon to indicate waiting for dependencies
+		prefixLen += 2
+	}
+
+	// Instance number and truncated task
+	maxTaskLen := max(width-8-prefixLen, 10) // Account for number, dot, prefix, padding
+	label := fmt.Sprintf("%d %s%s", i+1, prefix, truncate(inst.Task, maxTaskLen))
 
 	// Choose style based on active state and status
 	var itemStyle lipgloss.Style


### PR DESCRIPTION
## Summary

- Add task chaining support allowing instances to declare dependencies on other instances
- Dependent instances auto-start when all their dependencies complete
- Add `--depends-on` flag to `claudio add` command for creating task chains
- Display dependency relationships in TUI (instance view and sidebar)

## Motivation

Some development workflows have natural dependencies:
- Write API → Write tests → Write docs
- Implement feature → Fix lint → Run tests
- Create migration → Update models → Update handlers

This feature enables these sequential workflows without manual intervention.

## Usage

```bash
# Create a chain of dependent tasks
claudio add "Implement feature" -s
claudio add "Write tests" --depends-on "Implement feature"
claudio add "Write docs" --depends-on "Write tests"

# Dependencies can be specified by instance ID or task name substring
claudio add "Run integration tests" --depends-on abc123,def456
```

## Test plan

- [x] Unit tests for `AreDependenciesMet`, `GetDependentInstances`, `GetReadyInstances`
- [x] Unit tests for dependency field initialization
- [x] All existing tests pass
- [ ] Manual testing of task chain creation and auto-start behavior

Closes #25