### PR TITLE
feat(config): add configurable worktree directory path

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -83,7 +83,7 @@ func New(baseDir string) (*Orchestrator, error) {
 // This is a legacy constructor that doesn't support multi-session - use NewWithSession instead.
 func NewWithConfig(baseDir string, cfg *config.Config) (*Orchestrator, error) {
 	claudioDir := filepath.Join(baseDir, ".claudio")
-	worktreeDir := filepath.Join(claudioDir, "worktrees")
+	worktreeDir := cfg.Paths.ResolveWorktreeDir(baseDir)
 
 	wt, err := worktree.New(baseDir)
 	if err != nil {
@@ -131,7 +131,7 @@ func NewWithConfig(baseDir string, cfg *config.Config) (*Orchestrator, error) {
 // The sessionID determines the storage location and lock file.
 func NewWithSession(baseDir, sessionID string, cfg *config.Config) (*Orchestrator, error) {
 	claudioDir := filepath.Join(baseDir, ".claudio")
-	worktreeDir := filepath.Join(claudioDir, "worktrees")
+	worktreeDir := cfg.Paths.ResolveWorktreeDir(baseDir)
 	sessionDir := session.GetSessionDir(baseDir, sessionID)
 
 	wt, err := worktree.New(baseDir)


### PR DESCRIPTION
## Summary

- Adds `PathsConfig` with a configurable `worktree_dir` setting to control where git worktrees are created
- Enables storing worktrees outside the repository (e.g., on a faster SSD, in a RAM disk, or to keep the project directory clean)
- Supports three path formats: absolute paths, paths with `~` home expansion, and relative paths (resolved against repo root)
- Maintains backward compatibility by defaulting to `.claudio/worktrees` when unset

## Changes

| File | Description |
|------|-------------|
| `internal/config/config.go` | Added `PathsConfig` struct and `ResolveWorktreeDir()` method with home dir expansion and relative path resolution |
| `internal/config/config_test.go` | Tests for path resolution logic covering all path formats |
| `internal/config/validator.go` | Validation for null bytes and excessive path length |
| `internal/config/validator_test.go` | Tests for path validation edge cases |
| `internal/orchestrator/orchestrator.go` | Updated `NewWithConfig` and `NewWithSession` to use the resolved worktree path |

## Example Configuration

```yaml
paths:
  # Absolute path
  worktree_dir: /fast-ssd/claudio-worktrees
  
  # Home directory
  worktree_dir: ~/claudio-worktrees
  
  # Relative to repo (less common)
  worktree_dir: .worktrees
```

## Test plan

- [x] `TestConfig_PathsConfig_Defaults` - empty default
- [x] `TestPathsConfig_ResolveWorktreeDir` - all path resolution cases
- [x] `TestPathsConfig_ResolveWorktreeDir_ViperLoading` - config loading
- [x] `TestConfig_Validate_Paths` - validation edge cases