### PR TITLE
fix(ultraplan): compute ExecutionOrder when importing plan files

### DIFF
--- a/internal/cmd/ultraplan.go
+++ b/internal/cmd/ultraplan.go
@@ -262,6 +262,10 @@ func loadPlanFile(path string) (*orchestrator.PlanSpec, error) {
 		return nil, fmt.Errorf("failed to parse plan JSON: %w", err)
 	}
 
+	// Compute DependencyGraph and ExecutionOrder if they weren't in the JSON
+	// (e.g., plan files that only have tasks with depends_on fields)
+	orchestrator.EnsurePlanComputed(&plan)
+
 	if err := orchestrator.ValidatePlan(&plan); err != nil {
 		return nil, err
 	}

--- a/internal/orchestrator/ultraplan.go
+++ b/internal/orchestrator/ultraplan.go
@@ -1104,6 +1104,28 @@ func calculateExecutionOrder(tasks []PlannedTask, deps map[string][]string) [][]
 	return groups
 }
 
+// EnsurePlanComputed fills in computed fields (DependencyGraph and ExecutionOrder)
+// if they are missing. This is used when loading a plan file that only has tasks
+// with depends_on fields but not the pre-computed graph and execution order.
+func EnsurePlanComputed(plan *PlanSpec) {
+	if plan == nil || len(plan.Tasks) == 0 {
+		return
+	}
+
+	// Build DependencyGraph from task DependsOn fields if missing
+	if len(plan.DependencyGraph) == 0 {
+		plan.DependencyGraph = make(map[string][]string)
+		for _, task := range plan.Tasks {
+			plan.DependencyGraph[task.ID] = task.DependsOn
+		}
+	}
+
+	// Calculate ExecutionOrder if missing
+	if len(plan.ExecutionOrder) == 0 {
+		plan.ExecutionOrder = calculateExecutionOrder(plan.Tasks, plan.DependencyGraph)
+	}
+}
+
 // ValidatePlan checks the plan for validity (no cycles, valid dependencies)
 func ValidatePlan(plan *PlanSpec) error {
 	if plan == nil {


### PR DESCRIPTION
## Summary

- Plan files imported via `--plan` flag were missing computed fields (`ExecutionOrder` and `DependencyGraph`) because `loadPlanFile()` did a raw JSON unmarshal without computing them from task `depends_on` fields
- This caused the TUI to show "EXECUTION [0/36]" with no visible groups since it iterates over the empty `ExecutionOrder` slice
- Added `EnsurePlanComputed()` helper that fills in missing computed fields and call it from `loadPlanFile()` after unmarshaling

Fixes #244

## Test plan

- [x] Added `TestEnsurePlanComputed` with table-driven tests covering:
  - Computing missing fields from tasks with `depends_on`
  - Preserving existing `ExecutionOrder` and `DependencyGraph`
  - Handling nil plan
  - Handling empty tasks
  - All independent tasks in single group
- [x] All existing tests pass
- [x] `go vet` passes
- [x] `gofmt` passes
- [x] Build succeeds