### PR TITLE
feat(tui): highlight 'New Task' entry in sidebar when adding task

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -542,3 +542,8 @@ func (m Model) TerminalWidth() int {
 func (m Model) TerminalHeight() int {
 	return m.height
 }
+
+// IsAddingTask returns whether the user is currently adding a new task
+func (m Model) IsAddingTask() bool {
+	return m.addingTask
+}


### PR DESCRIPTION
## Summary
- When pressing `[a]` to add a new task in normal Claudio mode, the sidebar now shows a highlighted "New Task" entry at the bottom
- Existing instances are no longer highlighted during task addition, reducing user confusion about which item is selected
- Adds `IsAddingTask()` method to the `DashboardState` interface to expose the task-adding state to the view layer

## Test plan
- [ ] Start Claudio with no instances, press `[a]` - verify "New Task" entry appears highlighted
- [ ] Start Claudio with existing instances, press `[a]` - verify existing instances are dimmed and "New Task" appears highlighted at bottom
- [ ] Press `Escape` to cancel - verify selection returns to previous instance
- [ ] Submit a new task - verify the new instance becomes selected