### PR TITLE
refactor(tui): move ultraplan cancel to command mode for safety

### DIFF
--- a/internal/tui/ultraplan.go
+++ b/internal/tui/ultraplan.go
@@ -470,13 +470,8 @@ func (m Model) handleUltraPlanKeypress(msg tea.KeyMsg) (bool, tea.Model, tea.Cmd
 		}
 		return true, m, nil
 
-	case "c":
-		// Cancel execution (only during executing phase)
-		if session.Phase == orchestrator.PhaseExecuting {
-			m.ultraPlan.Coordinator.Cancel()
-			m.infoMessage = "Execution cancelled"
-		}
-		return true, m, nil
+	// NOTE: Cancel execution ('c') is now handled via command mode (:cancel)
+	// to prevent accidental cancellation from stray keypresses. See executeCommand() in app.go.
 
 	case "tab", "l":
 		// Navigate to next navigable instance across all phases

--- a/internal/tui/view/ultraplan.go
+++ b/internal/tui/view/ultraplan.go
@@ -1087,7 +1087,7 @@ func (v *UltraplanView) RenderHelp() string {
 		keys = append(keys, "[1-9] select task")
 		keys = append(keys, "[i] input mode")
 		keys = append(keys, "[v] toggle plan view")
-		keys = append(keys, "[c] cancel")
+		keys = append(keys, "[:cancel] cancel")
 
 	case orchestrator.PhaseSynthesis:
 		keys = append(keys, "[i] input mode")


### PR DESCRIPTION
## Summary

- Move cancel execution from bare `c` keypress to command mode (`:cancel`)
- Prevents accidental cancellation from stray keypresses in ultraplan mode
- Update help bar to show `[:cancel]` syntax

## Changes

- **internal/tui/ultraplan.go**: Remove `c` key handler from `handleUltraPlanKeypress()`
- **internal/tui/app.go**: Add `:cancel` command and `cmdUltraPlanCancel()` implementation
- **internal/tui/view/ultraplan.go**: Update help bar from `[c] cancel` to `[:cancel] cancel`

## Test plan

- [x] Build passes: `go build ./...`
- [x] Tests pass: `go test ./...`
- [x] Linting passes: `go vet ./...`
- [ ] Manual testing: During ultraplan execution, verify `c` no longer cancels, and `:cancel` + Enter does