### PR TITLE
fix(tui): preserve ANSI colors in terminal pane output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.10.1
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gobwas/glob v0.2.3
 	github.com/spf13/cobra v1.10.2
@@ -17,7 +18,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect

--- a/internal/tui/terminal/process.go
+++ b/internal/tui/terminal/process.go
@@ -262,8 +262,9 @@ func (p *Process) CaptureOutput() (string, error) {
 		return "", ErrNotRunning
 	}
 
-	// Capture visible pane content
-	cmd := exec.Command("tmux", "capture-pane", "-t", sessionName, "-p")
+	// Capture visible pane content with escape sequences preserved (-e flag)
+	// The -e flag preserves ANSI color codes and other escape sequences
+	cmd := exec.Command("tmux", "capture-pane", "-t", sessionName, "-p", "-e")
 	output, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to capture terminal output: %w", err)
@@ -284,7 +285,8 @@ func (p *Process) CaptureOutputWithHistory(lines int) (string, error) {
 	}
 
 	// Capture with history (-S for start line, negative means history)
-	cmd := exec.Command("tmux", "capture-pane", "-t", sessionName, "-p", "-S", fmt.Sprintf("-%d", lines))
+	// The -e flag preserves ANSI color codes and other escape sequences
+	cmd := exec.Command("tmux", "capture-pane", "-t", sessionName, "-p", "-e", "-S", fmt.Sprintf("-%d", lines))
 	output, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to capture terminal output with history: %w", err)

--- a/internal/tui/view/terminal.go
+++ b/internal/tui/view/terminal.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Iron-Ham/claudio/internal/tui/styles"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // TerminalView handles rendering of the terminal pane at the bottom of the screen.
@@ -146,6 +147,7 @@ func (v *TerminalView) renderOutput(output string, height int) string {
 }
 
 // truncateString truncates a string to the given width, adding ellipsis if needed.
+// This function properly handles ANSI escape codes and wide characters.
 func truncateString(s string, maxWidth int) string {
 	if maxWidth <= 3 {
 		return "..."
@@ -153,10 +155,7 @@ func truncateString(s string, maxWidth int) string {
 	if lipgloss.Width(s) <= maxWidth {
 		return s
 	}
-	// Simple truncation (doesn't handle ANSI codes perfectly)
-	runes := []rune(s)
-	if len(runes) > maxWidth-3 {
-		return string(runes[:maxWidth-3]) + "..."
-	}
-	return s
+	// Use ANSI-aware truncation to preserve escape sequences
+	// ansi.Truncate includes the tail in the final width calculation
+	return ansi.Truncate(s, maxWidth, "...")
 }

--- a/internal/tui/view/terminal_test.go
+++ b/internal/tui/view/terminal_test.go
@@ -337,6 +337,31 @@ func TestTruncateString(t *testing.T) {
 			maxWidth: 2,
 			want:     "...",
 		},
+		// ANSI escape sequence test cases
+		{
+			name:     "ANSI colored string shorter than max",
+			input:    "\x1b[34mhello\x1b[0m",
+			maxWidth: 10,
+			want:     "\x1b[34mhello\x1b[0m",
+		},
+		{
+			name:     "ANSI colored string equal to max",
+			input:    "\x1b[34mhello\x1b[0m",
+			maxWidth: 5,
+			want:     "\x1b[34mhello\x1b[0m",
+		},
+		{
+			name:     "ANSI colored string truncated",
+			input:    "\x1b[34mhello world\x1b[0m",
+			maxWidth: 8,
+			want:     "\x1b[34mhello...\x1b[0m", // reset comes after ellipsis
+		},
+		{
+			name:     "multiple ANSI codes preserved",
+			input:    "\x1b[1m\x1b[34mbold blue text\x1b[0m",
+			maxWidth: 10,
+			want:     "\x1b[1m\x1b[34mbold bl...\x1b[0m", // reset comes after ellipsis
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Add `-e` flag to `tmux capture-pane` commands to preserve ANSI escape sequences, fixing the issue where terminal colors (like blue directories in `ls` output) were being stripped
- Improve `truncateString` to use ANSI-aware truncation from `charmbracelet/x/ansi`, preventing escape sequences from being corrupted when header text is truncated
- Add test cases for ANSI escape sequence handling in truncation

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New ANSI truncation tests pass
- [x] `go vet ./...` passes
- [x] `gofmt -d .` shows no formatting issues
- [ ] Manual testing: run Claudio, open terminal pane, run `ls --color` and verify directories appear in blue