### PR TITLE
feat(ultraplan): add step restart and universal input mode

### DIFF
--- a/internal/orchestrator/ultraplan.go
+++ b/internal/orchestrator/ultraplan.go
@@ -41,6 +41,28 @@ const (
 	ComplexityHigh   TaskComplexity = "high"
 )
 
+// StepType represents the type of an ultraplan step for restart/input mode operations
+type StepType string
+
+const (
+	StepTypePlanning          StepType = "planning"
+	StepTypePlanManager       StepType = "plan_manager"
+	StepTypeTask              StepType = "task"
+	StepTypeSynthesis         StepType = "synthesis"
+	StepTypeRevision          StepType = "revision"
+	StepTypeConsolidation     StepType = "consolidation"
+	StepTypeGroupConsolidator StepType = "group_consolidator"
+)
+
+// StepInfo contains information about an ultraplan step for restart/input operations
+type StepInfo struct {
+	Type       StepType
+	InstanceID string
+	TaskID     string // Only set for task and group_consolidator steps
+	GroupIndex int    // Only set for task and group_consolidator steps (-1 otherwise)
+	Label      string // Human-readable description
+}
+
 // PlannedTask represents a single decomposed task from the planning phase
 type PlannedTask struct {
 	ID            string         `json:"id"`

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -733,9 +733,10 @@ func (m Model) handleKeypress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "enter", "i":
 		// Enter input mode for the active instance
+		// Allow input if tmux session exists (running or waiting for input)
 		if inst := m.activeInstance(); inst != nil {
 			mgr := m.orchestrator.GetInstanceManager(inst.ID)
-			if mgr != nil && mgr.Running() {
+			if mgr != nil && mgr.TmuxSessionExists() {
 				m.inputMode = true
 			}
 		}

--- a/internal/tui/view/ultraplan.go
+++ b/internal/tui/view/ultraplan.go
@@ -1074,9 +1074,12 @@ func (v *UltraplanView) RenderHelp() string {
 	case orchestrator.PhasePlanning:
 		keys = append(keys, "[p] parse plan")
 		keys = append(keys, "[i] input mode")
+		keys = append(keys, "[:restart] restart step")
 
 	case orchestrator.PhasePlanSelection:
 		keys = append(keys, "[v] toggle plan view")
+		keys = append(keys, "[i] input mode")
+		keys = append(keys, "[:restart] restart step")
 
 	case orchestrator.PhaseRefresh:
 		keys = append(keys, "[e] start execution")
@@ -1087,11 +1090,13 @@ func (v *UltraplanView) RenderHelp() string {
 		keys = append(keys, "[1-9] select task")
 		keys = append(keys, "[i] input mode")
 		keys = append(keys, "[v] toggle plan view")
+		keys = append(keys, "[:restart] restart task")
 		keys = append(keys, "[:cancel] cancel")
 
 	case orchestrator.PhaseSynthesis:
 		keys = append(keys, "[i] input mode")
 		keys = append(keys, "[v] toggle plan view")
+		keys = append(keys, "[:restart] restart synthesis")
 		if session.SynthesisAwaitingApproval {
 			keys = append(keys, "[s] approve → proceed")
 		} else {
@@ -1100,13 +1105,17 @@ func (v *UltraplanView) RenderHelp() string {
 
 	case orchestrator.PhaseRevision:
 		keys = append(keys, "[tab] next instance")
+		keys = append(keys, "[i] input mode")
 		keys = append(keys, "[v] toggle plan view")
+		keys = append(keys, "[:restart] restart revision")
 		if session.Revision != nil {
 			keys = append(keys, fmt.Sprintf("round %d/%d", session.Revision.RevisionRound, session.Revision.MaxRevisions))
 		}
 
 	case orchestrator.PhaseConsolidating:
+		keys = append(keys, "[i] input mode")
 		keys = append(keys, "[v] toggle plan view")
+		keys = append(keys, "[:restart] restart consolidation")
 		if session.Consolidation != nil && session.Consolidation.Phase == orchestrator.ConsolidationPaused {
 			keys = append(keys, "[r] resume")
 		}


### PR DESCRIPTION
## Summary
- Allow users to restart any UltraPlan step (task, synthesis, consolidation, revision, planning, or plan manager) when it fails or times out
- Enable entering input mode for any step with an active tmux session, not just "running" instances
- Add `StepType` enum, `StepInfo` struct, `GetStepInfo()`, and `RestartStep()` methods with type-specific restart logic for all 7 step types

## Test plan
- [x] Run `go test ./...` - all tests pass
- [x] Run `go build ./...` - build succeeds
- [x] Run `go vet ./...` - no lint warnings
- [ ] Manual testing: Start UltraPlan, let a task timeout, use `:restart` to restart it
- [ ] Manual testing: While an instance is waiting for input (not "running"), press `i` to enter input mode