### PR TITLE
fix(tui): require command mode for quit, remove q and ctrl+c shortcuts

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -683,17 +683,6 @@ func (m Model) handleKeypress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.commandBuffer = ""
 		return m, nil
 
-	case "q", "ctrl+c":
-		m.quitting = true
-		// Cleanup terminal pane if running
-		m.cleanupTerminal()
-		// Log session end with duration
-		if m.logger != nil {
-			duration := time.Since(m.startTime)
-			m.logger.Info("TUI session ended", "duration_ms", duration.Milliseconds())
-		}
-		return m, tea.Quit
-
 	case "?":
 		m.showHelp = !m.showHelp
 		return m, nil
@@ -2706,7 +2695,7 @@ Input Mode Details:
 
 General:
   ?              Quick toggle help
-  q              Quick quit
+  :q             Quit (via command mode)
   Auto-scroll follows new output. Scroll up to pause,
   press G to resume. "NEW OUTPUT" appears when paused.
 `
@@ -2903,7 +2892,7 @@ func (m Model) renderHelp() string {
 		styles.HelpKey.Render("[i]") + " input",
 		styles.HelpKey.Render("[/]") + " search",
 		styles.HelpKey.Render("[?]") + " help",
-		styles.HelpKey.Render("[q]") + " quit",
+		styles.HelpKey.Render("[:q]") + " quit",
 	}
 
 	// Add terminal key based on visibility

--- a/internal/tui/config/config.go
+++ b/internal/tui/config/config.go
@@ -335,7 +335,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		switch msg.String() {
-		case "q", "ctrl+c":
+		case "esc":
 			if m.configModified {
 				m.infoMsg = "Changes saved!"
 			}
@@ -612,7 +612,7 @@ func (m Model) renderHelp() string {
 			keyStyle.Render("tab") + " next category  " +
 			keyStyle.Render("enter/space") + " edit  " +
 			keyStyle.Render("r") + " reset  " +
-			keyStyle.Render("q") + " quit",
+			keyStyle.Render("esc") + " quit",
 	)
 }
 

--- a/internal/tui/view/ultraplan.go
+++ b/internal/tui/view/ultraplan.go
@@ -1066,7 +1066,7 @@ func (v *UltraplanView) RenderHelp() string {
 	}
 
 	// Common keys
-	keys = append(keys, "[q] quit")
+	keys = append(keys, "[:q] quit")
 	keys = append(keys, "[↑↓] nav")
 
 	// Phase-specific keys


### PR DESCRIPTION
## Summary

- Remove direct `q` and `ctrl+c` quit shortcuts from main TUI keypress handler
- Quitting now requires command mode via `:q` or `:quit`
- Update config TUI to use `esc` for quit (simpler interface without command mode)
- Update all help text and help bars to reflect new behavior

## Motivation

Prevents accidental quits by requiring explicit intent through command mode, aligning with vim-style modal interface conventions where destructive actions should not be a single keypress away.

## Changes

| File | Change |
|------|--------|
| `internal/tui/app.go` | Remove `q` and `ctrl+c` from quit case, update help text to show `:q` |
| `internal/tui/config/config.go` | Change quit from `q`/`ctrl+c` to `esc` |
| `internal/tui/view/ultraplan.go` | Update help bar from `[q]` to `[:q]` |

## Notes

- `ctrl+c` still works at OS signal level (via SIGINT handler in `app.go:70-81`) for emergency exit
- The `:q` command in command mode (`app.go:1016`) is unchanged and remains the primary quit method
- Config TUI uses `esc` instead of `:q` since it's a simpler interface without command mode

## Test plan

- [x] Build passes (`go build ./...`)
- [x] TUI tests pass (`go test ./internal/tui/...`)
- [ ] Manual: Verify `q` no longer quits main TUI
- [ ] Manual: Verify `:q` still quits main TUI
- [ ] Manual: Verify `esc` quits config TUI
- [ ] Manual: Verify `ctrl+c` still works as emergency exit (OS signal)