### PR TITLE
docs: add Unreleased section to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Claudio will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+### Changed
+
+### Performance
+
 ## [0.3.0] - 2026-01-12
 
 This release brings **deep GitHub Issues integration**, **plan import from URLs**, **a persistent terminal pane**, major **architecture improvements**, and numerous reliability enhancements across the board.


### PR DESCRIPTION
## Summary
- Adds an empty `[Unreleased]` section to CHANGELOG.md following Keep a Changelog format
- Includes subsection headers (Added, Fixed, Changed, Performance) ready for entries
- Enables incremental changelog updates as changes are made

Stacked on #309

## Test plan
- [x] Verify Unreleased section follows Keep a Changelog format
- [x] Verify subsections are present and empty