### PR TITLE
feat(tui): add persistent terminal pane at bottom of screen

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -417,6 +417,11 @@ func (o *Orchestrator) SessionID() string {
 	return o.sessionID
 }
 
+// BaseDir returns the base directory (where Claudio was invoked)
+func (o *Orchestrator) BaseDir() string {
+	return o.baseDir
+}
+
 // ReleaseLock releases the session lock if one is held.
 // Safe to call multiple times.
 func (o *Orchestrator) ReleaseLock() error {

--- a/internal/tui/command_test.go
+++ b/internal/tui/command_test.go
@@ -514,7 +514,7 @@ func TestCommandAliasesRequiringInstance(t *testing.T) {
 		"D", "remove",
 		"kill",
 		// Utilities
-		"t", "tmux",
+		"tmux", // Note: :t is now a normal mode key for terminal, not a command
 		"r", "pr",
 	}
 

--- a/internal/tui/styles/styles.go
+++ b/internal/tui/styles/styles.go
@@ -263,6 +263,25 @@ var (
 
 	FilterCheckboxEmpty = lipgloss.NewStyle().
 				Foreground(MutedColor)
+
+	// Terminal pane styles
+	TerminalPaneBorder = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(BorderColor).
+				Padding(0, 1)
+
+	TerminalPaneBorderFocused = lipgloss.NewStyle().
+					Border(lipgloss.RoundedBorder()).
+					BorderForeground(SecondaryColor).
+					Padding(0, 1)
+
+	TerminalHeader = lipgloss.NewStyle().
+			Foreground(MutedColor)
+
+	TerminalFocusIndicator = lipgloss.NewStyle().
+				Background(SecondaryColor).
+				Foreground(TextColor).
+				Bold(true)
 )
 
 // StatusColor returns the color for a given status

--- a/internal/tui/terminal/process.go
+++ b/internal/tui/terminal/process.go
@@ -1,0 +1,359 @@
+// Package terminal provides a persistent shell session for the TUI terminal pane.
+package terminal
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Common errors for terminal process management.
+var (
+	ErrAlreadyRunning = errors.New("terminal process is already running")
+	ErrNotRunning     = errors.New("terminal process is not running")
+)
+
+// Process manages a persistent shell session in a tmux session for the terminal pane.
+// Unlike the instance TmuxProcess, this runs a plain shell (no Claude command).
+type Process struct {
+	sessionName   string // tmux session name
+	invocationDir string // Directory where Claudio was invoked (never changes)
+	currentDir    string // Current working directory
+	width         int
+	height        int
+
+	mu      sync.RWMutex
+	running bool
+}
+
+// NewProcess creates a new terminal process manager.
+// sessionID should be the Claudio session ID to ensure unique tmux session names.
+// invocationDir is the directory where Claudio was launched.
+func NewProcess(sessionID, invocationDir string, width, height int) *Process {
+	return &Process{
+		sessionName:   fmt.Sprintf("claudio-term-%s", sessionID),
+		invocationDir: invocationDir,
+		currentDir:    invocationDir,
+		width:         width,
+		height:        height,
+	}
+}
+
+// Start launches the terminal shell in a tmux session.
+func (p *Process) Start() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.startLocked()
+}
+
+// startLocked is the internal start implementation that assumes the lock is already held.
+func (p *Process) startLocked() error {
+	if p.running {
+		return ErrAlreadyRunning
+	}
+
+	// Kill any existing session with this name (cleanup from previous run)
+	if err := exec.Command("tmux", "kill-session", "-t", p.sessionName).Run(); err != nil {
+		if !isSessionNotFoundError(err) {
+			log.Printf("WARNING: failed to cleanup existing terminal tmux session %s: %v", p.sessionName, err)
+		}
+	}
+
+	// Determine dimensions
+	width := p.width
+	if width == 0 {
+		width = 200
+	}
+	height := p.height
+	if height == 0 {
+		height = 10
+	}
+
+	// Create a new detached tmux session
+	createCmd := exec.Command("tmux",
+		"new-session",
+		"-d",
+		"-s", p.sessionName,
+		"-x", fmt.Sprintf("%d", width),
+		"-y", fmt.Sprintf("%d", height),
+		"-c", p.currentDir, // Start in the current directory
+	)
+	if err := createCmd.Run(); err != nil {
+		return fmt.Errorf("failed to create terminal tmux session: %w", err)
+	}
+
+	// Set up tmux session options
+	if err := exec.Command("tmux", "set-option", "-t", p.sessionName, "history-limit", "10000").Run(); err != nil {
+		log.Printf("WARNING: failed to set history-limit for terminal tmux session %s: %v", p.sessionName, err)
+	}
+	if err := exec.Command("tmux", "set-option", "-t", p.sessionName, "default-terminal", "xterm-256color").Run(); err != nil {
+		log.Printf("WARNING: failed to set default-terminal for terminal tmux session %s: %v", p.sessionName, err)
+	}
+
+	p.running = true
+
+	return nil
+}
+
+// Stop terminates the terminal session.
+func (p *Process) Stop() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.running {
+		return nil
+	}
+
+	// Kill the tmux session
+	if err := exec.Command("tmux", "kill-session", "-t", p.sessionName).Run(); err != nil {
+		if !isSessionNotFoundError(err) {
+			log.Printf("WARNING: unexpected error killing terminal tmux session %s: %v", p.sessionName, err)
+		}
+	}
+
+	p.running = false
+	return nil
+}
+
+// IsRunning returns whether the terminal process is currently running.
+func (p *Process) IsRunning() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.running
+}
+
+// SessionExists checks if the tmux session still exists.
+func (p *Process) SessionExists() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.sessionExists()
+}
+
+func (p *Process) sessionExists() bool {
+	cmd := exec.Command("tmux", "has-session", "-t", p.sessionName)
+	return cmd.Run() == nil
+}
+
+// EnsureRunning starts the process if it's not running, or restarts if the session died.
+func (p *Process) EnsureRunning() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// If we think it's running, verify the session exists
+	if p.running && !p.sessionExists() {
+		p.running = false
+	}
+
+	if p.running {
+		return nil
+	}
+
+	return p.startLocked()
+}
+
+// ChangeDirectory changes the terminal's working directory.
+func (p *Process) ChangeDirectory(dir string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.running {
+		// Just update the stored directory; it will be used when we start
+		p.currentDir = dir
+		return nil
+	}
+
+	// Send cd command to the terminal
+	cdCmd := fmt.Sprintf("cd %q", dir)
+	if err := exec.Command("tmux", "send-keys", "-t", p.sessionName, cdCmd, "Enter").Run(); err != nil {
+		return fmt.Errorf("failed to change directory: %w", err)
+	}
+
+	p.currentDir = dir
+	return nil
+}
+
+// CurrentDir returns the current working directory of the terminal.
+func (p *Process) CurrentDir() string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.currentDir
+}
+
+// InvocationDir returns the directory where Claudio was invoked.
+func (p *Process) InvocationDir() string {
+	return p.invocationDir
+}
+
+// SendKey sends a special key (like "Enter", "C-c", "Up") to the terminal.
+func (p *Process) SendKey(key string) error {
+	p.mu.RLock()
+	running := p.running
+	sessionName := p.sessionName
+	p.mu.RUnlock()
+
+	if !running {
+		return ErrNotRunning
+	}
+
+	if err := exec.Command("tmux", "send-keys", "-t", sessionName, key).Run(); err != nil {
+		return fmt.Errorf("failed to send key to terminal: %w", err)
+	}
+	return nil
+}
+
+// SendLiteral sends literal text to the terminal (characters sent as-is).
+func (p *Process) SendLiteral(text string) error {
+	p.mu.RLock()
+	running := p.running
+	sessionName := p.sessionName
+	p.mu.RUnlock()
+
+	if !running {
+		return ErrNotRunning
+	}
+
+	if err := exec.Command("tmux", "send-keys", "-t", sessionName, "-l", text).Run(); err != nil {
+		return fmt.Errorf("failed to send literal to terminal: %w", err)
+	}
+	return nil
+}
+
+// SendPaste sends pasted text with bracketed paste sequences.
+func (p *Process) SendPaste(text string) error {
+	p.mu.RLock()
+	running := p.running
+	sessionName := p.sessionName
+	p.mu.RUnlock()
+
+	if !running {
+		return ErrNotRunning
+	}
+
+	// Send bracketed paste start sequence
+	if err := exec.Command("tmux", "send-keys", "-t", sessionName, "-l", "\x1b[200~").Run(); err != nil {
+		return fmt.Errorf("failed to send paste start: %w", err)
+	}
+
+	// Send the pasted content
+	if err := exec.Command("tmux", "send-keys", "-t", sessionName, "-l", text).Run(); err != nil {
+		return fmt.Errorf("failed to send paste content: %w", err)
+	}
+
+	// Send bracketed paste end sequence
+	if err := exec.Command("tmux", "send-keys", "-t", sessionName, "-l", "\x1b[201~").Run(); err != nil {
+		return fmt.Errorf("failed to send paste end: %w", err)
+	}
+
+	return nil
+}
+
+// CaptureOutput captures the current visible content of the terminal pane.
+func (p *Process) CaptureOutput() (string, error) {
+	p.mu.RLock()
+	running := p.running
+	sessionName := p.sessionName
+	p.mu.RUnlock()
+
+	if !running {
+		return "", ErrNotRunning
+	}
+
+	// Capture visible pane content
+	cmd := exec.Command("tmux", "capture-pane", "-t", sessionName, "-p")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to capture terminal output: %w", err)
+	}
+
+	return string(output), nil
+}
+
+// CaptureOutputWithHistory captures terminal content including scrollback history.
+func (p *Process) CaptureOutputWithHistory(lines int) (string, error) {
+	p.mu.RLock()
+	running := p.running
+	sessionName := p.sessionName
+	p.mu.RUnlock()
+
+	if !running {
+		return "", ErrNotRunning
+	}
+
+	// Capture with history (-S for start line, negative means history)
+	cmd := exec.Command("tmux", "capture-pane", "-t", sessionName, "-p", "-S", fmt.Sprintf("-%d", lines))
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to capture terminal output with history: %w", err)
+	}
+
+	return string(output), nil
+}
+
+// Resize adjusts the terminal dimensions.
+func (p *Process) Resize(width, height int) error {
+	p.mu.Lock()
+	p.width = width
+	p.height = height
+	running := p.running
+	sessionName := p.sessionName
+	p.mu.Unlock()
+
+	if !running {
+		return nil
+	}
+
+	resizeCmd := exec.Command("tmux",
+		"resize-window",
+		"-t", sessionName,
+		"-x", fmt.Sprintf("%d", width),
+		"-y", fmt.Sprintf("%d", height),
+	)
+	if err := resizeCmd.Run(); err != nil {
+		return fmt.Errorf("failed to resize terminal: %w", err)
+	}
+
+	return nil
+}
+
+// AttachCommand returns the command to attach to this terminal's tmux session.
+func (p *Process) AttachCommand() string {
+	return fmt.Sprintf("tmux attach -t %s", p.sessionName)
+}
+
+// SessionName returns the tmux session name.
+func (p *Process) SessionName() string {
+	return p.sessionName
+}
+
+// WaitForPrompt waits for the shell prompt to appear (basic readiness check).
+func (p *Process) WaitForPrompt(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		output, err := p.CaptureOutput()
+		if err != nil {
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		// Check for common prompt indicators
+		if strings.Contains(output, "$") || strings.Contains(output, "%") || strings.Contains(output, ">") {
+			return nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("timeout waiting for shell prompt")
+}
+
+// isSessionNotFoundError checks if the error indicates a tmux session was not found.
+func isSessionNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return strings.Contains(errStr, "session not found") ||
+		strings.Contains(errStr, "no server running") ||
+		strings.Contains(errStr, "can't find session")
+}

--- a/internal/tui/view/terminal.go
+++ b/internal/tui/view/terminal.go
@@ -1,0 +1,161 @@
+// Package view provides reusable view components for the TUI.
+package view
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/Iron-Ham/claudio/internal/tui/styles"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// TerminalView handles rendering of the terminal pane at the bottom of the screen.
+type TerminalView struct {
+	Width  int
+	Height int
+}
+
+// NewTerminalView creates a new TerminalView with the given dimensions.
+func NewTerminalView(width, height int) *TerminalView {
+	return &TerminalView{
+		Width:  width,
+		Height: height,
+	}
+}
+
+// TerminalState holds the state needed for rendering the terminal pane.
+type TerminalState struct {
+	// Output is the current terminal output
+	Output string
+	// IsWorktreeMode indicates whether we're in worktree mode (true) or invocation dir mode (false)
+	IsWorktreeMode bool
+	// CurrentDir is the current working directory of the terminal
+	CurrentDir string
+	// InvocationDir is the directory where Claudio was invoked
+	InvocationDir string
+	// TerminalMode indicates if the terminal has input focus
+	TerminalMode bool
+	// InstanceID is the active instance ID (for worktree mode display)
+	InstanceID string
+}
+
+// Render renders the complete terminal pane.
+func (v *TerminalView) Render(state TerminalState) string {
+	if v.Height < 2 {
+		return ""
+	}
+
+	var b strings.Builder
+
+	// Header line with directory info and mode indicator
+	header := v.renderHeader(state)
+	b.WriteString(header)
+	b.WriteString("\n")
+
+	// Output area (remaining height minus header)
+	outputHeight := v.Height - 2 // 1 for header, 1 for border
+	if outputHeight < 1 {
+		outputHeight = 1
+	}
+	output := v.renderOutput(state.Output, outputHeight)
+	b.WriteString(output)
+
+	// Apply border style
+	borderStyle := styles.TerminalPaneBorder
+	if state.TerminalMode {
+		borderStyle = styles.TerminalPaneBorderFocused
+	}
+
+	return borderStyle.
+		Width(v.Width - 2). // Account for border
+		Height(v.Height).
+		MaxHeight(v.Height).
+		Render(b.String())
+}
+
+// renderHeader renders the terminal pane header line.
+func (v *TerminalView) renderHeader(state TerminalState) string {
+	// Mode indicator
+	var modeStr string
+	if state.IsWorktreeMode {
+		if state.InstanceID != "" {
+			modeStr = "[worktree:" + state.InstanceID + "]"
+		} else {
+			modeStr = "[worktree]"
+		}
+	} else {
+		modeStr = "[invoke]"
+	}
+
+	// Shorten the directory path for display
+	displayDir := state.CurrentDir
+	if state.InvocationDir != "" && strings.HasPrefix(displayDir, state.InvocationDir) {
+		relPath, err := filepath.Rel(state.InvocationDir, displayDir)
+		if err == nil && relPath != "." {
+			displayDir = "./" + relPath
+		} else if relPath == "." {
+			displayDir = "."
+		}
+	}
+
+	// Focus indicator
+	focusIndicator := ""
+	if state.TerminalMode {
+		focusIndicator = styles.TerminalFocusIndicator.Render(" TERMINAL ")
+	}
+
+	// Build header
+	header := styles.TerminalHeader.Render(modeStr + " " + displayDir)
+	if focusIndicator != "" {
+		header = focusIndicator + " " + header
+	}
+
+	// Truncate if too long
+	maxWidth := v.Width - 4 // Account for borders and padding
+	if lipgloss.Width(header) > maxWidth {
+		header = truncateString(header, maxWidth)
+	}
+
+	return header
+}
+
+// renderOutput renders the terminal output area.
+func (v *TerminalView) renderOutput(output string, height int) string {
+	if output == "" {
+		// Show placeholder text when terminal is empty
+		placeholder := styles.Muted.Render("(shell ready)")
+		return placeholder
+	}
+
+	// Split into lines
+	lines := strings.Split(output, "\n")
+
+	// Take only the last 'height' lines (most recent output)
+	if len(lines) > height {
+		lines = lines[len(lines)-height:]
+	}
+
+	// Trim trailing empty lines (tmux capture often includes them)
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	// Join and return
+	return strings.Join(lines, "\n")
+}
+
+// truncateString truncates a string to the given width, adding ellipsis if needed.
+func truncateString(s string, maxWidth int) string {
+	if maxWidth <= 3 {
+		return "..."
+	}
+	if lipgloss.Width(s) <= maxWidth {
+		return s
+	}
+	// Simple truncation (doesn't handle ANSI codes perfectly)
+	runes := []rune(s)
+	if len(runes) > maxWidth-3 {
+		return string(runes[:maxWidth-3]) + "..."
+	}
+	return s
+}


### PR DESCRIPTION
## Summary
- Adds a persistent terminal pane at the bottom of the TUI screen in standard mode
- Terminal runs in a tmux session for shell persistence across toggles
- Supports switching between worktree directory mode (follows active instance) and invocation directory mode
- Integrates with existing mode system (normal → terminal mode for input focus)

## Key Features
- **Toggle visibility**: Backtick (`) or `T` to show/hide terminal pane
- **Enter terminal mode**: `t` when terminal is visible to give it input focus
- **Exit terminal mode**: `Ctrl+]` to return to normal mode
- **Switch directory mode**: `Ctrl+Shift+T` to toggle between worktree and invocation dir
- **Commands**: `:term`, `:terminal`, `:termdir worktree`, `:termdir invoke`

## Technical Details
- New `internal/tui/terminal/process.go` - manages tmux session for terminal pane
- New `internal/tui/view/terminal.go` - renders terminal pane with header showing mode/directory
- Updates to `internal/tui/model.go` - terminal state fields and helpers
- Updates to `internal/tui/app.go` - key handling, view integration, commands

## Test plan
- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [x] gofmt compliance
- [ ] Manual testing: toggle terminal visibility with backtick
- [ ] Manual testing: enter/exit terminal mode with t/Ctrl+]
- [ ] Manual testing: switch directory modes with Ctrl+Shift+T
- [ ] Manual testing: verify terminal follows active instance in worktree mode