### PR TITLE
fix(tui): require command mode for terminal focus

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -749,13 +749,6 @@ func (m Model) handleKeypress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.toggleTerminalVisibility(sessionID)
 		return m, nil
 
-	case "t":
-		// Enter terminal mode (if terminal is visible)
-		if m.terminalVisible {
-			m.enterTerminalMode()
-		}
-		return m, nil
-
 	case "ctrl+shift+t":
 		// Switch terminal directory mode (worktree <-> invocation)
 		if m.terminalVisible {
@@ -1069,6 +1062,15 @@ func (m Model) executeCommand(cmd string) (tea.Model, tea.Cmd) {
 		return m.cmdPR()
 
 	// Terminal pane commands
+	case "t":
+		// Enter terminal mode (focus terminal for typing)
+		if m.terminalVisible {
+			m.enterTerminalMode()
+			m.infoMessage = "Terminal focused. Press Ctrl+] to exit."
+		} else {
+			m.errorMessage = "Terminal not visible. Use :term to open it first."
+		}
+		return m, nil
 	case "term", "terminal":
 		return m.cmdTerminal()
 	case "termdir worktree", "termdir wt":
@@ -1384,7 +1386,7 @@ func (m Model) cmdTerminal() (tea.Model, tea.Cmd) {
 	}
 	m.toggleTerminalVisibility(sessionID)
 	if m.terminalVisible {
-		m.infoMessage = "Terminal pane opened. Press [t] to focus, [`] to hide."
+		m.infoMessage = "Terminal pane opened. Press [:t] to focus, [`] to hide."
 	} else {
 		m.infoMessage = "Terminal pane closed."
 	}
@@ -2656,12 +2658,19 @@ View Commands:
   :m :stats      Toggle metrics panel (tokens, cost, timing)
   :c :conflicts  Toggle conflict view (show merge conflicts)
   :f :filter     Open filter panel (filter output by category)
-  :t :tmux       Show tmux attach command for direct access
+  :tmux          Show tmux attach command for direct access
   :r :pr         Show PR creation command for the instance
 
 Session Commands:
   :h :help       Toggle this help panel
   :q :quit       Quit Claudio (instances continue in tmux)
+
+Terminal Pane:
+  Backtick       Toggle terminal pane visibility
+  :term          Toggle terminal pane (same as backtick)
+  :t             Focus terminal pane for typing
+  Ctrl+]         Exit terminal typing mode
+  Ctrl+Shift+T   Switch terminal directory (worktree/invocation)
 
 Input Mode:
   i / Enter      Enter input mode (interact with Claude)
@@ -2897,7 +2906,7 @@ func (m Model) renderHelp() string {
 
 	// Add terminal key based on visibility
 	if m.terminalVisible {
-		keys = append(keys, styles.HelpKey.Render("[t]")+" term "+styles.HelpKey.Render("[`]")+" hide")
+		keys = append(keys, styles.HelpKey.Render("[:t]")+" term "+styles.HelpKey.Render("[`]")+" hide")
 	} else {
 		keys = append(keys, styles.HelpKey.Render("[`]")+" term")
 	}

--- a/internal/tui/view/instance.go
+++ b/internal/tui/view/instance.go
@@ -253,7 +253,7 @@ func (v *InstanceView) RenderStatusBanner(isRunning, inputMode bool) string {
 		Render("RUNNING")
 	return runningBanner + "  " + styles.Muted.Render("Press ") +
 		styles.HelpKey.Render("[i]") + styles.Muted.Render(" to interact  ") +
-		styles.HelpKey.Render("[t]") + styles.Muted.Render(" for tmux attach cmd")
+		styles.HelpKey.Render("[:tmux]") + styles.Muted.Render(" for tmux attach cmd")
 }
 
 // RenderOutput renders the output area with scrolling support.


### PR DESCRIPTION
## Summary
- Move terminal focus shortcut from direct `t` key to `:t` command mode
- Prevents accidentally triggering terminal focus when typing in the TUI
- Update all help text and documentation to reflect the new behavior

## Changes
- Remove `t` key binding from normal keypress handler (`handleKeypress`)
- Add `:t` command to `executeCommand` for entering terminal mode
- Update help text from `[t]` to `[:t]` in help bar, help panel, and instance view
- Add new "Terminal Pane" section to the help panel documenting all terminal commands
- Add regression tests ensuring `t` key no longer triggers terminal mode

## Test plan
- [x] Run `go test ./internal/tui/...` - all tests pass
- [x] New `TestTerminalFocusCommand` tests verify:
  - `:t` command works when terminal is visible
  - `:t` shows error when terminal not visible  
  - `t` key in normal mode does NOT enter terminal mode (regression test)
  - `:t` is recognized as a valid command