### PR TITLE
fix(tui): correct terminal pane width and resize display artifacts

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -323,7 +323,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		return m, nil
+		// Force a full screen redraw after resize to prevent display artifacts
+		// This helps with terminal emulators that don't properly clear stale content
+		return m, tea.ClearScreen
 
 	case tickMsg:
 		// Update outputs from instances

--- a/internal/tui/view/terminal.go
+++ b/internal/tui/view/terminal.go
@@ -69,7 +69,7 @@ func (v *TerminalView) Render(state TerminalState) string {
 	}
 
 	return borderStyle.
-		Width(v.Width - 2). // Account for border only (padding is inside)
+		Width(v.Width). // Full width - lipgloss Width() sets outer width including border/padding
 		Height(v.Height).
 		MaxHeight(v.Height).
 		Render(b.String())


### PR DESCRIPTION
## Summary
- Fix terminal pane width calculation to properly align tmux content with view boundaries
- Add screen clear on resize to prevent display artifacts in terminal emulators

## Details

### Width Calculation Fix
The terminal pane was cutting off ~2 characters on the right edge. This was caused by a mismatch between:
- The tmux process, which was sized to `width - 4` (accounting for border + padding)
- The view, which was setting `Width(v.Width - 2)` (only accounting for border)

In lipgloss, `Width()` sets the **outer** width. With border (2 chars) and padding (2 chars), the inner content area is `width - 4`. The fix changes to `Width(v.Width)` so the outer width matches the terminal width and inner content matches tmux.

### Resize Display Fix
When resizing the terminal (especially in iTerm with split panes), the alternate screen buffer sometimes retained stale content, causing visual artifacts like duplicate titles. Adding `tea.ClearScreen` on resize forces a full redraw.

## Test plan
- [x] All existing tests pass
- [x] Build succeeds
- [x] `go vet` passes
- [ ] Manual testing: resize terminal while terminal pane is visible
- [ ] Manual testing: verify terminal pane content is not cut off on the right