### PR TITLE
fix(tui): show all command shortcuts in command mode help bar

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2482,7 +2482,7 @@ func (m Model) renderHelp() string {
 				styles.Muted.Render("█") + "  " +
 				styles.HelpKey.Render("[Enter]") + " execute  " +
 				styles.HelpKey.Render("[Esc]") + " cancel  " +
-				styles.Muted.Render("Type command (e.g., :s :a :d :h)"),
+				styles.Muted.Render("Commands: s/x/e/p/R a/D/C d/m/c/f t/r h/q (or :help)"),
 		)
 	}
 


### PR DESCRIPTION
## Summary
- Updated the command mode help bar to display all available single-letter shortcuts
- Previously only showed `(e.g., :s :a :d :h)` - just 4 example commands
- Now shows `Commands: s/x/e/p/R a/D/C d/m/c/f t/r h/q (or :help)` - all 17 shortcuts grouped by function

This change helps users discover commands like `:D` (remove), `:x` (stop), `:C` (clear), etc. that were previously not visible in the command mode hint.

## Command Groups
| Group | Shortcuts | Commands |
|-------|-----------|----------|
| Instance control | s/x/e/p/R | start, stop, exit, pause, reconnect |
| Instance management | a/D/C | add, remove, clear |
| View toggles | d/m/c/f | diff, metrics, conflicts, filter |
| Utility | t/r | tmux, pr |
| Session | h/q | help, quit |

## Test plan
- [x] Build passes (`go build ./...`)
- [x] TUI tests pass (`go test ./internal/tui/...`)
- [x] Code review passed with no issues