### PR TITLE
perf(instance): implement differential capture for tmux output

### DIFF
--- a/internal/instance/manager_test.go
+++ b/internal/instance/manager_test.go
@@ -242,6 +242,29 @@ func TestDefaultManagerConfig(t *testing.T) {
 	}
 }
 
+func TestManager_DifferentialCaptureFieldsInitialized(t *testing.T) {
+	mgr := NewManager("test-diff-capture", "/tmp", "task")
+
+	// Verify differential capture fields are initialized to zero values
+	if mgr.lastHistorySize != 0 {
+		t.Errorf("lastHistorySize should be 0 initially, got %d", mgr.lastHistorySize)
+	}
+
+	if mgr.fullRefreshCounter != 0 {
+		t.Errorf("fullRefreshCounter should be 0 initially, got %d", mgr.fullRefreshCounter)
+	}
+}
+
+func TestManager_GetHistorySize_NoSession(t *testing.T) {
+	mgr := NewManager("nonexistent-hist-test", "/tmp", "task")
+
+	// getHistorySize should return -1 for a non-existent session
+	size := mgr.getHistorySize("nonexistent-session-xyz")
+	if size != -1 {
+		t.Errorf("getHistorySize for non-existent session should return -1, got %d", size)
+	}
+}
+
 func TestListClaudioTmuxSessions_NoTmuxServer(t *testing.T) {
 	// This test may return nil or an empty list depending on whether tmux is running
 	// The important thing is it should not error in a way that causes a panic


### PR DESCRIPTION
## Summary

- Implement differential capture strategy for tmux output to reduce CPU/IO overhead
- Track tmux history size to detect new output without capturing entire scrollback
- Capture only visible pane (~30 lines) when history unchanged vs full scrollback (10K lines)
- Full scrollback capture every 5 seconds or when history grows for completeness
- Add debug logging for capture failures instead of silent errors
- Add tests for locked session handling in discovery package

## Performance Impact

Before: Every 100ms, capture entire 10,000-line scrollback buffer (~2MB per poll)
After: Every 100ms, capture visible pane (~6KB) with periodic full refresh every 5s

Expected 90%+ reduction in data captured per poll cycle.

## Related Issue

See #291 for full optimization roadmap (Phases 2-4).

## Test plan

- [x] Run `go test ./internal/instance/...` - all tests pass
- [x] Run `go test ./internal/session/...` - all tests pass including new locked session tests
- [x] Run `go vet ./...` - no issues
- [x] Run `gofmt -d .` - no formatting issues
- [x] Build succeeds: `go build ./...`
- [ ] Manual test: Run claudio with multiple instances and verify output still updates correctly