### PR TITLE
feat(plan): add hierarchical GitHub issue creation

### DIFF
--- a/internal/plan/issue.go
+++ b/internal/plan/issue.go
@@ -22,6 +22,8 @@ type IssueCreationResult struct {
 	ParentIssueURL    string
 	SubIssueNumbers   map[string]int    // task_id -> issue_number
 	SubIssueURLs      map[string]string // task_id -> issue_url
+	GroupIssueNumbers []int             // group issue numbers (for groups with >1 task)
+	GroupIssueURLs    []string          // group issue URLs
 }
 
 // CreateIssue creates a GitHub issue using the gh CLI

--- a/internal/plan/template_test.go
+++ b/internal/plan/template_test.go
@@ -137,3 +137,116 @@ func TestRenderParentIssueBodyEmptySections(t *testing.T) {
 		t.Error("Body missing summary")
 	}
 }
+
+func TestRenderParentIssueBodyHierarchical(t *testing.T) {
+	plan := &orchestrator.PlanSpec{
+		Objective:   "Test objective",
+		Summary:     "Test summary for hierarchical parent",
+		Insights:    []string{"Insight 1"},
+		Constraints: []string{"Constraint 1"},
+	}
+
+	children := []ParentChild{
+		{Title: "Group 1: Foundation", IssueNumber: 101, IsGroup: true, TaskCount: 5},
+		{Title: "Single Task", IssueNumber: 102, IsGroup: false, TaskCount: 1},
+		{Title: "Group 2: Implementation", IssueNumber: 103, IsGroup: true, TaskCount: 3},
+	}
+
+	body, err := RenderParentIssueBodyHierarchical(plan, children)
+	if err != nil {
+		t.Fatalf("RenderParentIssueBodyHierarchical() error = %v", err)
+	}
+
+	// Check summary
+	if !strings.Contains(body, "Test summary for hierarchical parent") {
+		t.Error("Body missing summary")
+	}
+
+	// Check group references with task counts
+	if !strings.Contains(body, "#101") {
+		t.Error("Body missing group 1 reference")
+	}
+	if !strings.Contains(body, "(5 tasks)") {
+		t.Error("Body missing group 1 task count")
+	}
+
+	// Check single task (no task count annotation)
+	if !strings.Contains(body, "#102") {
+		t.Error("Body missing single task reference")
+	}
+	if !strings.Contains(body, "Single Task") {
+		t.Error("Body missing single task title")
+	}
+
+	// Check insights and constraints
+	if !strings.Contains(body, "Insight 1") {
+		t.Error("Body missing insights")
+	}
+	if !strings.Contains(body, "Constraint 1") {
+		t.Error("Body missing constraints")
+	}
+}
+
+func TestRenderGroupIssueBody(t *testing.T) {
+	data := GroupIssueData{
+		Summary:         "This group can start immediately.",
+		DependsOnGroups: nil,
+		Tasks: []GroupedTask{
+			{TaskID: "task-1", Title: "First Task", IssueNumber: 201},
+			{TaskID: "task-2", Title: "Second Task", IssueNumber: 202},
+		},
+		ParentIssueNumber: 100,
+	}
+
+	body, err := RenderGroupIssueBody(data)
+	if err != nil {
+		t.Fatalf("RenderGroupIssueBody() error = %v", err)
+	}
+
+	// Check summary
+	if !strings.Contains(body, "This group can start immediately.") {
+		t.Error("Body missing summary")
+	}
+
+	// Check task references
+	if !strings.Contains(body, "#201") || !strings.Contains(body, "#202") {
+		t.Error("Body missing task references")
+	}
+	if !strings.Contains(body, "First Task") || !strings.Contains(body, "Second Task") {
+		t.Error("Body missing task titles")
+	}
+
+	// Check parent reference
+	if !strings.Contains(body, "#100") {
+		t.Error("Body missing parent reference")
+	}
+
+	// Check acceptance criteria
+	if !strings.Contains(body, "All 2 sub-issues completed") {
+		t.Error("Body missing acceptance criteria with task count")
+	}
+}
+
+func TestRenderGroupIssueBodyWithDependencies(t *testing.T) {
+	data := GroupIssueData{
+		Summary:         "This group depends on previous groups.",
+		DependsOnGroups: []int{1},
+		Tasks: []GroupedTask{
+			{TaskID: "task-3", Title: "Third Task", IssueNumber: 203},
+		},
+		ParentIssueNumber: 100,
+	}
+
+	body, err := RenderGroupIssueBody(data)
+	if err != nil {
+		t.Fatalf("RenderGroupIssueBody() error = %v", err)
+	}
+
+	// Check dependencies section
+	if !strings.Contains(body, "Complete these groups first") {
+		t.Error("Body missing dependencies section")
+	}
+	if !strings.Contains(body, "Group 1") {
+		t.Error("Body missing dependency group reference")
+	}
+}


### PR DESCRIPTION
## Summary

- Groups with multiple tasks now get their own intermediate group issue
- Single-task groups link directly to the parent (no unnecessary nesting)
- Creates proper hierarchy: Parent → Groups → Tasks

This enables proper organization like:
```
#244 (Epic)
├── #281 - Group 1: Foundation (17 tasks)
├── #282 - Group 2: Implementations (12 tasks)
├── #283 - Group 3: Phase Executors (6 tasks)
└── #280 - Refactor Coordinator (single task, no group)
```

## Changes

- Add `ParentChild` and `GroupIssueData` types for hierarchical rendering
- Update `CreateIssuesFromPlan` to create group issues for multi-task groups
- Add `generateGroupTitle` helper that detects common action prefixes (Extract, Implement, etc.)
- Add `generateGroupSummary` helper for dependency-aware group summaries
- Add validation for task lookups (fail fast on data inconsistencies)
- Add validation in `RenderGroupIssueBody` for required fields
- Make map iteration deterministic in `generateGroupTitle`

## Test plan

- [x] All existing tests pass
- [x] New tests added for `generateGroupTitle`, `generateGroupSummary`
- [x] New tests for `RenderParentIssueBodyHierarchical`, `RenderGroupIssueBody`
- [x] `go vet` and `gofmt` pass

Closes #244