### PR TITLE
docs: add PATH export instruction for go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,12 @@ go build -o claudio ./cmd/claudio
 
 # Install to your PATH (optional)
 go install ./cmd/claudio
+
+# Ensure Go's bin directory is in your PATH
+export PATH="$PATH:$HOME/go/bin"
 ```
+
+To make this permanent, add the export line to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.).
 
 ### Verify Installation
 


### PR DESCRIPTION
## Summary
- Adds `export PATH="$PATH:$HOME/go/bin"` instruction to the installation section
- Includes note about making the PATH change permanent via shell profile

## Test plan
- [x] Verify README renders correctly on GitHub