### PR TITLE
feat(tui): add task chaining via :chain command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Claudio will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **TUI Task Chaining** - Chain tasks via TUI using `:chain`, `:dep`, or `:depends` commands to add tasks that auto-start when the selected instance completes
+
 ## [0.3.0] - 2026-01-12
 
 This release brings **deep GitHub Issues integration**, **plan import from URLs**, **a persistent terminal pane**, major **architecture improvements**, and numerous reliability enhancements across the board.

--- a/internal/tui/command/handler.go
+++ b/internal/tui/command/handler.go
@@ -61,6 +61,11 @@ type Result struct {
 	DiffContent   *string
 	DiffScroll    *int
 
+	// AddingDependentTask signals entering dependent task input mode
+	// DependentOnInstanceID is the ID of the instance the new task will depend on
+	AddingDependentTask   *bool
+	DependentOnInstanceID *string
+
 	// ActiveTabAdjustment indicates how to adjust the active tab after instance removal
 	// -1 = decrement if needed, 0 = no change needed, positive = specific check needed
 	ActiveTabAdjustment int
@@ -128,6 +133,9 @@ func (h *Handler) registerCommands() {
 	// Instance management commands
 	h.commands["a"] = cmdAdd
 	h.commands["add"] = cmdAdd
+	h.commands["chain"] = cmdChain
+	h.commands["dep"] = cmdChain
+	h.commands["depends"] = cmdChain
 	h.commands["D"] = cmdRemove
 	h.commands["remove"] = cmdRemove
 	h.commands["kill"] = cmdKill
@@ -360,6 +368,20 @@ func cmdRestart(deps Dependencies) Result {
 func cmdAdd(_ Dependencies) Result {
 	addingTask := true
 	return Result{AddingTask: &addingTask}
+}
+
+func cmdChain(deps Dependencies) Result {
+	inst := deps.ActiveInstance()
+	if inst == nil {
+		return Result{ErrorMessage: "No instance selected. Select an instance first, then use :chain to add a dependent task."}
+	}
+
+	addingDepTask := true
+	instanceID := inst.ID
+	return Result{
+		AddingDependentTask:   &addingDepTask,
+		DependentOnInstanceID: &instanceID,
+	}
 }
 
 func cmdRemove(deps Dependencies) Result {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -88,9 +88,13 @@ type Model struct {
 	addingTask      bool
 	taskInput       string
 	taskInputCursor int // Cursor position within taskInput (0 = before first char)
-	errorMessage    string
-	infoMessage     string // Non-error status message
-	inputMode       bool   // When true, all keys are forwarded to the active instance's tmux session
+
+	// Dependent task state (for :chain command - adding a task that depends on another)
+	addingDependentTask   bool   // When true, taskInput will create a dependent task
+	dependentOnInstanceID string // The instance ID that the new task will depend on
+	errorMessage          string
+	infoMessage           string // Non-error status message
+	inputMode             bool   // When true, all keys are forwarded to the active instance's tmux session
 
 	// Command mode state (vim-style ex commands with ':' prefix)
 	commandMode   bool   // When true, we're typing a command after ':'

--- a/internal/tui/view/input.go
+++ b/internal/tui/view/input.go
@@ -22,6 +22,10 @@ type InputState struct {
 	Text   string // The current input text
 	Cursor int    // Cursor position (0 = before first char)
 
+	// Title and subtitle (optional - uses defaults if empty)
+	Title    string // Title shown at top (default: "Add New Instance")
+	Subtitle string // Subtitle shown below title (default: "Enter task description:")
+
 	// Template dropdown state
 	ShowTemplates    bool           // Whether the template dropdown is visible
 	Templates        []TemplateItem // Filtered templates to display
@@ -42,10 +46,20 @@ func NewInputView() *InputView {
 func (v *InputView) Render(state *InputState, width int) string {
 	var b strings.Builder
 
-	// Title
-	b.WriteString(styles.Title.Render("Add New Instance"))
+	// Title (use default if not set)
+	title := state.Title
+	if title == "" {
+		title = "Add New Instance"
+	}
+	b.WriteString(styles.Title.Render(title))
 	b.WriteString("\n\n")
-	b.WriteString("Enter task description:\n\n")
+
+	// Subtitle (use default if not set)
+	subtitle := state.Subtitle
+	if subtitle == "" {
+		subtitle = "Enter task description:"
+	}
+	b.WriteString(subtitle + "\n\n")
 
 	// Render text input with cursor
 	b.WriteString(v.renderTextInput(state))


### PR DESCRIPTION
## Summary
- Add `:chain`, `:dep`, `:depends` commands to chain tasks via TUI
- New tasks automatically start when the selected parent instance completes
- Reuses existing `AddInstanceWithDependencies` infrastructure from CLI

## Changes
- **internal/tui/command/handler.go**: Add `cmdChain` function and register command aliases
- **internal/tui/app.go**: Add `dependentTaskAddedMsg`, `addDependentTaskAsync`, update message handling, add error logging
- **internal/tui/model.go**: Add `addingDependentTask` and `dependentOnInstanceID` state fields
- **internal/tui/view/input.go**: Add `Title` and `Subtitle` fields to `InputState` for customizable prompts
- **internal/tui/command/handler_test.go**: Add comprehensive tests for the new command

## Usage
1. Select an instance in the sidebar (Tab, h/l, or 1-9)
2. Press `:` to enter command mode
3. Type `chain`, `dep`, or `depends` and press Enter
4. Enter the task description
5. Press Enter - the new task is created in pending state and will auto-start when the parent completes

## Test plan
- [x] All existing tests pass
- [x] New `TestChainCommand` tests cover all aliases and error cases
- [x] Manual testing: `:chain` with/without selected instance
- [x] Build succeeds, `go vet` passes