### PR TITLE
feat(plan): group 3 - unified sub-issue parser

### DIFF
--- a/.claude-prompt
+++ b/.claude-prompt
@@ -1,2 +1,66 @@
-The terminal doesn't clearly display user input, nor does it clearly display command output. 
-We should have a fully functional terminal there. It should also be taller; it's currently too short to be useful. 
+# Task: Add --issue flag to ultraplan command
+
+## Part of Ultra-Plan: Enable ingesting GitHub Issues as UltraPlan execution plans via a new --issue CLI flag. This requires extending the existing ingestion pipeline to support human-authored (freeform) issue formats in addition to the current templated format, plus CLI integration to wire the feature end-to-end.
+
+## Your Task
+
+Add a new --issue flag to the ultraplan CLI command that accepts a GitHub issue URL or shorthand (owner/repo#123). When provided, the plan is loaded from the GitHub issue instead of being generated.
+
+Modify internal/cmd/ultraplan.go:
+- Add `ultraplanIssueURL string` variable
+- Add flag: `--issue` with description 'Load plan from GitHub issue URL'
+- In runUltraplan():
+  - If --issue is set, call plan.BuildPlanFromURL()
+  - Use the returned PlanSpec instead of generating one
+  - Set objective from parent issue title
+  - Skip planning phase (jump to PhaseRefresh)
+- Add validation that --issue and --plan are mutually exclusive
+
+Update command help text with examples.
+
+## Expected Files
+
+You are expected to work with these files:
+- internal/cmd/ultraplan.go
+
+## Context from Previous Group
+
+This task builds on work consolidated from Group 4.
+
+**Consolidator Notes**: Successfully consolidated task-5-build-plan-freeform which completes the auto-detection support for the ingestion pipeline. The commit adds DetectParentIssueFormat() and ParseParentIssueBodyAuto() functions that mirror the sub-issue auto-detection pattern from group-3. The buildPlanFromGitHubIssue() and convertSubIssuesToTasks() functions now use auto-detection, enabling full support for all combinations of templated and freeform parent/sub-issues. Cherry-pick applied cleanly with no conflicts.
+
+**Important**: The previous group's consolidator flagged these issues:
+- The freeform parser infers complexity (defaults to medium) when not explicitly specified - document this behavior for users
+- Dependency extraction from freeform bodies finds all #N references inline - could document that users can mention dependencies naturally in prose
+- Consider adding CLI documentation for the --issue flag to explain that both templated (Claudio-generated) and freeform (human-authored) issues are supported
+- With Groups 1-4 complete, the ingestion pipeline is fully functional - next steps would be CLI integration to expose the --issue flag to users
+
+The consolidated code from the previous group has been verified (build/lint/tests passed).
+
+## Guidelines
+
+- Focus only on this specific task
+- Do not modify files outside of your assigned scope unless necessary
+- Commit your changes before writing the completion file
+
+## Completion Protocol
+
+When your task is complete, you MUST write a completion file to signal the orchestrator:
+
+1. Use Write tool to create `.claudio-task-complete.json` in your worktree root
+2. Include this JSON structure:
+```json
+{
+  "task_id": "task-6-cli-issue-flag",
+  "status": "complete",
+  "summary": "Brief description of what you accomplished",
+  "files_modified": ["list", "of", "files", "you", "changed"],
+  "notes": "Any implementation notes for the consolidation phase",
+  "issues": ["Any concerns or blocking issues found"],
+  "suggestions": ["Suggestions for integration with other tasks"],
+  "dependencies": ["Any new runtime dependencies added"]
+}
+```
+
+3. Use status "blocked" if you cannot complete (explain in issues), or "failed" if something broke
+4. This file signals that your work is done and provides context for consolidation

--- a/internal/plan/ingest.go
+++ b/internal/plan/ingest.go
@@ -50,6 +50,173 @@ var defaultExecutor CommandExecutor = func(name string, args ...string) ([]byte,
 	return cmd.CombinedOutput()
 }
 
+// =============================================================================
+// Error Types for GitHub Issue Ingestion
+// =============================================================================
+
+// IngestErrorKind categorizes the type of ingestion error.
+type IngestErrorKind string
+
+const (
+	// ErrKindGHNotInstalled indicates gh CLI is not installed or not in PATH.
+	ErrKindGHNotInstalled IngestErrorKind = "gh_not_installed"
+	// ErrKindAuthRequired indicates GitHub authentication is required.
+	ErrKindAuthRequired IngestErrorKind = "auth_required"
+	// ErrKindIssueNotFound indicates the requested issue does not exist (404).
+	ErrKindIssueNotFound IngestErrorKind = "issue_not_found"
+	// ErrKindRateLimited indicates the request was rate limited by GitHub.
+	ErrKindRateLimited IngestErrorKind = "rate_limited"
+	// ErrKindNoSubIssues indicates the parent issue has no sub-issues.
+	ErrKindNoSubIssues IngestErrorKind = "no_sub_issues"
+	// ErrKindParsingFailed indicates parsing the issue content failed.
+	ErrKindParsingFailed IngestErrorKind = "parsing_failed"
+	// ErrKindCircularDependency indicates a circular dependency was detected.
+	ErrKindCircularDependency IngestErrorKind = "circular_dependency"
+	// ErrKindUnsupportedProvider indicates the URL provider is not supported.
+	ErrKindUnsupportedProvider IngestErrorKind = "unsupported_provider"
+	// ErrKindRepoNotFound indicates the repository was not found or not accessible.
+	ErrKindRepoNotFound IngestErrorKind = "repo_not_found"
+)
+
+// IngestError is a structured error type for issue ingestion failures.
+// It provides context about which issue failed and suggestions for resolution.
+type IngestError struct {
+	// Kind categorizes the error type for programmatic handling.
+	Kind IngestErrorKind
+
+	// Message is the human-readable error description.
+	Message string
+
+	// IssueNum is the issue number that caused the error (0 if not applicable).
+	IssueNum int
+
+	// Owner is the repository owner (empty if not applicable).
+	Owner string
+
+	// Repo is the repository name (empty if not applicable).
+	Repo string
+
+	// Suggestion provides actionable advice for resolving the error.
+	Suggestion string
+
+	// Cause is the underlying error, if any.
+	Cause error
+}
+
+// Error implements the error interface.
+func (e *IngestError) Error() string {
+	var sb strings.Builder
+
+	sb.WriteString(e.Message)
+
+	if e.IssueNum > 0 {
+		sb.WriteString(fmt.Sprintf(" (issue #%d)", e.IssueNum))
+	}
+
+	if e.Owner != "" && e.Repo != "" {
+		sb.WriteString(fmt.Sprintf(" in %s/%s", e.Owner, e.Repo))
+	}
+
+	if e.Cause != nil {
+		sb.WriteString(fmt.Sprintf(": %v", e.Cause))
+	}
+
+	return sb.String()
+}
+
+// Unwrap returns the underlying error for use with errors.Is and errors.As.
+func (e *IngestError) Unwrap() error {
+	return e.Cause
+}
+
+// Is implements error matching for errors.Is().
+// It matches based on the Kind field when comparing with sentinel errors.
+func (e *IngestError) Is(target error) bool {
+	switch target {
+	case ErrGHNotInstalled:
+		return e.Kind == ErrKindGHNotInstalled
+	case ErrGHAuthRequired:
+		return e.Kind == ErrKindAuthRequired
+	case ErrIssueNotFound:
+		return e.Kind == ErrKindIssueNotFound
+	case ErrRateLimited:
+		return e.Kind == ErrKindRateLimited
+	case ErrNoSubIssues:
+		return e.Kind == ErrKindNoSubIssues
+	case ErrParsingFailed:
+		return e.Kind == ErrKindParsingFailed
+	case ErrCircularDependency:
+		return e.Kind == ErrKindCircularDependency
+	case ErrUnsupportedProvider:
+		return e.Kind == ErrKindUnsupportedProvider
+	case ErrRepoNotFound:
+		return e.Kind == ErrKindRepoNotFound
+	}
+	return false
+}
+
+// FormatForTerminal returns a user-friendly formatted string suitable for terminal output.
+// It includes the error message and suggestion (if any) formatted for CLI display.
+func (e *IngestError) FormatForTerminal() string {
+	var sb strings.Builder
+
+	// Error message with context
+	sb.WriteString("Error: ")
+	sb.WriteString(e.Message)
+
+	if e.IssueNum > 0 {
+		sb.WriteString(fmt.Sprintf(" (issue #%d)", e.IssueNum))
+	}
+
+	if e.Owner != "" && e.Repo != "" {
+		sb.WriteString(fmt.Sprintf(" in %s/%s", e.Owner, e.Repo))
+	}
+
+	// Add suggestion if available
+	if e.Suggestion != "" {
+		sb.WriteString("\n\nSuggestion: ")
+		sb.WriteString(e.Suggestion)
+	}
+
+	return sb.String()
+}
+
+// NewIngestError creates a new IngestError with the given parameters.
+func NewIngestError(kind IngestErrorKind, message string) *IngestError {
+	return &IngestError{
+		Kind:    kind,
+		Message: message,
+	}
+}
+
+// WithIssue adds issue context to the error.
+func (e *IngestError) WithIssue(issueNum int) *IngestError {
+	e.IssueNum = issueNum
+	return e
+}
+
+// WithRepo adds repository context to the error.
+func (e *IngestError) WithRepo(owner, repo string) *IngestError {
+	e.Owner = owner
+	e.Repo = repo
+	return e
+}
+
+// WithSuggestion adds a suggestion for resolving the error.
+func (e *IngestError) WithSuggestion(suggestion string) *IngestError {
+	e.Suggestion = suggestion
+	return e
+}
+
+// WithCause adds an underlying error.
+func (e *IngestError) WithCause(cause error) *IngestError {
+	e.Cause = cause
+	return e
+}
+
+// Sentinel errors for backward compatibility and errors.Is() matching.
+// These are kept for compatibility with existing code that uses errors.Is().
+
 // ErrGHNotInstalled indicates that the gh CLI tool is not installed or not in PATH.
 var ErrGHNotInstalled = errors.New("gh CLI is not installed or not in PATH")
 
@@ -58,6 +225,15 @@ var ErrGHAuthRequired = errors.New("gh CLI requires authentication (run 'gh auth
 
 // ErrIssueNotFound indicates that the requested issue does not exist.
 var ErrIssueNotFound = errors.New("issue not found")
+
+// ErrRateLimited indicates that the request was rate limited by GitHub.
+var ErrRateLimited = errors.New("rate limited by GitHub")
+
+// ErrCircularDependency indicates that a circular dependency was detected in sub-issues.
+var ErrCircularDependency = errors.New("circular dependency detected")
+
+// ErrRepoNotFound indicates that the repository was not found or not accessible.
+var ErrRepoNotFound = errors.New("repository not found")
 
 // FetchIssue fetches a GitHub issue by owner, repo, and issue number using the gh CLI.
 // It returns a GitHubIssue struct containing the issue data, or an error if the fetch fails.
@@ -119,13 +295,15 @@ func fetchIssueWithExecutor(owner, repo string, issueNum int, executor CommandEx
 
 // classifyGHError analyzes the error and output from a gh command
 // and returns a more specific error type when possible.
+// It returns *IngestError with appropriate context and suggestions.
 func classifyGHError(err error, output []byte, issueNum int) error {
 	outStr := strings.ToLower(string(output))
 
 	// Check for "executable file not found" which indicates gh is not installed
 	var execErr *exec.Error
 	if errors.As(err, &execErr) {
-		return ErrGHNotInstalled
+		return NewIngestError(ErrKindGHNotInstalled, "GitHub CLI (gh) is not installed or not in PATH").
+			WithSuggestion("Install the GitHub CLI: https://cli.github.com/")
 	}
 
 	// Check for common error patterns in output
@@ -133,19 +311,40 @@ func classifyGHError(err error, output []byte, issueNum int) error {
 	case strings.Contains(outStr, "not logged in") ||
 		strings.Contains(outStr, "authentication required") ||
 		strings.Contains(outStr, "gh auth login"):
-		return ErrGHAuthRequired
+		return NewIngestError(ErrKindAuthRequired, "GitHub authentication required").
+			WithIssue(issueNum).
+			WithSuggestion("Run 'gh auth login' to authenticate with GitHub")
+
+	case strings.Contains(outStr, "rate limit") ||
+		strings.Contains(outStr, "api rate limit") ||
+		strings.Contains(outStr, "secondary rate limit") ||
+		strings.Contains(outStr, "abuse detection"):
+		return NewIngestError(ErrKindRateLimited, "GitHub API rate limit exceeded").
+			WithIssue(issueNum).
+			WithSuggestion("Wait a few minutes and try again. If using a token, ensure it has sufficient rate limits.")
 
 	case strings.Contains(outStr, "could not find issue") ||
-		strings.Contains(outStr, "issue not found") ||
-		strings.Contains(outStr, "not found"):
-		return fmt.Errorf("%w: #%d", ErrIssueNotFound, issueNum)
+		strings.Contains(outStr, "issue not found"):
+		return NewIngestError(ErrKindIssueNotFound, "issue not found").
+			WithIssue(issueNum).
+			WithSuggestion("Verify the issue number exists and you have access to the repository")
 
 	case strings.Contains(outStr, "could not resolve to a repository"):
-		return fmt.Errorf("repository not found or not accessible")
+		return NewIngestError(ErrKindRepoNotFound, "repository not found or not accessible").
+			WithIssue(issueNum).
+			WithSuggestion("Check the repository name and ensure you have access. For private repos, run 'gh auth login'")
+
+	case strings.Contains(outStr, "not found"):
+		// Generic "not found" - could be issue or repo
+		return NewIngestError(ErrKindIssueNotFound, "resource not found").
+			WithIssue(issueNum).
+			WithSuggestion("Verify the issue number and repository are correct")
 	}
 
 	// Return the original error with output for debugging
-	return fmt.Errorf("gh command failed: %w\n%s", err, string(output))
+	return NewIngestError(ErrKindParsingFailed, "gh command failed").
+		WithIssue(issueNum).
+		WithCause(fmt.Errorf("%w\n%s", err, string(output)))
 }
 
 // GitHub issue URL patterns
@@ -809,31 +1008,56 @@ func buildPlanFromGitHubIssue(url string, executor CommandExecutor) (*orchestrat
 	// Step 2: Fetch the parent issue
 	parentIssue, err := fetchIssueWithExecutor(owner, repo, issueNum, executor)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch parent issue #%d: %w", issueNum, err)
+		// Enhance error with repo context if not already present
+		if ingestErr, ok := err.(*IngestError); ok {
+			return nil, ingestErr.WithRepo(owner, repo)
+		}
+		return nil, NewIngestError(ErrKindParsingFailed, "failed to fetch parent issue").
+			WithIssue(issueNum).
+			WithRepo(owner, repo).
+			WithCause(err)
 	}
 
-	// Step 3: Parse the parent issue body to extract structure
-	parentContent, err := ParseParentIssueBody(parentIssue.Body)
+	// Step 3: Detect format and parse the parent issue body to extract structure
+	// This supports both templated (Claudio-generated) and freeform (human-authored) issues
+	parentContent, err := ParseParentIssueBodyAuto(parentIssue.Body)
 	if err != nil {
-		return nil, fmt.Errorf("%w: failed to parse parent issue body: %v", ErrParsingFailed, err)
+		return nil, NewIngestError(ErrKindParsingFailed, "failed to parse parent issue body").
+			WithIssue(issueNum).
+			WithRepo(owner, repo).
+			WithCause(err).
+			WithSuggestion("Ensure the issue follows a supported format with sub-issues listed as #N references")
 	}
 
 	// Step 4: Collect all sub-issue numbers from execution groups
 	subIssueNums := collectSubIssueNumbers(parentContent.ExecutionGroups)
 	if len(subIssueNums) == 0 {
-		return nil, fmt.Errorf("%w: no sub-issues found in parent issue #%d", ErrNoSubIssues, issueNum)
+		return nil, NewIngestError(ErrKindNoSubIssues, "no sub-issues found in parent issue").
+			WithIssue(issueNum).
+			WithRepo(owner, repo).
+			WithSuggestion("The parent issue must reference sub-issues using #N syntax (e.g., '- [ ] #123 - Task title')")
 	}
 
 	// Step 5: Fetch all sub-issues and build the issue number to task ID mapping
-	subIssues, issueNumToTaskID, err := fetchSubIssuesWithMapping(owner, repo, subIssueNums, executor)
+	subIssues, issueNumToTaskID, err := fetchSubIssuesWithMappingEnhanced(owner, repo, subIssueNums, executor)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch sub-issues: %w", err)
+		// Error already has context from fetchSubIssuesWithMappingEnhanced
+		return nil, err
 	}
 
 	// Step 6: Convert each sub-issue to a PlannedTask
-	tasks, err := convertSubIssuesToTasks(subIssues, issueNumToTaskID)
+	// Pass the parent issue number for freeform sub-issues to exclude from dependencies
+	tasks, err := convertSubIssuesToTasksEnhanced(subIssues, issueNumToTaskID, issueNum, owner, repo)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert issues to tasks: %w", err)
+		// Error already has context from convertSubIssuesToTasksEnhanced
+		return nil, err
+	}
+
+	// Step 6.5: Check for circular dependencies
+	if cycle := detectCircularDependencies(tasks); cycle != nil {
+		return nil, NewIngestError(ErrKindCircularDependency, "circular dependency detected in sub-issues").
+			WithRepo(owner, repo).
+			WithSuggestion(fmt.Sprintf("Review the dependency chain: %s", formatDependencyCycle(cycle)))
 	}
 
 	// Step 7: Build execution order from parent's execution groups
@@ -879,16 +1103,24 @@ func collectSubIssueNumbers(executionGroups [][]int) []int {
 	return nums
 }
 
-// fetchSubIssuesWithMapping fetches all sub-issues and builds a mapping from
-// issue numbers to task IDs (which are generated from issue number and title)
-func fetchSubIssuesWithMapping(owner, repo string, issueNums []int, executor CommandExecutor) (map[int]*GitHubIssue, map[int]string, error) {
+// fetchSubIssuesWithMappingEnhanced fetches all sub-issues and builds a mapping from
+// issue numbers to task IDs (which are generated from issue number and title).
+// Returns *IngestError with detailed context for each failure.
+func fetchSubIssuesWithMappingEnhanced(owner, repo string, issueNums []int, executor CommandExecutor) (map[int]*GitHubIssue, map[int]string, error) {
 	issues := make(map[int]*GitHubIssue)
 	issueNumToTaskID := make(map[int]string)
 
 	for _, num := range issueNums {
 		issue, err := fetchIssueWithExecutor(owner, repo, num, executor)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to fetch sub-issue #%d: %w", num, err)
+			// Enhance error with repo context if not already present
+			if ingestErr, ok := err.(*IngestError); ok {
+				return nil, nil, ingestErr.WithRepo(owner, repo)
+			}
+			return nil, nil, NewIngestError(ErrKindParsingFailed, "failed to fetch sub-issue").
+				WithIssue(num).
+				WithRepo(owner, repo).
+				WithCause(err)
 		}
 		issues[num] = issue
 		// Generate task ID immediately so we can use it for dependency resolution
@@ -898,27 +1130,107 @@ func fetchSubIssuesWithMapping(owner, repo string, issueNums []int, executor Com
 	return issues, issueNumToTaskID, nil
 }
 
-// convertSubIssuesToTasks converts all fetched sub-issues to PlannedTasks
-func convertSubIssuesToTasks(subIssues map[int]*GitHubIssue, issueNumToTaskID map[int]string) ([]orchestrator.PlannedTask, error) {
+// convertSubIssuesToTasksEnhanced converts all fetched sub-issues to PlannedTasks.
+// The parentIssueNum is used for freeform issues to exclude the parent from dependencies.
+// Returns *IngestError with detailed context for each failure.
+func convertSubIssuesToTasksEnhanced(subIssues map[int]*GitHubIssue, issueNumToTaskID map[int]string, parentIssueNum int, owner, repo string) ([]orchestrator.PlannedTask, error) {
 	var tasks []orchestrator.PlannedTask
 
 	for num, issue := range subIssues {
-		// Parse the sub-issue body
-		content, err := ParseSubIssueBody(issue.Body)
+		// Parse the sub-issue body using auto-detection
+		// This supports both templated (Claudio-generated) and freeform (human-authored) sub-issues
+		content, err := ParseSubIssueBodyAuto(issue.Body, parentIssueNum)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse sub-issue #%d body: %w", num, err)
+			return nil, NewIngestError(ErrKindParsingFailed, "failed to parse sub-issue body").
+				WithIssue(num).
+				WithRepo(owner, repo).
+				WithCause(err).
+				WithSuggestion("Check that the sub-issue body contains a valid description")
 		}
 
 		// Convert to PlannedTask
 		task, err := ConvertToPlannedTask(*issue, *content, issueNumToTaskID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert sub-issue #%d to task: %w", num, err)
+			return nil, NewIngestError(ErrKindParsingFailed, "failed to convert sub-issue to task").
+				WithIssue(num).
+				WithRepo(owner, repo).
+				WithCause(err).
+				WithSuggestion("Ensure the sub-issue has a title and valid content")
 		}
 
 		tasks = append(tasks, task)
 	}
 
 	return tasks, nil
+}
+
+// detectCircularDependencies checks for circular dependencies in a list of tasks.
+// Returns the cycle as a slice of task IDs if found, or nil if no cycle exists.
+func detectCircularDependencies(tasks []orchestrator.PlannedTask) []string {
+	// Build adjacency list from task dependencies
+	deps := make(map[string][]string)
+	taskExists := make(map[string]bool)
+	for _, task := range tasks {
+		deps[task.ID] = task.DependsOn
+		taskExists[task.ID] = true
+	}
+
+	// Track visit state: 0=unvisited, 1=visiting (in current path), 2=visited (complete)
+	state := make(map[string]int)
+	var cyclePath []string
+
+	// DFS to detect cycles
+	var visit func(taskID string, path []string) bool
+	visit = func(taskID string, path []string) bool {
+		if state[taskID] == 1 {
+			// Found a cycle - extract just the cycle portion
+			for i, id := range path {
+				if id == taskID {
+					cyclePath = append(path[i:], taskID)
+					return true
+				}
+			}
+			cyclePath = append(path, taskID)
+			return true
+		}
+		if state[taskID] == 2 {
+			return false
+		}
+
+		state[taskID] = 1
+		path = append(path, taskID)
+
+		for _, depID := range deps[taskID] {
+			// Only check dependencies that exist in our task set
+			if taskExists[depID] && visit(depID, path) {
+				return true
+			}
+		}
+
+		state[taskID] = 2
+		return false
+	}
+
+	// Check all tasks
+	for _, task := range tasks {
+		if state[task.ID] == 0 {
+			if visit(task.ID, nil) {
+				return cyclePath
+			}
+		}
+	}
+
+	return nil
+}
+
+// formatDependencyCycle formats a cycle path for display.
+// Input: ["task-1", "task-2", "task-3", "task-1"]
+// Output: "task-1 -> task-2 -> task-3 -> task-1"
+func formatDependencyCycle(cycle []string) string {
+	if len(cycle) == 0 {
+		return ""
+	}
+	return strings.Join(cycle, " -> ")
 }
 
 // buildExecutionOrder converts issue number groups to task ID groups
@@ -1531,5 +1843,65 @@ func ParseSubIssueBodyAuto(body string, parentIssueNum int) (*SubIssueContent, e
 		// This should never happen given the current implementation,
 		// but we handle it gracefully by defaulting to freeform parsing
 		return ParseFreeformSubIssueBody(body, parentIssueNum)
+	}
+}
+
+// DetectParentIssueFormat determines whether a parent issue body is templated or freeform.
+// Parent issues are templated if they have:
+//   - "## Summary" section AND "## Sub-Issues" section with "### Group N" headers
+//
+// Parent issues are considered freeform if they:
+//   - Use human-authored structure (e.g., "## Overview", "## Tasks", generic headers)
+//   - Don't follow the strict Claudio parent template format
+func DetectParentIssueFormat(body string) IssueFormat {
+	if strings.TrimSpace(body) == "" {
+		return IssueFormatFreeform
+	}
+
+	// Check for templated parent issue markers by scanning each line
+	// (the regex patterns are line-anchored with ^)
+	var hasSummarySection, hasSubIssuesSection, hasGroupHeaders bool
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if summaryHeaderRe.MatchString(trimmed) {
+			hasSummarySection = true
+		}
+		if subIssuesHeaderRe.MatchString(trimmed) {
+			hasSubIssuesSection = true
+		}
+		if groupHeaderRe.MatchString(trimmed) {
+			hasGroupHeaders = true
+		}
+	}
+
+	// A parent issue is templated if it has Summary + Sub-Issues sections with Group headers
+	if hasSummarySection && hasSubIssuesSection && hasGroupHeaders {
+		return IssueFormatTemplated
+	}
+
+	return IssueFormatFreeform
+}
+
+// ParseParentIssueBodyAuto is a unified entry point that auto-detects the parent issue
+// format and delegates to the appropriate parser. This simplifies the ingestion pipeline
+// by providing a single function that handles both templated and freeform parent issues.
+//
+// The function:
+//   - Detects the format using DetectParentIssueFormat
+//   - Delegates to ParseParentIssueBody for templated issues
+//   - Delegates to ParseFreeformParentIssueBody for freeform issues
+//
+// Returns a ParentIssueContent struct with consistent fields regardless of input format.
+func ParseParentIssueBodyAuto(body string) (*ParentIssueContent, error) {
+	format := DetectParentIssueFormat(body)
+
+	switch format {
+	case IssueFormatTemplated:
+		return ParseParentIssueBody(body)
+	case IssueFormatFreeform:
+		return ParseFreeformParentIssueBody(body)
+	default:
+		// Default to freeform parsing for robustness
+		return ParseFreeformParentIssueBody(body)
 	}
 }


### PR DESCRIPTION
## Objective

Enable UltraPlan to ingest GitHub Issues as task plans. This is group 3 of a stacked PR series implementing issue #244.

## Tasks Included

- **task-4-unified-sub-parser**: Create unified sub-issue parser

## Changes

This PR adds unified entry points that delegate to appropriate parsers based on detected format:

### `ParseParentIssueBodyAuto()`
Auto-detects issue format and routes to either:
- `ParseParentIssueBody()` for Claudio-templated issues
- `ParseFreeformParentIssueBody()` for human-authored issues

### `ParseSubIssueBodyAuto()`
Auto-detects issue format and routes to either:
- `ParseSubIssueBody()` for Claudio-templated issues
- `ParseFreeformSubIssueBody()` for human-authored issues

This abstraction allows the rest of the codebase to parse issues without caring about the underlying format.

## Merge Order

This is **group 3 of 6** in a stacked PR series. Merge in order:
1. Group 1 - Issue format detection
2. Group 2 - Freeform parsers
3. **This PR** (group 3) - Unified sub-issue parser
4. Group 4 - BuildPlanFromURL extension
5. Group 5 - CLI --issue flag
6. Group 6 - Error handling and documentation

Closes part of #244