### PR TITLE
feat(plan): group 2 - freeform issue parsers

### DIFF
--- a/.claude-prompt
+++ b/.claude-prompt
@@ -1,2 +1,66 @@
-The terminal doesn't clearly display user input, nor does it clearly display command output. 
-We should have a fully functional terminal there. It should also be taller; it's currently too short to be useful. 
+# Task: Add --issue flag to ultraplan command
+
+## Part of Ultra-Plan: Enable ingesting GitHub Issues as UltraPlan execution plans via a new --issue CLI flag. This requires extending the existing ingestion pipeline to support human-authored (freeform) issue formats in addition to the current templated format, plus CLI integration to wire the feature end-to-end.
+
+## Your Task
+
+Add a new --issue flag to the ultraplan CLI command that accepts a GitHub issue URL or shorthand (owner/repo#123). When provided, the plan is loaded from the GitHub issue instead of being generated.
+
+Modify internal/cmd/ultraplan.go:
+- Add `ultraplanIssueURL string` variable
+- Add flag: `--issue` with description 'Load plan from GitHub issue URL'
+- In runUltraplan():
+  - If --issue is set, call plan.BuildPlanFromURL()
+  - Use the returned PlanSpec instead of generating one
+  - Set objective from parent issue title
+  - Skip planning phase (jump to PhaseRefresh)
+- Add validation that --issue and --plan are mutually exclusive
+
+Update command help text with examples.
+
+## Expected Files
+
+You are expected to work with these files:
+- internal/cmd/ultraplan.go
+
+## Context from Previous Group
+
+This task builds on work consolidated from Group 4.
+
+**Consolidator Notes**: Successfully consolidated task-5-build-plan-freeform which completes the auto-detection support for the ingestion pipeline. The commit adds DetectParentIssueFormat() and ParseParentIssueBodyAuto() functions that mirror the sub-issue auto-detection pattern from group-3. The buildPlanFromGitHubIssue() and convertSubIssuesToTasks() functions now use auto-detection, enabling full support for all combinations of templated and freeform parent/sub-issues. Cherry-pick applied cleanly with no conflicts.
+
+**Important**: The previous group's consolidator flagged these issues:
+- The freeform parser infers complexity (defaults to medium) when not explicitly specified - document this behavior for users
+- Dependency extraction from freeform bodies finds all #N references inline - could document that users can mention dependencies naturally in prose
+- Consider adding CLI documentation for the --issue flag to explain that both templated (Claudio-generated) and freeform (human-authored) issues are supported
+- With Groups 1-4 complete, the ingestion pipeline is fully functional - next steps would be CLI integration to expose the --issue flag to users
+
+The consolidated code from the previous group has been verified (build/lint/tests passed).
+
+## Guidelines
+
+- Focus only on this specific task
+- Do not modify files outside of your assigned scope unless necessary
+- Commit your changes before writing the completion file
+
+## Completion Protocol
+
+When your task is complete, you MUST write a completion file to signal the orchestrator:
+
+1. Use Write tool to create `.claudio-task-complete.json` in your worktree root
+2. Include this JSON structure:
+```json
+{
+  "task_id": "task-6-cli-issue-flag",
+  "status": "complete",
+  "summary": "Brief description of what you accomplished",
+  "files_modified": ["list", "of", "files", "you", "changed"],
+  "notes": "Any implementation notes for the consolidation phase",
+  "issues": ["Any concerns or blocking issues found"],
+  "suggestions": ["Suggestions for integration with other tasks"],
+  "dependencies": ["Any new runtime dependencies added"]
+}
+```
+
+3. Use status "blocked" if you cannot complete (explain in issues), or "failed" if something broke
+4. This file signals that your work is done and provides context for consolidation

--- a/internal/plan/ingest.go
+++ b/internal/plan/ingest.go
@@ -50,6 +50,173 @@ var defaultExecutor CommandExecutor = func(name string, args ...string) ([]byte,
 	return cmd.CombinedOutput()
 }
 
+// =============================================================================
+// Error Types for GitHub Issue Ingestion
+// =============================================================================
+
+// IngestErrorKind categorizes the type of ingestion error.
+type IngestErrorKind string
+
+const (
+	// ErrKindGHNotInstalled indicates gh CLI is not installed or not in PATH.
+	ErrKindGHNotInstalled IngestErrorKind = "gh_not_installed"
+	// ErrKindAuthRequired indicates GitHub authentication is required.
+	ErrKindAuthRequired IngestErrorKind = "auth_required"
+	// ErrKindIssueNotFound indicates the requested issue does not exist (404).
+	ErrKindIssueNotFound IngestErrorKind = "issue_not_found"
+	// ErrKindRateLimited indicates the request was rate limited by GitHub.
+	ErrKindRateLimited IngestErrorKind = "rate_limited"
+	// ErrKindNoSubIssues indicates the parent issue has no sub-issues.
+	ErrKindNoSubIssues IngestErrorKind = "no_sub_issues"
+	// ErrKindParsingFailed indicates parsing the issue content failed.
+	ErrKindParsingFailed IngestErrorKind = "parsing_failed"
+	// ErrKindCircularDependency indicates a circular dependency was detected.
+	ErrKindCircularDependency IngestErrorKind = "circular_dependency"
+	// ErrKindUnsupportedProvider indicates the URL provider is not supported.
+	ErrKindUnsupportedProvider IngestErrorKind = "unsupported_provider"
+	// ErrKindRepoNotFound indicates the repository was not found or not accessible.
+	ErrKindRepoNotFound IngestErrorKind = "repo_not_found"
+)
+
+// IngestError is a structured error type for issue ingestion failures.
+// It provides context about which issue failed and suggestions for resolution.
+type IngestError struct {
+	// Kind categorizes the error type for programmatic handling.
+	Kind IngestErrorKind
+
+	// Message is the human-readable error description.
+	Message string
+
+	// IssueNum is the issue number that caused the error (0 if not applicable).
+	IssueNum int
+
+	// Owner is the repository owner (empty if not applicable).
+	Owner string
+
+	// Repo is the repository name (empty if not applicable).
+	Repo string
+
+	// Suggestion provides actionable advice for resolving the error.
+	Suggestion string
+
+	// Cause is the underlying error, if any.
+	Cause error
+}
+
+// Error implements the error interface.
+func (e *IngestError) Error() string {
+	var sb strings.Builder
+
+	sb.WriteString(e.Message)
+
+	if e.IssueNum > 0 {
+		sb.WriteString(fmt.Sprintf(" (issue #%d)", e.IssueNum))
+	}
+
+	if e.Owner != "" && e.Repo != "" {
+		sb.WriteString(fmt.Sprintf(" in %s/%s", e.Owner, e.Repo))
+	}
+
+	if e.Cause != nil {
+		sb.WriteString(fmt.Sprintf(": %v", e.Cause))
+	}
+
+	return sb.String()
+}
+
+// Unwrap returns the underlying error for use with errors.Is and errors.As.
+func (e *IngestError) Unwrap() error {
+	return e.Cause
+}
+
+// Is implements error matching for errors.Is().
+// It matches based on the Kind field when comparing with sentinel errors.
+func (e *IngestError) Is(target error) bool {
+	switch target {
+	case ErrGHNotInstalled:
+		return e.Kind == ErrKindGHNotInstalled
+	case ErrGHAuthRequired:
+		return e.Kind == ErrKindAuthRequired
+	case ErrIssueNotFound:
+		return e.Kind == ErrKindIssueNotFound
+	case ErrRateLimited:
+		return e.Kind == ErrKindRateLimited
+	case ErrNoSubIssues:
+		return e.Kind == ErrKindNoSubIssues
+	case ErrParsingFailed:
+		return e.Kind == ErrKindParsingFailed
+	case ErrCircularDependency:
+		return e.Kind == ErrKindCircularDependency
+	case ErrUnsupportedProvider:
+		return e.Kind == ErrKindUnsupportedProvider
+	case ErrRepoNotFound:
+		return e.Kind == ErrKindRepoNotFound
+	}
+	return false
+}
+
+// FormatForTerminal returns a user-friendly formatted string suitable for terminal output.
+// It includes the error message and suggestion (if any) formatted for CLI display.
+func (e *IngestError) FormatForTerminal() string {
+	var sb strings.Builder
+
+	// Error message with context
+	sb.WriteString("Error: ")
+	sb.WriteString(e.Message)
+
+	if e.IssueNum > 0 {
+		sb.WriteString(fmt.Sprintf(" (issue #%d)", e.IssueNum))
+	}
+
+	if e.Owner != "" && e.Repo != "" {
+		sb.WriteString(fmt.Sprintf(" in %s/%s", e.Owner, e.Repo))
+	}
+
+	// Add suggestion if available
+	if e.Suggestion != "" {
+		sb.WriteString("\n\nSuggestion: ")
+		sb.WriteString(e.Suggestion)
+	}
+
+	return sb.String()
+}
+
+// NewIngestError creates a new IngestError with the given parameters.
+func NewIngestError(kind IngestErrorKind, message string) *IngestError {
+	return &IngestError{
+		Kind:    kind,
+		Message: message,
+	}
+}
+
+// WithIssue adds issue context to the error.
+func (e *IngestError) WithIssue(issueNum int) *IngestError {
+	e.IssueNum = issueNum
+	return e
+}
+
+// WithRepo adds repository context to the error.
+func (e *IngestError) WithRepo(owner, repo string) *IngestError {
+	e.Owner = owner
+	e.Repo = repo
+	return e
+}
+
+// WithSuggestion adds a suggestion for resolving the error.
+func (e *IngestError) WithSuggestion(suggestion string) *IngestError {
+	e.Suggestion = suggestion
+	return e
+}
+
+// WithCause adds an underlying error.
+func (e *IngestError) WithCause(cause error) *IngestError {
+	e.Cause = cause
+	return e
+}
+
+// Sentinel errors for backward compatibility and errors.Is() matching.
+// These are kept for compatibility with existing code that uses errors.Is().
+
 // ErrGHNotInstalled indicates that the gh CLI tool is not installed or not in PATH.
 var ErrGHNotInstalled = errors.New("gh CLI is not installed or not in PATH")
 
@@ -58,6 +225,15 @@ var ErrGHAuthRequired = errors.New("gh CLI requires authentication (run 'gh auth
 
 // ErrIssueNotFound indicates that the requested issue does not exist.
 var ErrIssueNotFound = errors.New("issue not found")
+
+// ErrRateLimited indicates that the request was rate limited by GitHub.
+var ErrRateLimited = errors.New("rate limited by GitHub")
+
+// ErrCircularDependency indicates that a circular dependency was detected in sub-issues.
+var ErrCircularDependency = errors.New("circular dependency detected")
+
+// ErrRepoNotFound indicates that the repository was not found or not accessible.
+var ErrRepoNotFound = errors.New("repository not found")
 
 // FetchIssue fetches a GitHub issue by owner, repo, and issue number using the gh CLI.
 // It returns a GitHubIssue struct containing the issue data, or an error if the fetch fails.
@@ -119,13 +295,15 @@ func fetchIssueWithExecutor(owner, repo string, issueNum int, executor CommandEx
 
 // classifyGHError analyzes the error and output from a gh command
 // and returns a more specific error type when possible.
+// It returns *IngestError with appropriate context and suggestions.
 func classifyGHError(err error, output []byte, issueNum int) error {
 	outStr := strings.ToLower(string(output))
 
 	// Check for "executable file not found" which indicates gh is not installed
 	var execErr *exec.Error
 	if errors.As(err, &execErr) {
-		return ErrGHNotInstalled
+		return NewIngestError(ErrKindGHNotInstalled, "GitHub CLI (gh) is not installed or not in PATH").
+			WithSuggestion("Install the GitHub CLI: https://cli.github.com/")
 	}
 
 	// Check for common error patterns in output
@@ -133,19 +311,40 @@ func classifyGHError(err error, output []byte, issueNum int) error {
 	case strings.Contains(outStr, "not logged in") ||
 		strings.Contains(outStr, "authentication required") ||
 		strings.Contains(outStr, "gh auth login"):
-		return ErrGHAuthRequired
+		return NewIngestError(ErrKindAuthRequired, "GitHub authentication required").
+			WithIssue(issueNum).
+			WithSuggestion("Run 'gh auth login' to authenticate with GitHub")
+
+	case strings.Contains(outStr, "rate limit") ||
+		strings.Contains(outStr, "api rate limit") ||
+		strings.Contains(outStr, "secondary rate limit") ||
+		strings.Contains(outStr, "abuse detection"):
+		return NewIngestError(ErrKindRateLimited, "GitHub API rate limit exceeded").
+			WithIssue(issueNum).
+			WithSuggestion("Wait a few minutes and try again. If using a token, ensure it has sufficient rate limits.")
 
 	case strings.Contains(outStr, "could not find issue") ||
-		strings.Contains(outStr, "issue not found") ||
-		strings.Contains(outStr, "not found"):
-		return fmt.Errorf("%w: #%d", ErrIssueNotFound, issueNum)
+		strings.Contains(outStr, "issue not found"):
+		return NewIngestError(ErrKindIssueNotFound, "issue not found").
+			WithIssue(issueNum).
+			WithSuggestion("Verify the issue number exists and you have access to the repository")
 
 	case strings.Contains(outStr, "could not resolve to a repository"):
-		return fmt.Errorf("repository not found or not accessible")
+		return NewIngestError(ErrKindRepoNotFound, "repository not found or not accessible").
+			WithIssue(issueNum).
+			WithSuggestion("Check the repository name and ensure you have access. For private repos, run 'gh auth login'")
+
+	case strings.Contains(outStr, "not found"):
+		// Generic "not found" - could be issue or repo
+		return NewIngestError(ErrKindIssueNotFound, "resource not found").
+			WithIssue(issueNum).
+			WithSuggestion("Verify the issue number and repository are correct")
 	}
 
 	// Return the original error with output for debugging
-	return fmt.Errorf("gh command failed: %w\n%s", err, string(output))
+	return NewIngestError(ErrKindParsingFailed, "gh command failed").
+		WithIssue(issueNum).
+		WithCause(fmt.Errorf("%w\n%s", err, string(output)))
 }
 
 // GitHub issue URL patterns
@@ -809,31 +1008,56 @@ func buildPlanFromGitHubIssue(url string, executor CommandExecutor) (*orchestrat
 	// Step 2: Fetch the parent issue
 	parentIssue, err := fetchIssueWithExecutor(owner, repo, issueNum, executor)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch parent issue #%d: %w", issueNum, err)
+		// Enhance error with repo context if not already present
+		if ingestErr, ok := err.(*IngestError); ok {
+			return nil, ingestErr.WithRepo(owner, repo)
+		}
+		return nil, NewIngestError(ErrKindParsingFailed, "failed to fetch parent issue").
+			WithIssue(issueNum).
+			WithRepo(owner, repo).
+			WithCause(err)
 	}
 
-	// Step 3: Parse the parent issue body to extract structure
-	parentContent, err := ParseParentIssueBody(parentIssue.Body)
+	// Step 3: Detect format and parse the parent issue body to extract structure
+	// This supports both templated (Claudio-generated) and freeform (human-authored) issues
+	parentContent, err := ParseParentIssueBodyAuto(parentIssue.Body)
 	if err != nil {
-		return nil, fmt.Errorf("%w: failed to parse parent issue body: %v", ErrParsingFailed, err)
+		return nil, NewIngestError(ErrKindParsingFailed, "failed to parse parent issue body").
+			WithIssue(issueNum).
+			WithRepo(owner, repo).
+			WithCause(err).
+			WithSuggestion("Ensure the issue follows a supported format with sub-issues listed as #N references")
 	}
 
 	// Step 4: Collect all sub-issue numbers from execution groups
 	subIssueNums := collectSubIssueNumbers(parentContent.ExecutionGroups)
 	if len(subIssueNums) == 0 {
-		return nil, fmt.Errorf("%w: no sub-issues found in parent issue #%d", ErrNoSubIssues, issueNum)
+		return nil, NewIngestError(ErrKindNoSubIssues, "no sub-issues found in parent issue").
+			WithIssue(issueNum).
+			WithRepo(owner, repo).
+			WithSuggestion("The parent issue must reference sub-issues using #N syntax (e.g., '- [ ] #123 - Task title')")
 	}
 
 	// Step 5: Fetch all sub-issues and build the issue number to task ID mapping
-	subIssues, issueNumToTaskID, err := fetchSubIssuesWithMapping(owner, repo, subIssueNums, executor)
+	subIssues, issueNumToTaskID, err := fetchSubIssuesWithMappingEnhanced(owner, repo, subIssueNums, executor)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch sub-issues: %w", err)
+		// Error already has context from fetchSubIssuesWithMappingEnhanced
+		return nil, err
 	}
 
 	// Step 6: Convert each sub-issue to a PlannedTask
-	tasks, err := convertSubIssuesToTasks(subIssues, issueNumToTaskID)
+	// Pass the parent issue number for freeform sub-issues to exclude from dependencies
+	tasks, err := convertSubIssuesToTasksEnhanced(subIssues, issueNumToTaskID, issueNum, owner, repo)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert issues to tasks: %w", err)
+		// Error already has context from convertSubIssuesToTasksEnhanced
+		return nil, err
+	}
+
+	// Step 6.5: Check for circular dependencies
+	if cycle := detectCircularDependencies(tasks); cycle != nil {
+		return nil, NewIngestError(ErrKindCircularDependency, "circular dependency detected in sub-issues").
+			WithRepo(owner, repo).
+			WithSuggestion(fmt.Sprintf("Review the dependency chain: %s", formatDependencyCycle(cycle)))
 	}
 
 	// Step 7: Build execution order from parent's execution groups
@@ -879,16 +1103,24 @@ func collectSubIssueNumbers(executionGroups [][]int) []int {
 	return nums
 }
 
-// fetchSubIssuesWithMapping fetches all sub-issues and builds a mapping from
-// issue numbers to task IDs (which are generated from issue number and title)
-func fetchSubIssuesWithMapping(owner, repo string, issueNums []int, executor CommandExecutor) (map[int]*GitHubIssue, map[int]string, error) {
+// fetchSubIssuesWithMappingEnhanced fetches all sub-issues and builds a mapping from
+// issue numbers to task IDs (which are generated from issue number and title).
+// Returns *IngestError with detailed context for each failure.
+func fetchSubIssuesWithMappingEnhanced(owner, repo string, issueNums []int, executor CommandExecutor) (map[int]*GitHubIssue, map[int]string, error) {
 	issues := make(map[int]*GitHubIssue)
 	issueNumToTaskID := make(map[int]string)
 
 	for _, num := range issueNums {
 		issue, err := fetchIssueWithExecutor(owner, repo, num, executor)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to fetch sub-issue #%d: %w", num, err)
+			// Enhance error with repo context if not already present
+			if ingestErr, ok := err.(*IngestError); ok {
+				return nil, nil, ingestErr.WithRepo(owner, repo)
+			}
+			return nil, nil, NewIngestError(ErrKindParsingFailed, "failed to fetch sub-issue").
+				WithIssue(num).
+				WithRepo(owner, repo).
+				WithCause(err)
 		}
 		issues[num] = issue
 		// Generate task ID immediately so we can use it for dependency resolution
@@ -898,27 +1130,107 @@ func fetchSubIssuesWithMapping(owner, repo string, issueNums []int, executor Com
 	return issues, issueNumToTaskID, nil
 }
 
-// convertSubIssuesToTasks converts all fetched sub-issues to PlannedTasks
-func convertSubIssuesToTasks(subIssues map[int]*GitHubIssue, issueNumToTaskID map[int]string) ([]orchestrator.PlannedTask, error) {
+// convertSubIssuesToTasksEnhanced converts all fetched sub-issues to PlannedTasks.
+// The parentIssueNum is used for freeform issues to exclude the parent from dependencies.
+// Returns *IngestError with detailed context for each failure.
+func convertSubIssuesToTasksEnhanced(subIssues map[int]*GitHubIssue, issueNumToTaskID map[int]string, parentIssueNum int, owner, repo string) ([]orchestrator.PlannedTask, error) {
 	var tasks []orchestrator.PlannedTask
 
 	for num, issue := range subIssues {
-		// Parse the sub-issue body
-		content, err := ParseSubIssueBody(issue.Body)
+		// Parse the sub-issue body using auto-detection
+		// This supports both templated (Claudio-generated) and freeform (human-authored) sub-issues
+		content, err := ParseSubIssueBodyAuto(issue.Body, parentIssueNum)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse sub-issue #%d body: %w", num, err)
+			return nil, NewIngestError(ErrKindParsingFailed, "failed to parse sub-issue body").
+				WithIssue(num).
+				WithRepo(owner, repo).
+				WithCause(err).
+				WithSuggestion("Check that the sub-issue body contains a valid description")
 		}
 
 		// Convert to PlannedTask
 		task, err := ConvertToPlannedTask(*issue, *content, issueNumToTaskID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert sub-issue #%d to task: %w", num, err)
+			return nil, NewIngestError(ErrKindParsingFailed, "failed to convert sub-issue to task").
+				WithIssue(num).
+				WithRepo(owner, repo).
+				WithCause(err).
+				WithSuggestion("Ensure the sub-issue has a title and valid content")
 		}
 
 		tasks = append(tasks, task)
 	}
 
 	return tasks, nil
+}
+
+// detectCircularDependencies checks for circular dependencies in a list of tasks.
+// Returns the cycle as a slice of task IDs if found, or nil if no cycle exists.
+func detectCircularDependencies(tasks []orchestrator.PlannedTask) []string {
+	// Build adjacency list from task dependencies
+	deps := make(map[string][]string)
+	taskExists := make(map[string]bool)
+	for _, task := range tasks {
+		deps[task.ID] = task.DependsOn
+		taskExists[task.ID] = true
+	}
+
+	// Track visit state: 0=unvisited, 1=visiting (in current path), 2=visited (complete)
+	state := make(map[string]int)
+	var cyclePath []string
+
+	// DFS to detect cycles
+	var visit func(taskID string, path []string) bool
+	visit = func(taskID string, path []string) bool {
+		if state[taskID] == 1 {
+			// Found a cycle - extract just the cycle portion
+			for i, id := range path {
+				if id == taskID {
+					cyclePath = append(path[i:], taskID)
+					return true
+				}
+			}
+			cyclePath = append(path, taskID)
+			return true
+		}
+		if state[taskID] == 2 {
+			return false
+		}
+
+		state[taskID] = 1
+		path = append(path, taskID)
+
+		for _, depID := range deps[taskID] {
+			// Only check dependencies that exist in our task set
+			if taskExists[depID] && visit(depID, path) {
+				return true
+			}
+		}
+
+		state[taskID] = 2
+		return false
+	}
+
+	// Check all tasks
+	for _, task := range tasks {
+		if state[task.ID] == 0 {
+			if visit(task.ID, nil) {
+				return cyclePath
+			}
+		}
+	}
+
+	return nil
+}
+
+// formatDependencyCycle formats a cycle path for display.
+// Input: ["task-1", "task-2", "task-3", "task-1"]
+// Output: "task-1 -> task-2 -> task-3 -> task-1"
+func formatDependencyCycle(cycle []string) string {
+	if len(cycle) == 0 {
+		return ""
+	}
+	return strings.Join(cycle, " -> ")
 }
 
 // buildExecutionOrder converts issue number groups to task ID groups
@@ -1500,4 +1812,96 @@ func DetectIssueFormat(body string) IssueFormat {
 
 	// Everything else is considered freeform
 	return IssueFormatFreeform
+}
+
+// ParseSubIssueBodyAuto is a unified entry point that auto-detects the issue format
+// and delegates to the appropriate parser. This simplifies the ingestion pipeline
+// by providing a single function that handles both templated and freeform sub-issues.
+//
+// Parameters:
+//   - body: The markdown body of the sub-issue to parse
+//   - parentIssueNum: The parent issue number (used for freeform parsing to exclude
+//     the parent from dependencies; pass 0 if unknown)
+//
+// The function:
+//   - Detects the format using DetectIssueFormat
+//   - Delegates to ParseSubIssueBody for templated issues
+//   - Delegates to ParseFreeformSubIssueBody for freeform issues
+//
+// Returns a SubIssueContent struct with consistent fields regardless of input format.
+// For templated issues, the ParentIssueNum is extracted from the body.
+// For freeform issues, the parentIssueNum parameter is used.
+func ParseSubIssueBodyAuto(body string, parentIssueNum int) (*SubIssueContent, error) {
+	format := DetectIssueFormat(body)
+
+	switch format {
+	case IssueFormatTemplated:
+		return ParseSubIssueBody(body)
+	case IssueFormatFreeform:
+		return ParseFreeformSubIssueBody(body, parentIssueNum)
+	default:
+		// This should never happen given the current implementation,
+		// but we handle it gracefully by defaulting to freeform parsing
+		return ParseFreeformSubIssueBody(body, parentIssueNum)
+	}
+}
+
+// DetectParentIssueFormat determines whether a parent issue body is templated or freeform.
+// Parent issues are templated if they have:
+//   - "## Summary" section AND "## Sub-Issues" section with "### Group N" headers
+//
+// Parent issues are considered freeform if they:
+//   - Use human-authored structure (e.g., "## Overview", "## Tasks", generic headers)
+//   - Don't follow the strict Claudio parent template format
+func DetectParentIssueFormat(body string) IssueFormat {
+	if strings.TrimSpace(body) == "" {
+		return IssueFormatFreeform
+	}
+
+	// Check for templated parent issue markers by scanning each line
+	// (the regex patterns are line-anchored with ^)
+	var hasSummarySection, hasSubIssuesSection, hasGroupHeaders bool
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if summaryHeaderRe.MatchString(trimmed) {
+			hasSummarySection = true
+		}
+		if subIssuesHeaderRe.MatchString(trimmed) {
+			hasSubIssuesSection = true
+		}
+		if groupHeaderRe.MatchString(trimmed) {
+			hasGroupHeaders = true
+		}
+	}
+
+	// A parent issue is templated if it has Summary + Sub-Issues sections with Group headers
+	if hasSummarySection && hasSubIssuesSection && hasGroupHeaders {
+		return IssueFormatTemplated
+	}
+
+	return IssueFormatFreeform
+}
+
+// ParseParentIssueBodyAuto is a unified entry point that auto-detects the parent issue
+// format and delegates to the appropriate parser. This simplifies the ingestion pipeline
+// by providing a single function that handles both templated and freeform parent issues.
+//
+// The function:
+//   - Detects the format using DetectParentIssueFormat
+//   - Delegates to ParseParentIssueBody for templated issues
+//   - Delegates to ParseFreeformParentIssueBody for freeform issues
+//
+// Returns a ParentIssueContent struct with consistent fields regardless of input format.
+func ParseParentIssueBodyAuto(body string) (*ParentIssueContent, error) {
+	format := DetectParentIssueFormat(body)
+
+	switch format {
+	case IssueFormatTemplated:
+		return ParseParentIssueBody(body)
+	case IssueFormatFreeform:
+		return ParseFreeformParentIssueBody(body)
+	default:
+		// Default to freeform parsing for robustness
+		return ParseFreeformParentIssueBody(body)
+	}
 }

--- a/internal/plan/ingest_test.go
+++ b/internal/plan/ingest_test.go
@@ -2877,8 +2877,19 @@ func TestBuildPlanFromURL_ParentFetchFails(t *testing.T) {
 	if err == nil {
 		t.Error("expected error when parent issue fetch fails")
 	}
-	if !strings.Contains(err.Error(), "failed to fetch parent issue") {
-		t.Errorf("error should mention parent issue fetch failure: %v", err)
+
+	// The error should be an IngestError or contain relevant information
+	var ingestErr *IngestError
+	if errors.As(err, &ingestErr) {
+		// If it's an IngestError, check the issue number
+		if ingestErr.IssueNum != 999 {
+			t.Errorf("error should reference issue #999, got #%d", ingestErr.IssueNum)
+		}
+	} else {
+		// Fallback: check for issue number in error message
+		if !strings.Contains(err.Error(), "999") {
+			t.Errorf("error should mention parent issue #999: %v", err)
+		}
 	}
 }
 
@@ -2899,8 +2910,19 @@ func TestBuildPlanFromURL_SubIssueFetchFails(t *testing.T) {
 	if err == nil {
 		t.Error("expected error when sub-issue fetch fails")
 	}
-	if !strings.Contains(err.Error(), "failed to fetch sub-issue") {
-		t.Errorf("error should mention sub-issue fetch failure: %v", err)
+
+	// The error should indicate the sub-issue that failed
+	// Check if it's an IngestError with the correct issue number
+	var ingestErr *IngestError
+	if errors.As(err, &ingestErr) {
+		if ingestErr.IssueNum != 101 {
+			t.Errorf("error should reference issue #101, got #%d", ingestErr.IssueNum)
+		}
+	} else {
+		// Fallback check for string content
+		if !strings.Contains(err.Error(), "101") {
+			t.Errorf("error should mention sub-issue #101: %v", err)
+		}
 	}
 }
 
@@ -4992,5 +5014,1883 @@ func TestExtractFreeformDescription_Strategies(t *testing.T) {
 				t.Errorf("extractFreeformDescription() = %q, want to contain %q", got, tt.wantContain)
 			}
 		})
+	}
+}
+
+// =============================================================================
+// Unified Sub-Issue Parser Tests (task-4-unified-sub-parser)
+// =============================================================================
+
+func TestParseSubIssueBodyAuto_TemplatedFormat(t *testing.T) {
+	// Test that templated issues are correctly routed to ParseSubIssueBody
+	body := `## Task
+
+Implement the new authentication handler.
+
+## Files to Modify
+
+- ` + "`internal/auth/handler.go`" + `
+- ` + "`internal/auth/service.go`" + `
+
+## Dependencies
+
+- #41
+- #42
+
+## Complexity
+
+Estimated: **medium**
+
+---
+*Part of #100*
+`
+
+	content, err := ParseSubIssueBodyAuto(body, 0)
+	if err != nil {
+		t.Fatalf("ParseSubIssueBodyAuto() error = %v", err)
+	}
+
+	// Verify templated parsing results
+	if content.Description != "Implement the new authentication handler." {
+		t.Errorf("Description = %q, want %q", content.Description, "Implement the new authentication handler.")
+	}
+	if len(content.Files) != 2 {
+		t.Errorf("len(Files) = %d, want 2", len(content.Files))
+	}
+	if content.Complexity != "medium" {
+		t.Errorf("Complexity = %q, want %q", content.Complexity, "medium")
+	}
+	if content.ParentIssueNum != 100 {
+		t.Errorf("ParentIssueNum = %d, want 100", content.ParentIssueNum)
+	}
+	// Templated parsing gets dependencies from the Dependencies section
+	if len(content.DependencyIssueNums) != 2 {
+		t.Errorf("len(DependencyIssueNums) = %d, want 2", len(content.DependencyIssueNums))
+	}
+}
+
+func TestParseSubIssueBodyAuto_FreeformFormat(t *testing.T) {
+	// Test that freeform issues are correctly routed to ParseFreeformSubIssueBody
+	body := `This is a simple task description written by a human.
+
+We need to update the ` + "`config.go`" + ` file to support the new settings.
+
+See also #45 for related changes.
+`
+
+	content, err := ParseSubIssueBodyAuto(body, 100)
+	if err != nil {
+		t.Fatalf("ParseSubIssueBodyAuto() error = %v", err)
+	}
+
+	// Verify freeform parsing results
+	if !strings.Contains(content.Description, "simple task description") {
+		t.Errorf("Description = %q, should contain 'simple task description'", content.Description)
+	}
+	if len(content.Files) != 1 || content.Files[0] != "config.go" {
+		t.Errorf("Files = %v, want [config.go]", content.Files)
+	}
+	// Freeform defaults to medium complexity
+	if content.Complexity != "medium" {
+		t.Errorf("Complexity = %q, want %q", content.Complexity, "medium")
+	}
+	// ParentIssueNum comes from the parameter for freeform
+	if content.ParentIssueNum != 100 {
+		t.Errorf("ParentIssueNum = %d, want 100", content.ParentIssueNum)
+	}
+	// Should extract issue references (excluding parent)
+	if len(content.DependencyIssueNums) != 1 || content.DependencyIssueNums[0] != 45 {
+		t.Errorf("DependencyIssueNums = %v, want [45]", content.DependencyIssueNums)
+	}
+}
+
+func TestParseSubIssueBodyAuto_ConsistentOutput(t *testing.T) {
+	// Test that both formats produce SubIssueContent with all fields populated
+	tests := []struct {
+		name           string
+		body           string
+		parentIssueNum int
+		wantFormat     IssueFormat
+	}{
+		{
+			name: "templated with all fields",
+			body: `## Task
+
+Do the thing.
+
+## Files to Modify
+
+- ` + "`main.go`" + `
+
+## Dependencies
+
+- #10
+
+## Complexity
+
+Estimated: **low**
+
+---
+*Part of #50*
+`,
+			parentIssueNum: 0,
+			wantFormat:     IssueFormatTemplated,
+		},
+		{
+			name: "freeform with mentions",
+			body: `We need to update ` + "`handler.go`" + ` per #20.
+
+This is low complexity work.
+`,
+			parentIssueNum: 50,
+			wantFormat:     IssueFormatFreeform,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Verify format detection matches expected
+			gotFormat := DetectIssueFormat(tt.body)
+			if gotFormat != tt.wantFormat {
+				t.Errorf("DetectIssueFormat() = %q, want %q", gotFormat, tt.wantFormat)
+			}
+
+			// Parse and verify all fields are present
+			content, err := ParseSubIssueBodyAuto(tt.body, tt.parentIssueNum)
+			if err != nil {
+				t.Fatalf("ParseSubIssueBodyAuto() error = %v", err)
+			}
+
+			// Description should never be empty
+			if content.Description == "" {
+				t.Error("Description should not be empty")
+			}
+
+			// Complexity should always be set
+			if content.Complexity == "" {
+				t.Error("Complexity should not be empty")
+			}
+			validComplexities := map[string]bool{"low": true, "medium": true, "high": true}
+			if !validComplexities[content.Complexity] {
+				t.Errorf("Complexity = %q, want one of low/medium/high", content.Complexity)
+			}
+
+			// Files can be empty but should not be nil slice with entries
+			// (just verifying no panic occurs)
+			_ = len(content.Files)
+
+			// DependencyIssueNums can be empty
+			_ = len(content.DependencyIssueNums)
+		})
+	}
+}
+
+func TestParseSubIssueBodyAuto_EmptyBody(t *testing.T) {
+	// Empty body should fail (freeform parser rejects empty bodies)
+	_, err := ParseSubIssueBodyAuto("", 0)
+	if err == nil {
+		t.Error("ParseSubIssueBodyAuto() should error on empty body")
+	}
+}
+
+func TestParseSubIssueBodyAuto_WhitespaceOnlyBody(t *testing.T) {
+	// Whitespace-only body should fail
+	_, err := ParseSubIssueBodyAuto("   \n\t\n   ", 0)
+	if err == nil {
+		t.Error("ParseSubIssueBodyAuto() should error on whitespace-only body")
+	}
+}
+
+func TestParseSubIssueBodyAuto_TemplatedMissingRequiredSections(t *testing.T) {
+	// A body that looks templated but is missing required sections should fail
+	// Note: If it has *Part of #N* and ## Task, it's detected as templated
+	// but if Task section is empty, it should fail
+	body := `## Task
+
+## Complexity
+
+Estimated: **low**
+
+---
+*Part of #42*
+`
+	_, err := ParseSubIssueBodyAuto(body, 0)
+	if err == nil {
+		t.Error("ParseSubIssueBodyAuto() should error when Task section is empty")
+	}
+}
+
+func TestParseSubIssueBodyAuto_FreeformWithComplexity(t *testing.T) {
+	// Freeform issue with explicit complexity mentioned
+	body := `Add validation to the form.
+
+This is a low complexity change.
+`
+
+	content, err := ParseSubIssueBodyAuto(body, 10)
+	if err != nil {
+		t.Fatalf("ParseSubIssueBodyAuto() error = %v", err)
+	}
+
+	if content.Complexity != "low" {
+		t.Errorf("Complexity = %q, want %q", content.Complexity, "low")
+	}
+}
+
+func TestParseSubIssueBodyAuto_TemplatedParentExtraction(t *testing.T) {
+	// For templated issues, parent should be extracted from body, not parameter
+	body := `## Task
+
+Simple task.
+
+## Complexity
+
+Estimated: **high**
+
+---
+*Part of #999*
+`
+
+	// Pass different parentIssueNum - should be ignored for templated
+	content, err := ParseSubIssueBodyAuto(body, 123)
+	if err != nil {
+		t.Fatalf("ParseSubIssueBodyAuto() error = %v", err)
+	}
+
+	// Should use the value from the body, not the parameter
+	if content.ParentIssueNum != 999 {
+		t.Errorf("ParentIssueNum = %d, want 999 (from body)", content.ParentIssueNum)
+	}
+}
+
+func TestParseSubIssueBodyAuto_FreeformParentFromParam(t *testing.T) {
+	// For freeform issues, parent should come from parameter
+	body := `Just a simple freeform task description.
+`
+
+	content, err := ParseSubIssueBodyAuto(body, 456)
+	if err != nil {
+		t.Fatalf("ParseSubIssueBodyAuto() error = %v", err)
+	}
+
+	// Should use the parameter value
+	if content.ParentIssueNum != 456 {
+		t.Errorf("ParentIssueNum = %d, want 456 (from parameter)", content.ParentIssueNum)
+	}
+}
+
+func TestParseSubIssueBodyAuto_RealWorldTemplated(t *testing.T) {
+	// Real-world example of a Claudio-generated sub-issue
+	body := `## Task
+
+Create unified sub-issue parser that auto-detects format and delegates to the appropriate parser. This simplifies the ingestion pipeline.
+
+Implement:
+- ` + "`ParseSubIssueBodyAuto(body string, parentIssueNum int) (*SubIssueContent, error)`" + `
+- Detect format using task-1's detection function
+- Delegate to ParseSubIssueBody() for templated or ParseFreeformSubIssueBody() for freeform
+- Ensure consistent output regardless of input format
+
+## Files to Modify
+
+- ` + "`internal/plan/ingest.go`" + `
+- ` + "`internal/plan/ingest_test.go`" + `
+
+## Dependencies
+
+- #290
+- #291
+
+## Complexity
+
+Estimated: **medium**
+
+---
+*Part of #289*
+`
+
+	content, err := ParseSubIssueBodyAuto(body, 0)
+	if err != nil {
+		t.Fatalf("ParseSubIssueBodyAuto() error = %v", err)
+	}
+
+	if !strings.Contains(content.Description, "unified sub-issue parser") {
+		t.Errorf("Description should contain 'unified sub-issue parser', got %q", content.Description)
+	}
+	if len(content.Files) != 2 {
+		t.Errorf("len(Files) = %d, want 2", len(content.Files))
+	}
+	if content.Complexity != "medium" {
+		t.Errorf("Complexity = %q, want medium", content.Complexity)
+	}
+	if content.ParentIssueNum != 289 {
+		t.Errorf("ParentIssueNum = %d, want 289", content.ParentIssueNum)
+	}
+	if len(content.DependencyIssueNums) != 2 {
+		t.Errorf("len(DependencyIssueNums) = %d, want 2", len(content.DependencyIssueNums))
+	}
+}
+
+func TestParseSubIssueBodyAuto_RealWorldFreeform(t *testing.T) {
+	// Real-world example of a human-authored issue
+	body := `## Description
+
+We need to add support for parsing user-written GitHub issues that don't follow our template. The current parser is too strict and rejects valid issues.
+
+## Requirements
+
+- Handle issues without structured sections
+- Extract file paths from inline code mentions
+- Detect complexity from keywords
+
+## Files
+
+- ` + "`internal/plan/ingest.go`" + ` - main parser logic
+- ` + "`internal/plan/ingest_test.go`" + ` - tests
+
+## Related
+
+See #100 for the original feature request.
+`
+
+	content, err := ParseSubIssueBodyAuto(body, 50)
+	if err != nil {
+		t.Fatalf("ParseSubIssueBodyAuto() error = %v", err)
+	}
+
+	// Should extract description from the Description section
+	if !strings.Contains(content.Description, "parsing user-written GitHub issues") {
+		t.Errorf("Description should mention parsing, got %q", content.Description)
+	}
+
+	// Should find files mentioned in backticks
+	if len(content.Files) != 2 {
+		t.Errorf("len(Files) = %d, want 2, got %v", len(content.Files), content.Files)
+	}
+
+	// Should default to medium complexity
+	if content.Complexity != "medium" {
+		t.Errorf("Complexity = %q, want medium", content.Complexity)
+	}
+
+	// Should use parent from parameter
+	if content.ParentIssueNum != 50 {
+		t.Errorf("ParentIssueNum = %d, want 50", content.ParentIssueNum)
+	}
+
+	// Should extract issue reference #100
+	if len(content.DependencyIssueNums) != 1 || content.DependencyIssueNums[0] != 100 {
+		t.Errorf("DependencyIssueNums = %v, want [100]", content.DependencyIssueNums)
+	}
+}
+
+func TestParseSubIssueBodyAuto_BothFormatsProduceSameStructure(t *testing.T) {
+	// Create equivalent content in both formats and verify structure compatibility
+	templatedBody := `## Task
+
+Update the configuration parser.
+
+## Files to Modify
+
+- ` + "`config.go`" + `
+
+## Complexity
+
+Estimated: **low**
+
+---
+*Part of #100*
+`
+
+	freeformBody := `Update the configuration parser.
+
+Files: ` + "`config.go`" + `
+
+low complexity
+`
+
+	templatedContent, err := ParseSubIssueBodyAuto(templatedBody, 0)
+	if err != nil {
+		t.Fatalf("ParseSubIssueBodyAuto(templated) error = %v", err)
+	}
+
+	freeformContent, err := ParseSubIssueBodyAuto(freeformBody, 100)
+	if err != nil {
+		t.Fatalf("ParseSubIssueBodyAuto(freeform) error = %v", err)
+	}
+
+	// Both should produce similar (though not identical) results
+	// Description should exist in both
+	if templatedContent.Description == "" || freeformContent.Description == "" {
+		t.Error("Both should have non-empty descriptions")
+	}
+
+	// Both should have files
+	if len(templatedContent.Files) != 1 || len(freeformContent.Files) != 1 {
+		t.Errorf("Both should have 1 file: templated=%v, freeform=%v",
+			templatedContent.Files, freeformContent.Files)
+	}
+
+	// Both should have complexity
+	if templatedContent.Complexity != "low" || freeformContent.Complexity != "low" {
+		t.Errorf("Both should have low complexity: templated=%q, freeform=%q",
+			templatedContent.Complexity, freeformContent.Complexity)
+	}
+
+	// Both should have parent issue number
+	if templatedContent.ParentIssueNum != 100 || freeformContent.ParentIssueNum != 100 {
+		t.Errorf("Both should have parent 100: templated=%d, freeform=%d",
+			templatedContent.ParentIssueNum, freeformContent.ParentIssueNum)
+	}
+}
+
+// =============================================================================
+// Parent Issue Auto-Detection Tests (task-5-build-plan-freeform)
+// =============================================================================
+
+func TestDetectParentIssueFormat_Templated(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want IssueFormat
+	}{
+		{
+			name: "complete templated parent issue",
+			body: `## Summary
+
+Add OAuth2 authentication support.
+
+## Analysis
+
+- Existing user table can be extended
+- JWT library available
+
+## Constraints
+
+- Must maintain backward compatibility
+
+## Sub-Issues
+
+### Group 1 (can start immediately)
+- [ ] #101 - **Setup auth models**
+- [ ] #102 - **Add JWT utilities**
+
+### Group 2 (depends on previous groups)
+- [ ] #103 - **Implement OAuth endpoints**
+
+## Execution Order
+
+Tasks grouped by dependencies.
+`,
+			want: IssueFormatTemplated,
+		},
+		{
+			name: "minimal templated with Summary and Sub-Issues",
+			body: `## Summary
+
+Simple plan.
+
+## Sub-Issues
+
+### Group 1
+- [ ] #10 - **Task**
+`,
+			want: IssueFormatTemplated,
+		},
+		{
+			name: "templated with multiple groups",
+			body: `## Summary
+
+Multi-group plan.
+
+## Sub-Issues
+
+### Group 1
+- [ ] #1
+
+### Group 2
+- [ ] #2
+
+### Group 3
+- [ ] #3
+`,
+			want: IssueFormatTemplated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectParentIssueFormat(tt.body)
+			if got != tt.want {
+				t.Errorf("DetectParentIssueFormat() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectParentIssueFormat_Freeform(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want IssueFormat
+	}{
+		{
+			name: "human-authored epic",
+			body: `# Epic: Implement Notifications
+
+## Problem Statement
+
+Users need real-time updates.
+
+## Tasks
+
+### Phase 1
+- [ ] #100 - Setup WebSocket server
+
+### Phase 2
+- [ ] #101 - Add notification UI
+`,
+			want: IssueFormatFreeform,
+		},
+		{
+			name: "simple feature request with tasks",
+			body: `Add dark mode support.
+
+Tasks:
+- #10 - Create theme context
+- #11 - Add toggle component
+`,
+			want: IssueFormatFreeform,
+		},
+		{
+			name: "has Summary but no Sub-Issues section",
+			body: `## Summary
+
+Just a summary with no Sub-Issues section.
+
+## Tasks
+
+- #10
+- #11
+`,
+			want: IssueFormatFreeform,
+		},
+		{
+			name: "has Sub-Issues but no Summary",
+			body: `# Feature Request
+
+## Sub-Issues
+
+### Group 1
+- #10
+`,
+			want: IssueFormatFreeform,
+		},
+		{
+			name: "has Summary and Sub-Issues but no Group headers",
+			body: `## Summary
+
+A plan without groups.
+
+## Sub-Issues
+
+- #10
+- #11
+`,
+			want: IssueFormatFreeform,
+		},
+		{
+			name: "empty body",
+			body: "",
+			want: IssueFormatFreeform,
+		},
+		{
+			name: "whitespace only",
+			body: "   \n\t\n   ",
+			want: IssueFormatFreeform,
+		},
+		{
+			name: "overview format",
+			body: `## Overview
+
+Project overview here.
+
+## Implementation Plan
+
+### Step 1
+- #100
+
+### Step 2
+- #101
+`,
+			want: IssueFormatFreeform,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectParentIssueFormat(tt.body)
+			if got != tt.want {
+				t.Errorf("DetectParentIssueFormat() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseParentIssueBodyAuto_Templated(t *testing.T) {
+	body := `## Summary
+
+Implement user authentication.
+
+## Analysis
+
+- Existing user model can be extended
+- JWT library available
+
+## Constraints
+
+- Must maintain API compatibility
+
+## Sub-Issues
+
+### Group 1 (can start immediately)
+- [ ] #101 - **Setup auth models**
+- [ ] #102 - **Add JWT utilities**
+
+### Group 2 (depends on previous groups)
+- [ ] #103 - **Implement OAuth endpoints**
+
+## Execution Order
+
+Tasks grouped by dependencies.
+`
+
+	content, err := ParseParentIssueBodyAuto(body)
+	if err != nil {
+		t.Fatalf("ParseParentIssueBodyAuto() error = %v", err)
+	}
+
+	// Verify templated parsing results
+	if content.Summary != "Implement user authentication." {
+		t.Errorf("Summary = %q, want %q", content.Summary, "Implement user authentication.")
+	}
+
+	expectedInsights := []string{
+		"Existing user model can be extended",
+		"JWT library available",
+	}
+	if !reflect.DeepEqual(content.Insights, expectedInsights) {
+		t.Errorf("Insights = %v, want %v", content.Insights, expectedInsights)
+	}
+
+	expectedConstraints := []string{"Must maintain API compatibility"}
+	if !reflect.DeepEqual(content.Constraints, expectedConstraints) {
+		t.Errorf("Constraints = %v, want %v", content.Constraints, expectedConstraints)
+	}
+
+	expectedGroups := [][]int{{101, 102}, {103}}
+	if !reflect.DeepEqual(content.ExecutionGroups, expectedGroups) {
+		t.Errorf("ExecutionGroups = %v, want %v", content.ExecutionGroups, expectedGroups)
+	}
+}
+
+func TestParseParentIssueBodyAuto_Freeform(t *testing.T) {
+	body := `# Epic: Dark Mode Support
+
+Add dark mode to the application.
+
+## Tasks
+
+### Phase 1 - Infrastructure
+- #200 - Create theme context
+- #201 - Add CSS variables
+
+### Phase 2 - Components
+- #202 - Update all components for theming
+- #203 - Add toggle switch
+`
+
+	content, err := ParseParentIssueBodyAuto(body)
+	if err != nil {
+		t.Fatalf("ParseParentIssueBodyAuto() error = %v", err)
+	}
+
+	// Verify freeform parsing results
+	// Summary should be the content before headers
+	if !strings.Contains(content.Summary, "Dark Mode Support") {
+		t.Errorf("Summary should contain 'Dark Mode Support', got %q", content.Summary)
+	}
+
+	// Insights and Constraints should be empty for freeform
+	if len(content.Insights) != 0 {
+		t.Errorf("Insights should be empty for freeform, got %v", content.Insights)
+	}
+	if len(content.Constraints) != 0 {
+		t.Errorf("Constraints should be empty for freeform, got %v", content.Constraints)
+	}
+
+	// Should have two groups from the Phase headers
+	expectedGroups := [][]int{{200, 201}, {202, 203}}
+	if !reflect.DeepEqual(content.ExecutionGroups, expectedGroups) {
+		t.Errorf("ExecutionGroups = %v, want %v", content.ExecutionGroups, expectedGroups)
+	}
+}
+
+func TestParseParentIssueBodyAuto_RoundTrip(t *testing.T) {
+	// Create a plan, render it as a parent issue, then parse it back using auto
+	plan := &orchestrator.PlanSpec{
+		Objective: "Implement caching layer",
+		Summary:   "Add Redis caching to improve performance",
+		Tasks: []orchestrator.PlannedTask{
+			{ID: "task-1", Title: "Setup Redis connection"},
+			{ID: "task-2", Title: "Add cache service"},
+		},
+		ExecutionOrder: [][]string{{"task-1"}, {"task-2"}},
+		Insights:       []string{"Existing code uses in-memory cache"},
+		Constraints:    []string{"Must support cluster mode"},
+	}
+
+	subIssueNumbers := map[string]int{
+		"task-1": 50,
+		"task-2": 51,
+	}
+
+	body, err := RenderParentIssueBody(plan, subIssueNumbers)
+	if err != nil {
+		t.Fatalf("RenderParentIssueBody() error = %v", err)
+	}
+
+	// Parse back using auto-detection
+	content, err := ParseParentIssueBodyAuto(body)
+	if err != nil {
+		t.Fatalf("ParseParentIssueBodyAuto() error = %v", err)
+	}
+
+	// Should detect as templated and parse correctly
+	if content.Summary != plan.Summary {
+		t.Errorf("Summary = %q, want %q", content.Summary, plan.Summary)
+	}
+	if !reflect.DeepEqual(content.Insights, plan.Insights) {
+		t.Errorf("Insights = %v, want %v", content.Insights, plan.Insights)
+	}
+	if !reflect.DeepEqual(content.Constraints, plan.Constraints) {
+		t.Errorf("Constraints = %v, want %v", content.Constraints, plan.Constraints)
+	}
+}
+
+// =============================================================================
+// Full Pipeline Integration Tests with Freeform Issues (task-5-build-plan-freeform)
+// =============================================================================
+
+func TestBuildPlanFromURL_FreeformPipeline(t *testing.T) {
+	// Test full pipeline with freeform parent and freeform sub-issues
+	parentIssueJSON := `{
+		"number": 500,
+		"title": "Epic: Add Export Feature",
+		"body": "# Add CSV Export\n\nAllow users to export their data as CSV files.\n\n## Tasks\n\n### Phase 1 - Backend\n- #501 - Create export service\n- #502 - Add CSV generator\n\n### Phase 2 - Frontend\n- #503 - Add export button\n- #504 - Show download progress\n",
+		"labels": [{"name": "epic"}],
+		"url": "https://github.com/owner/repo/issues/500",
+		"state": "open"
+	}`
+
+	subIssue501JSON := `{
+		"number": 501,
+		"title": "Create export service",
+		"body": "Create the backend service that handles export requests.\n\nFiles to modify:\n- ` + "`internal/export/service.go`" + `\n- ` + "`internal/export/handler.go`" + `\n\nThis is a medium complexity task.",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/501",
+		"state": "open"
+	}`
+
+	subIssue502JSON := `{
+		"number": 502,
+		"title": "Add CSV generator",
+		"body": "Implement CSV generation logic.\n\nDepends on #501 for the service interface.\n\nFiles: ` + "`internal/export/csv.go`" + `\n\nlow complexity",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/502",
+		"state": "open"
+	}`
+
+	subIssue503JSON := `{
+		"number": 503,
+		"title": "Add export button",
+		"body": "Add the export button to the UI.\n\nDepends on #501 and #502.\n\nFiles: ` + "`src/components/ExportButton.tsx`" + `",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/503",
+		"state": "open"
+	}`
+
+	subIssue504JSON := `{
+		"number": 504,
+		"title": "Show download progress",
+		"body": "Show progress indicator during export.\n\nRelated to #503.\n\nFiles: ` + "`src/components/Progress.tsx`" + `\n\nThis is low complexity.",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/504",
+		"state": "open"
+	}`
+
+	issueResponses := map[int]string{
+		500: parentIssueJSON,
+		501: subIssue501JSON,
+		502: subIssue502JSON,
+		503: subIssue503JSON,
+		504: subIssue504JSON,
+	}
+
+	executor := multiIssueMockExecutor(issueResponses)
+
+	plan, err := buildPlanFromURLWithExecutor("https://github.com/owner/repo/issues/500", executor)
+	if err != nil {
+		t.Fatalf("buildPlanFromURLWithExecutor() error: %v", err)
+	}
+
+	// Verify plan metadata
+	if plan.Objective != "Epic: Add Export Feature" {
+		t.Errorf("Objective = %q", plan.Objective)
+	}
+
+	// Summary should be extracted from freeform
+	if !strings.Contains(plan.Summary, "CSV Export") {
+		t.Errorf("Summary should contain 'CSV Export', got %q", plan.Summary)
+	}
+
+	// Verify we have 4 tasks
+	if len(plan.Tasks) != 4 {
+		t.Fatalf("Expected 4 tasks, got %d", len(plan.Tasks))
+	}
+
+	// Verify execution order (2 phases)
+	if len(plan.ExecutionOrder) != 2 {
+		t.Fatalf("Expected 2 execution groups, got %d", len(plan.ExecutionOrder))
+	}
+
+	// Phase 1 should have 2 tasks (501, 502)
+	if len(plan.ExecutionOrder[0]) != 2 {
+		t.Errorf("Phase 1 should have 2 tasks, got %d", len(plan.ExecutionOrder[0]))
+	}
+
+	// Phase 2 should have 2 tasks (503, 504)
+	if len(plan.ExecutionOrder[1]) != 2 {
+		t.Errorf("Phase 2 should have 2 tasks, got %d", len(plan.ExecutionOrder[1]))
+	}
+
+	// Find task 502 and verify its dependencies
+	var task502 *orchestrator.PlannedTask
+	for i := range plan.Tasks {
+		if strings.Contains(plan.Tasks[i].ID, "502") {
+			task502 = &plan.Tasks[i]
+			break
+		}
+	}
+	if task502 == nil {
+		t.Fatal("Task 502 not found")
+	}
+
+	// Task 502 should depend on task 501 (extracted from freeform body)
+	if len(task502.DependsOn) != 1 {
+		t.Errorf("Task 502 should have 1 dependency, got %d: %v", len(task502.DependsOn), task502.DependsOn)
+	}
+
+	// Verify complexity was extracted from freeform
+	if task502.EstComplexity != orchestrator.ComplexityLow {
+		t.Errorf("Task 502 complexity = %q, want %q", task502.EstComplexity, orchestrator.ComplexityLow)
+	}
+
+	// Verify files were extracted from freeform
+	if len(task502.Files) != 1 {
+		t.Errorf("Task 502 should have 1 file, got %d: %v", len(task502.Files), task502.Files)
+	}
+}
+
+func TestBuildPlanFromURL_MixedTemplatedAndFreeform(t *testing.T) {
+	// Test pipeline with templated parent and mixed sub-issues (some templated, some freeform)
+	parentIssueJSON := `{
+		"number": 600,
+		"title": "Plan: API Refactoring",
+		"body": "## Summary\n\nRefactor the API layer for better maintainability.\n\n## Analysis\n\n- Current API has inconsistent error handling\n\n## Constraints\n\n- Must maintain backward compatibility\n\n## Sub-Issues\n\n### Group 1 (can start immediately)\n- [ ] #601 - **Add error types**\n\n### Group 2 (depends on previous groups)\n- [ ] #602 - **Update handlers**\n\n## Execution Order\n\nTasks grouped by dependencies.",
+		"labels": [{"name": "plan"}],
+		"url": "https://github.com/owner/repo/issues/600",
+		"state": "open"
+	}`
+
+	// Templated sub-issue
+	subIssue601JSON := `{
+		"number": 601,
+		"title": "Add error types",
+		"body": "## Task\n\nDefine custom error types for the API.\n\n## Files to Modify\n\n- ` + "`internal/api/errors.go`" + `\n\n## Complexity\n\nEstimated: **low**\n\n---\n*Part of #600*",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/601",
+		"state": "open"
+	}`
+
+	// Freeform sub-issue
+	subIssue602JSON := `{
+		"number": 602,
+		"title": "Update handlers",
+		"body": "Update all API handlers to use the new error types.\n\nDepends on #601.\n\nFiles:\n- ` + "`internal/api/users.go`" + `\n- ` + "`internal/api/orders.go`" + `\n\nThis is high complexity work due to many files.",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/602",
+		"state": "open"
+	}`
+
+	issueResponses := map[int]string{
+		600: parentIssueJSON,
+		601: subIssue601JSON,
+		602: subIssue602JSON,
+	}
+
+	executor := multiIssueMockExecutor(issueResponses)
+
+	plan, err := buildPlanFromURLWithExecutor("https://github.com/owner/repo/issues/600", executor)
+	if err != nil {
+		t.Fatalf("buildPlanFromURLWithExecutor() error: %v", err)
+	}
+
+	// Verify templated parent parsing
+	if plan.Summary != "Refactor the API layer for better maintainability." {
+		t.Errorf("Summary = %q", plan.Summary)
+	}
+
+	expectedInsights := []string{"Current API has inconsistent error handling"}
+	if !reflect.DeepEqual(plan.Insights, expectedInsights) {
+		t.Errorf("Insights = %v, want %v", plan.Insights, expectedInsights)
+	}
+
+	expectedConstraints := []string{"Must maintain backward compatibility"}
+	if !reflect.DeepEqual(plan.Constraints, expectedConstraints) {
+		t.Errorf("Constraints = %v, want %v", plan.Constraints, expectedConstraints)
+	}
+
+	// Verify we have 2 tasks
+	if len(plan.Tasks) != 2 {
+		t.Fatalf("Expected 2 tasks, got %d", len(plan.Tasks))
+	}
+
+	// Find both tasks
+	var task601, task602 *orchestrator.PlannedTask
+	for i := range plan.Tasks {
+		if strings.Contains(plan.Tasks[i].ID, "601") {
+			task601 = &plan.Tasks[i]
+		}
+		if strings.Contains(plan.Tasks[i].ID, "602") {
+			task602 = &plan.Tasks[i]
+		}
+	}
+
+	if task601 == nil || task602 == nil {
+		t.Fatal("Tasks 601 and/or 602 not found")
+	}
+
+	// Task 601 (templated) should have low complexity
+	if task601.EstComplexity != orchestrator.ComplexityLow {
+		t.Errorf("Task 601 complexity = %q, want %q", task601.EstComplexity, orchestrator.ComplexityLow)
+	}
+
+	// Task 602 (freeform) should have high complexity (detected from "high complexity")
+	if task602.EstComplexity != orchestrator.ComplexityHigh {
+		t.Errorf("Task 602 complexity = %q, want %q", task602.EstComplexity, orchestrator.ComplexityHigh)
+	}
+
+	// Task 602 should depend on task 601
+	if len(task602.DependsOn) != 1 {
+		t.Errorf("Task 602 should have 1 dependency, got %d: %v", len(task602.DependsOn), task602.DependsOn)
+	}
+
+	// Task 602 should have 2 files
+	if len(task602.Files) != 2 {
+		t.Errorf("Task 602 should have 2 files, got %d: %v", len(task602.Files), task602.Files)
+	}
+}
+
+func TestBuildPlanFromURL_FreeformParentTemplatedSubs(t *testing.T) {
+	// Test with freeform parent but templated sub-issues
+	parentIssueJSON := `{
+		"number": 700,
+		"title": "Add User Profile Features",
+		"body": "Add new features to user profiles.\n\n## Implementation\n\n### Phase 1\n- #701 - Avatar upload\n\n### Phase 2\n- #702 - Bio editor\n",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/700",
+		"state": "open"
+	}`
+
+	// Templated sub-issues
+	subIssue701JSON := `{
+		"number": 701,
+		"title": "Avatar upload",
+		"body": "## Task\n\nImplement avatar image upload.\n\n## Files to Modify\n\n- ` + "`internal/user/avatar.go`" + `\n\n## Complexity\n\nEstimated: **medium**\n\n---\n*Part of #700*",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/701",
+		"state": "open"
+	}`
+
+	subIssue702JSON := `{
+		"number": 702,
+		"title": "Bio editor",
+		"body": "## Task\n\nAdd bio text editor to profile.\n\n## Files to Modify\n\n- ` + "`internal/user/bio.go`" + `\n\n## Dependencies\n\nComplete these issues first:\n- #701 - Avatar upload\n\n## Complexity\n\nEstimated: **low**\n\n---\n*Part of #700*",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/702",
+		"state": "open"
+	}`
+
+	issueResponses := map[int]string{
+		700: parentIssueJSON,
+		701: subIssue701JSON,
+		702: subIssue702JSON,
+	}
+
+	executor := multiIssueMockExecutor(issueResponses)
+
+	plan, err := buildPlanFromURLWithExecutor("https://github.com/owner/repo/issues/700", executor)
+	if err != nil {
+		t.Fatalf("buildPlanFromURLWithExecutor() error: %v", err)
+	}
+
+	// Verify freeform parent parsing
+	if plan.Objective != "Add User Profile Features" {
+		t.Errorf("Objective = %q", plan.Objective)
+	}
+
+	// Summary from freeform
+	if !strings.Contains(plan.Summary, "user profiles") {
+		t.Errorf("Summary should contain 'user profiles', got %q", plan.Summary)
+	}
+
+	// Should have empty insights and constraints (freeform parent)
+	if len(plan.Insights) != 0 {
+		t.Errorf("Insights should be empty for freeform parent, got %v", plan.Insights)
+	}
+
+	// Verify we have 2 tasks
+	if len(plan.Tasks) != 2 {
+		t.Fatalf("Expected 2 tasks, got %d", len(plan.Tasks))
+	}
+
+	// Find task 702 and verify dependencies
+	var task702 *orchestrator.PlannedTask
+	for i := range plan.Tasks {
+		if strings.Contains(plan.Tasks[i].ID, "702") {
+			task702 = &plan.Tasks[i]
+			break
+		}
+	}
+
+	if task702 == nil {
+		t.Fatal("Task 702 not found")
+	}
+
+	// Task 702 (templated sub-issue) should have dependency on 701
+	if len(task702.DependsOn) != 1 {
+		t.Errorf("Task 702 should have 1 dependency, got %d: %v", len(task702.DependsOn), task702.DependsOn)
+	}
+
+	// Verify complexity from templated format
+	if task702.EstComplexity != orchestrator.ComplexityLow {
+		t.Errorf("Task 702 complexity = %q, want %q", task702.EstComplexity, orchestrator.ComplexityLow)
+	}
+}
+
+func TestBuildPlanFromURL_FreeformNoDependenciesSection(t *testing.T) {
+	// Test freeform sub-issues that mention dependencies inline rather than in a section
+	parentIssueJSON := `{
+		"number": 800,
+		"title": "Database Migration",
+		"body": "Migrate to new database schema.\n\n### Step 1\n- #801\n\n### Step 2\n- #802\n",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/800",
+		"state": "open"
+	}`
+
+	subIssue801JSON := `{
+		"number": 801,
+		"title": "Create new schema",
+		"body": "Create the new database schema.\n\nFile: ` + "`migrations/001_new_schema.sql`" + `",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/801",
+		"state": "open"
+	}`
+
+	subIssue802JSON := `{
+		"number": 802,
+		"title": "Migrate data",
+		"body": "Migrate existing data to new schema.\n\nThis needs #801 to be complete first.\n\nFile: ` + "`migrations/002_migrate_data.sql`" + `",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/802",
+		"state": "open"
+	}`
+
+	issueResponses := map[int]string{
+		800: parentIssueJSON,
+		801: subIssue801JSON,
+		802: subIssue802JSON,
+	}
+
+	executor := multiIssueMockExecutor(issueResponses)
+
+	plan, err := buildPlanFromURLWithExecutor("https://github.com/owner/repo/issues/800", executor)
+	if err != nil {
+		t.Fatalf("buildPlanFromURLWithExecutor() error: %v", err)
+	}
+
+	// Find task 802
+	var task802 *orchestrator.PlannedTask
+	for i := range plan.Tasks {
+		if strings.Contains(plan.Tasks[i].ID, "802") {
+			task802 = &plan.Tasks[i]
+			break
+		}
+	}
+
+	if task802 == nil {
+		t.Fatal("Task 802 not found")
+	}
+
+	// Task 802 should have dependency on 801 (from inline mention "needs #801")
+	if len(task802.DependsOn) != 1 {
+		t.Errorf("Task 802 should have 1 dependency (inline mention), got %d: %v", len(task802.DependsOn), task802.DependsOn)
+	}
+
+	// Verify file was extracted
+	if len(task802.Files) != 1 {
+		t.Errorf("Task 802 should have 1 file, got %d: %v", len(task802.Files), task802.Files)
+	}
+}
+
+func TestBuildPlanFromURL_FreeformComplexityInference(t *testing.T) {
+	// Test that complexity is correctly inferred from freeform bodies
+	parentIssueJSON := `{
+		"number": 900,
+		"title": "Various Tasks",
+		"body": "Tasks:\n\n- #901\n- #902\n- #903\n",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/900",
+		"state": "open"
+	}`
+
+	// Low complexity
+	subIssue901JSON := `{
+		"number": 901,
+		"title": "Simple fix",
+		"body": "This is a low complexity bug fix.",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/901",
+		"state": "open"
+	}`
+
+	// High complexity
+	subIssue902JSON := `{
+		"number": 902,
+		"title": "Major refactor",
+		"body": "Complexity: high\n\nComplete rewrite of the module.",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/902",
+		"state": "open"
+	}`
+
+	// Default (medium)
+	subIssue903JSON := `{
+		"number": 903,
+		"title": "Regular task",
+		"body": "Just a regular task without complexity mentioned.",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/903",
+		"state": "open"
+	}`
+
+	issueResponses := map[int]string{
+		900: parentIssueJSON,
+		901: subIssue901JSON,
+		902: subIssue902JSON,
+		903: subIssue903JSON,
+	}
+
+	executor := multiIssueMockExecutor(issueResponses)
+
+	plan, err := buildPlanFromURLWithExecutor("https://github.com/owner/repo/issues/900", executor)
+	if err != nil {
+		t.Fatalf("buildPlanFromURLWithExecutor() error: %v", err)
+	}
+
+	// Find all tasks
+	taskComplexities := make(map[int]orchestrator.TaskComplexity)
+	for _, task := range plan.Tasks {
+		if strings.Contains(task.ID, "901") {
+			taskComplexities[901] = task.EstComplexity
+		}
+		if strings.Contains(task.ID, "902") {
+			taskComplexities[902] = task.EstComplexity
+		}
+		if strings.Contains(task.ID, "903") {
+			taskComplexities[903] = task.EstComplexity
+		}
+	}
+
+	if taskComplexities[901] != orchestrator.ComplexityLow {
+		t.Errorf("Task 901 complexity = %q, want %q", taskComplexities[901], orchestrator.ComplexityLow)
+	}
+	if taskComplexities[902] != orchestrator.ComplexityHigh {
+		t.Errorf("Task 902 complexity = %q, want %q", taskComplexities[902], orchestrator.ComplexityHigh)
+	}
+	if taskComplexities[903] != orchestrator.ComplexityMedium {
+		t.Errorf("Task 903 complexity = %q, want %q (default)", taskComplexities[903], orchestrator.ComplexityMedium)
+	}
+}
+
+// =============================================================================
+// IngestError Tests (task-7-error-handling)
+// =============================================================================
+
+func TestIngestError_Error(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *IngestError
+		expected string
+	}{
+		{
+			name: "message only",
+			err: &IngestError{
+				Kind:    ErrKindIssueNotFound,
+				Message: "issue not found",
+			},
+			expected: "issue not found",
+		},
+		{
+			name: "with issue number",
+			err: &IngestError{
+				Kind:     ErrKindIssueNotFound,
+				Message:  "issue not found",
+				IssueNum: 42,
+			},
+			expected: "issue not found (issue #42)",
+		},
+		{
+			name: "with repo context",
+			err: &IngestError{
+				Kind:     ErrKindIssueNotFound,
+				Message:  "issue not found",
+				IssueNum: 42,
+				Owner:    "owner",
+				Repo:     "repo",
+			},
+			expected: "issue not found (issue #42) in owner/repo",
+		},
+		{
+			name: "with cause",
+			err: &IngestError{
+				Kind:     ErrKindParsingFailed,
+				Message:  "failed to parse",
+				IssueNum: 123,
+				Cause:    errors.New("underlying error"),
+			},
+			expected: "failed to parse (issue #123): underlying error",
+		},
+		{
+			name: "full context",
+			err: &IngestError{
+				Kind:     ErrKindAuthRequired,
+				Message:  "authentication required",
+				IssueNum: 5,
+				Owner:    "acme",
+				Repo:     "widgets",
+				Cause:    errors.New("not logged in"),
+			},
+			expected: "authentication required (issue #5) in acme/widgets: not logged in",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.err.Error()
+			if got != tt.expected {
+				t.Errorf("Error() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIngestError_Is(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *IngestError
+		target   error
+		expected bool
+	}{
+		{
+			name:     "matches ErrGHNotInstalled",
+			err:      &IngestError{Kind: ErrKindGHNotInstalled, Message: "gh not installed"},
+			target:   ErrGHNotInstalled,
+			expected: true,
+		},
+		{
+			name:     "matches ErrGHAuthRequired",
+			err:      &IngestError{Kind: ErrKindAuthRequired, Message: "auth required"},
+			target:   ErrGHAuthRequired,
+			expected: true,
+		},
+		{
+			name:     "matches ErrIssueNotFound",
+			err:      &IngestError{Kind: ErrKindIssueNotFound, Message: "not found"},
+			target:   ErrIssueNotFound,
+			expected: true,
+		},
+		{
+			name:     "matches ErrRateLimited",
+			err:      &IngestError{Kind: ErrKindRateLimited, Message: "rate limited"},
+			target:   ErrRateLimited,
+			expected: true,
+		},
+		{
+			name:     "matches ErrNoSubIssues",
+			err:      &IngestError{Kind: ErrKindNoSubIssues, Message: "no sub-issues"},
+			target:   ErrNoSubIssues,
+			expected: true,
+		},
+		{
+			name:     "matches ErrParsingFailed",
+			err:      &IngestError{Kind: ErrKindParsingFailed, Message: "parsing failed"},
+			target:   ErrParsingFailed,
+			expected: true,
+		},
+		{
+			name:     "matches ErrCircularDependency",
+			err:      &IngestError{Kind: ErrKindCircularDependency, Message: "circular"},
+			target:   ErrCircularDependency,
+			expected: true,
+		},
+		{
+			name:     "matches ErrUnsupportedProvider",
+			err:      &IngestError{Kind: ErrKindUnsupportedProvider, Message: "unsupported"},
+			target:   ErrUnsupportedProvider,
+			expected: true,
+		},
+		{
+			name:     "matches ErrRepoNotFound",
+			err:      &IngestError{Kind: ErrKindRepoNotFound, Message: "repo not found"},
+			target:   ErrRepoNotFound,
+			expected: true,
+		},
+		{
+			name:     "does not match wrong sentinel",
+			err:      &IngestError{Kind: ErrKindIssueNotFound, Message: "not found"},
+			target:   ErrGHAuthRequired,
+			expected: false,
+		},
+		{
+			name:     "does not match random error",
+			err:      &IngestError{Kind: ErrKindIssueNotFound, Message: "not found"},
+			target:   errors.New("some error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := errors.Is(tt.err, tt.target); got != tt.expected {
+				t.Errorf("errors.Is() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIngestError_Unwrap(t *testing.T) {
+	cause := errors.New("underlying cause")
+	err := &IngestError{
+		Kind:    ErrKindParsingFailed,
+		Message: "parsing failed",
+		Cause:   cause,
+	}
+
+	// Test Unwrap returns the cause
+	if got := err.Unwrap(); got != cause {
+		t.Errorf("Unwrap() = %v, want %v", got, cause)
+	}
+
+	// Test errors.Unwrap works
+	if got := errors.Unwrap(err); got != cause {
+		t.Errorf("errors.Unwrap() = %v, want %v", got, cause)
+	}
+
+	// Test error without cause
+	errNoCause := &IngestError{Kind: ErrKindIssueNotFound, Message: "not found"}
+	if got := errNoCause.Unwrap(); got != nil {
+		t.Errorf("Unwrap() with no cause = %v, want nil", got)
+	}
+}
+
+func TestIngestError_FormatForTerminal(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *IngestError
+		contains []string
+	}{
+		{
+			name: "simple error",
+			err: &IngestError{
+				Kind:    ErrKindIssueNotFound,
+				Message: "issue not found",
+			},
+			contains: []string{"Error:", "issue not found"},
+		},
+		{
+			name: "with suggestion",
+			err: &IngestError{
+				Kind:       ErrKindAuthRequired,
+				Message:    "authentication required",
+				Suggestion: "Run 'gh auth login'",
+			},
+			contains: []string{"Error:", "authentication required", "Suggestion:", "gh auth login"},
+		},
+		{
+			name: "with full context",
+			err: &IngestError{
+				Kind:       ErrKindNoSubIssues,
+				Message:    "no sub-issues found",
+				IssueNum:   100,
+				Owner:      "myorg",
+				Repo:       "myrepo",
+				Suggestion: "Add sub-issues using #N syntax",
+			},
+			contains: []string{
+				"Error:", "no sub-issues found",
+				"#100", "myorg/myrepo",
+				"Suggestion:", "Add sub-issues",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.err.FormatForTerminal()
+			for _, want := range tt.contains {
+				if !strings.Contains(got, want) {
+					t.Errorf("FormatForTerminal() = %q, want to contain %q", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestIngestError_BuilderPattern(t *testing.T) {
+	err := NewIngestError(ErrKindIssueNotFound, "issue not found").
+		WithIssue(42).
+		WithRepo("owner", "repo").
+		WithSuggestion("Check the issue number").
+		WithCause(errors.New("404"))
+
+	if err.Kind != ErrKindIssueNotFound {
+		t.Errorf("Kind = %q, want %q", err.Kind, ErrKindIssueNotFound)
+	}
+	if err.Message != "issue not found" {
+		t.Errorf("Message = %q, want %q", err.Message, "issue not found")
+	}
+	if err.IssueNum != 42 {
+		t.Errorf("IssueNum = %d, want %d", err.IssueNum, 42)
+	}
+	if err.Owner != "owner" {
+		t.Errorf("Owner = %q, want %q", err.Owner, "owner")
+	}
+	if err.Repo != "repo" {
+		t.Errorf("Repo = %q, want %q", err.Repo, "repo")
+	}
+	if err.Suggestion != "Check the issue number" {
+		t.Errorf("Suggestion = %q, want %q", err.Suggestion, "Check the issue number")
+	}
+	if err.Cause == nil || err.Cause.Error() != "404" {
+		t.Errorf("Cause = %v, want error with message '404'", err.Cause)
+	}
+}
+
+func TestClassifyGHError_RateLimited(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+	}{
+		{"rate limit message", "API rate limit exceeded for user ID 12345"},
+		{"secondary rate limit", "You have exceeded a secondary rate limit"},
+		{"abuse detection", "abuse detection mechanism was triggered"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := classifyGHError(errors.New("exit status 1"), []byte(tt.output), 123)
+			if !errors.Is(err, ErrRateLimited) {
+				t.Errorf("classifyGHError() = %v, want ErrRateLimited", err)
+			}
+
+			// Verify it's an IngestError with suggestion
+			var ingestErr *IngestError
+			if !errors.As(err, &ingestErr) {
+				t.Fatalf("error is not *IngestError")
+			}
+			if ingestErr.Suggestion == "" {
+				t.Error("IngestError.Suggestion should not be empty for rate limit errors")
+			}
+			if ingestErr.IssueNum != 123 {
+				t.Errorf("IngestError.IssueNum = %d, want 123", ingestErr.IssueNum)
+			}
+		})
+	}
+}
+
+func TestClassifyGHError_WithIngestErrorTypes(t *testing.T) {
+	tests := []struct {
+		name           string
+		output         string
+		execErr        error
+		issueNum       int
+		wantKind       IngestErrorKind
+		wantSuggestion bool
+	}{
+		{
+			name:           "gh not installed",
+			output:         "",
+			execErr:        &exec.Error{Name: "gh", Err: errors.New("not found")},
+			issueNum:       1,
+			wantKind:       ErrKindGHNotInstalled,
+			wantSuggestion: true,
+		},
+		{
+			name:           "auth required",
+			output:         "To authenticate, please run `gh auth login`",
+			execErr:        errors.New("exit status 1"),
+			issueNum:       42,
+			wantKind:       ErrKindAuthRequired,
+			wantSuggestion: true,
+		},
+		{
+			name:           "issue not found",
+			output:         "GraphQL: Could not find issue #9999",
+			execErr:        errors.New("exit status 1"),
+			issueNum:       9999,
+			wantKind:       ErrKindIssueNotFound,
+			wantSuggestion: true,
+		},
+		{
+			name:           "repo not found",
+			output:         "GraphQL: Could not resolve to a Repository",
+			execErr:        errors.New("exit status 1"),
+			issueNum:       1,
+			wantKind:       ErrKindRepoNotFound,
+			wantSuggestion: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := classifyGHError(tt.execErr, []byte(tt.output), tt.issueNum)
+
+			var ingestErr *IngestError
+			if !errors.As(err, &ingestErr) {
+				t.Fatalf("error is not *IngestError: %v", err)
+			}
+
+			if ingestErr.Kind != tt.wantKind {
+				t.Errorf("Kind = %q, want %q", ingestErr.Kind, tt.wantKind)
+			}
+
+			if tt.wantSuggestion && ingestErr.Suggestion == "" {
+				t.Error("expected non-empty Suggestion")
+			}
+		})
+	}
+}
+
+func TestDetectCircularDependencies(t *testing.T) {
+	tests := []struct {
+		name      string
+		tasks     []orchestrator.PlannedTask
+		wantCycle bool
+	}{
+		{
+			name: "no cycle",
+			tasks: []orchestrator.PlannedTask{
+				{ID: "task-1", DependsOn: nil},
+				{ID: "task-2", DependsOn: []string{"task-1"}},
+				{ID: "task-3", DependsOn: []string{"task-2"}},
+			},
+			wantCycle: false,
+		},
+		{
+			name: "simple cycle",
+			tasks: []orchestrator.PlannedTask{
+				{ID: "task-1", DependsOn: []string{"task-2"}},
+				{ID: "task-2", DependsOn: []string{"task-1"}},
+			},
+			wantCycle: true,
+		},
+		{
+			name: "self-reference",
+			tasks: []orchestrator.PlannedTask{
+				{ID: "task-1", DependsOn: []string{"task-1"}},
+			},
+			wantCycle: true,
+		},
+		{
+			name: "complex cycle",
+			tasks: []orchestrator.PlannedTask{
+				{ID: "task-1", DependsOn: nil},
+				{ID: "task-2", DependsOn: []string{"task-1"}},
+				{ID: "task-3", DependsOn: []string{"task-2"}},
+				{ID: "task-4", DependsOn: []string{"task-3"}},
+				{ID: "task-5", DependsOn: []string{"task-4", "task-2"}},
+			},
+			wantCycle: false,
+		},
+		{
+			name: "cycle in middle",
+			tasks: []orchestrator.PlannedTask{
+				{ID: "task-1", DependsOn: nil},
+				{ID: "task-2", DependsOn: []string{"task-1", "task-4"}},
+				{ID: "task-3", DependsOn: []string{"task-2"}},
+				{ID: "task-4", DependsOn: []string{"task-3"}},
+			},
+			wantCycle: true,
+		},
+		{
+			name: "dependency on non-existent task (ignored)",
+			tasks: []orchestrator.PlannedTask{
+				{ID: "task-1", DependsOn: []string{"task-999"}},
+				{ID: "task-2", DependsOn: []string{"task-1"}},
+			},
+			wantCycle: false,
+		},
+		{
+			name:      "empty tasks",
+			tasks:     []orchestrator.PlannedTask{},
+			wantCycle: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cycle := detectCircularDependencies(tt.tasks)
+			if tt.wantCycle && cycle == nil {
+				t.Error("expected cycle to be detected, got nil")
+			}
+			if !tt.wantCycle && cycle != nil {
+				t.Errorf("expected no cycle, got %v", cycle)
+			}
+		})
+	}
+}
+
+func TestFormatDependencyCycle(t *testing.T) {
+	tests := []struct {
+		name     string
+		cycle    []string
+		expected string
+	}{
+		{
+			name:     "simple cycle",
+			cycle:    []string{"task-1", "task-2", "task-1"},
+			expected: "task-1 -> task-2 -> task-1",
+		},
+		{
+			name:     "longer cycle",
+			cycle:    []string{"a", "b", "c", "d", "a"},
+			expected: "a -> b -> c -> d -> a",
+		},
+		{
+			name:     "empty",
+			cycle:    []string{},
+			expected: "",
+		},
+		{
+			name:     "single element",
+			cycle:    []string{"task-1"},
+			expected: "task-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatDependencyCycle(tt.cycle)
+			if got != tt.expected {
+				t.Errorf("formatDependencyCycle() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildPlanFromURL_CircularDependency(t *testing.T) {
+	// Create parent issue with two sub-issues
+	parentJSON := `{
+		"number": 100,
+		"title": "Parent Issue",
+		"body": "## Summary\nTest\n\n## Sub-Issues\n### Group 1\n- [ ] #101 - Task A\n- [ ] #102 - Task B",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/100",
+		"state": "open"
+	}`
+
+	// Sub-issues have circular dependency: 101 depends on 102, 102 depends on 101
+	// Using the proper ## Dependencies section for templated format
+	subIssue101JSON := `{
+		"number": 101,
+		"title": "Task A",
+		"body": "## Task\nDo A\n\n## Dependencies\n- #102\n\n## Complexity\nEstimated: **low**\n\n*Part of #100*",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/101",
+		"state": "open"
+	}`
+
+	subIssue102JSON := `{
+		"number": 102,
+		"title": "Task B",
+		"body": "## Task\nDo B\n\n## Dependencies\n- #101\n\n## Complexity\nEstimated: **low**\n\n*Part of #100*",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/102",
+		"state": "open"
+	}`
+
+	issueResponses := map[int]string{
+		100: parentJSON,
+		101: subIssue101JSON,
+		102: subIssue102JSON,
+	}
+
+	executor := multiIssueMockExecutor(issueResponses)
+
+	_, err := buildPlanFromURLWithExecutor("https://github.com/owner/repo/issues/100", executor)
+	if err == nil {
+		t.Fatal("expected error for circular dependency, got nil")
+	}
+
+	if !errors.Is(err, ErrCircularDependency) {
+		t.Errorf("expected ErrCircularDependency, got: %v", err)
+	}
+
+	// Verify it's an IngestError with suggestion
+	var ingestErr *IngestError
+	if errors.As(err, &ingestErr) {
+		if ingestErr.Suggestion == "" {
+			t.Error("expected suggestion for circular dependency error")
+		}
+	}
+}
+
+func TestBuildPlanFromURL_NoSubIssues_ReturnsIngestError(t *testing.T) {
+	parentJSON := `{
+		"number": 200,
+		"title": "Empty Parent",
+		"body": "## Summary\nNo sub-issues here\n\n## Sub-Issues\nNone defined",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/200",
+		"state": "open"
+	}`
+
+	executor := mockExecutor([]byte(parentJSON), nil)
+
+	_, err := buildPlanFromURLWithExecutor("https://github.com/owner/repo/issues/200", executor)
+	if err == nil {
+		t.Fatal("expected error for no sub-issues, got nil")
+	}
+
+	if !errors.Is(err, ErrNoSubIssues) {
+		t.Errorf("expected ErrNoSubIssues, got: %v", err)
+	}
+
+	// Verify it's an IngestError with proper context
+	var ingestErr *IngestError
+	if errors.As(err, &ingestErr) {
+		if ingestErr.IssueNum != 200 {
+			t.Errorf("IssueNum = %d, want 200", ingestErr.IssueNum)
+		}
+		if ingestErr.Owner != "owner" {
+			t.Errorf("Owner = %q, want 'owner'", ingestErr.Owner)
+		}
+		if ingestErr.Repo != "repo" {
+			t.Errorf("Repo = %q, want 'repo'", ingestErr.Repo)
+		}
+		if ingestErr.Suggestion == "" {
+			t.Error("expected suggestion for no sub-issues error")
+		}
+	} else {
+		t.Error("expected error to be *IngestError")
+	}
+}
+
+func TestBuildPlanFromURL_SubIssueFetchFails_ReturnsIngestError(t *testing.T) {
+	// Parent issue that references sub-issue #201
+	parentJSON := `{
+		"number": 300,
+		"title": "Parent with missing sub-issue",
+		"body": "## Summary\nTest\n\n## Sub-Issues\n### Group 1\n- [ ] #301 - Missing task",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/300",
+		"state": "open"
+	}`
+
+	// Sub-issue fetch will fail with "not found"
+	callCount := 0
+	executor := func(name string, args ...string) ([]byte, error) {
+		callCount++
+		if callCount == 1 {
+			// First call: parent issue
+			return []byte(parentJSON), nil
+		}
+		// Second call: sub-issue - simulate not found
+		return []byte("Could not find issue #301"), errors.New("exit status 1")
+	}
+
+	_, err := buildPlanFromURLWithExecutor("https://github.com/owner/repo/issues/300", executor)
+	if err == nil {
+		t.Fatal("expected error for missing sub-issue, got nil")
+	}
+
+	// Should be wrapped with context about which sub-issue failed
+	var ingestErr *IngestError
+	if errors.As(err, &ingestErr) {
+		if ingestErr.IssueNum != 301 {
+			t.Errorf("IssueNum = %d, want 301 (the failing sub-issue)", ingestErr.IssueNum)
+		}
+	}
+}
+
+func TestBuildPlanFromURL_ParsingFailed_ReturnsIngestError(t *testing.T) {
+	// Parent issue with valid structure
+	parentJSON := `{
+		"number": 400,
+		"title": "Parent Issue",
+		"body": "## Summary\nTest\n\n## Sub-Issues\n### Group 1\n- [ ] #401 - Task",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/400",
+		"state": "open"
+	}`
+
+	// Sub-issue with empty body (will fail parsing)
+	subIssueJSON := `{
+		"number": 401,
+		"title": "Task with empty body",
+		"body": "",
+		"labels": [],
+		"url": "https://github.com/owner/repo/issues/401",
+		"state": "open"
+	}`
+
+	issueResponses := map[int]string{
+		400: parentJSON,
+		401: subIssueJSON,
+	}
+
+	executor := multiIssueMockExecutor(issueResponses)
+
+	_, err := buildPlanFromURLWithExecutor("https://github.com/owner/repo/issues/400", executor)
+	if err == nil {
+		t.Fatal("expected error for parsing failure, got nil")
+	}
+
+	if !errors.Is(err, ErrParsingFailed) {
+		t.Errorf("expected ErrParsingFailed, got: %v", err)
+	}
+
+	// Verify it's an IngestError with proper context
+	var ingestErr *IngestError
+	if errors.As(err, &ingestErr) {
+		if ingestErr.IssueNum != 401 {
+			t.Errorf("IssueNum = %d, want 401", ingestErr.IssueNum)
+		}
+		if ingestErr.Suggestion == "" {
+			t.Error("expected suggestion for parsing failure")
+		}
 	}
 }


### PR DESCRIPTION
## Objective

Enable UltraPlan to ingest GitHub Issues as task plans. This is group 2 of a stacked PR series implementing issue #244.

## Tasks Included

- **task-2-parse-freeform-parent**: Parse freeform parent issue body
- **task-3-parse-freeform-sub**: Parse freeform sub-issue body

## Changes

This PR adds parsers for human-authored GitHub issues that don't follow the Claudio template:

### `ParseFreeformParentIssueBody()`
- Extracts summary from text before headers
- Identifies execution groups from `### Group N` or `### Phase N` headers
- Finds issue references from `#N` patterns anywhere in text

### `ParseFreeformSubIssueBody()`
- Extracts summary from text before headers
- Identifies file paths from backticks
- Determines complexity from various textual patterns (defaults to 'medium')

## Merge Order

This is **group 2 of 6** in a stacked PR series. Merge in order:
1. Group 1 - Issue format detection
2. **This PR** (group 2) - Freeform parsers
3. Group 3 - Unified sub-issue parser
4. Group 4 - BuildPlanFromURL extension
5. Group 5 - CLI --issue flag
6. Group 6 - Error handling and documentation

Closes part of #244