### PR TITLE
perf(input): batch keyboard input via persistent worker goroutine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **TUI Task Chaining** - Chain tasks via TUI using `:chain`, `:dep`, or `:depends` commands to add tasks that auto-start when the selected instance completes
 
+### Performance
+- **Input Mode Batching** - Keyboard input in Input mode now batches consecutive characters through a persistent worker goroutine, dramatically reducing subprocess overhead during typing (#313)
+
 ## [0.3.0] - 2026-01-12
 
 This release brings **deep GitHub Issues integration**, **plan import from URLs**, **a persistent terminal pane**, major **architecture improvements**, and numerous reliability enhancements across the board.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1377,9 +1377,10 @@ func (m Model) sendKeyToTmux(mgr *instance.Manager, msg tea.KeyMsg) {
 		// Handle Alt+key combinations
 		if msg.Alt {
 			// For alt combinations, tmux uses M- prefix or Escape followed by char
+			// Use QueueKey for escape to flush any pending batch, then queue the character
 			key = string(msg.Runes)
-			mgr.SendKey("Escape") // Send escape first
-			mgr.SendLiteral(key)  // Then send the character
+			mgr.QueueKey("Escape") // Send escape first (flushes batch)
+			mgr.QueueLiteral(key)  // Then send the character
 			return
 		}
 		key = string(msg.Runes)
@@ -1413,11 +1414,11 @@ func (m Model) sendKeyToTmux(mgr *instance.Manager, msg tea.KeyMsg) {
 		case strings.HasPrefix(keyStr, "alt+"):
 			// Alt combinations: send Escape then the key
 			baseKey := strings.TrimPrefix(keyStr, "alt+")
-			mgr.SendKey("Escape")
+			mgr.QueueKey("Escape")
 			if len(baseKey) == 1 {
-				mgr.SendLiteral(baseKey)
+				mgr.QueueLiteral(baseKey)
 			} else {
-				mgr.SendKey(baseKey)
+				mgr.QueueKey(baseKey)
 			}
 			return
 		case strings.HasPrefix(keyStr, "ctrl+"):
@@ -1438,9 +1439,9 @@ func (m Model) sendKeyToTmux(mgr *instance.Manager, msg tea.KeyMsg) {
 
 	if key != "" {
 		if literal {
-			mgr.SendLiteral(key)
+			mgr.QueueLiteral(key)
 		} else {
-			mgr.SendKey(key)
+			mgr.QueueKey(key)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Implements persistent worker goroutine pattern for batching keyboard input in Input mode
- Adds `QueueLiteral()` and `QueueKey()` methods that send to a buffered channel instead of spawning goroutines per keystroke
- Worker batches consecutive literal characters and flushes on special keys, session changes, or 5ms timeout
- Updates TUI `sendKeyToTmux()` to use the new queued methods

For typing "hello world", this reduces subprocess calls from 11+ to just 2-3 (batched literals + space + batched literals).

## Test plan

- [x] All existing tests pass
- [x] Added comprehensive tests for new Queue methods:
  - `TestHandler_QueueLiteral` - basic functionality
  - `TestHandler_QueueLiteral_Batching` - verifies consecutive chars are batched
  - `TestHandler_QueueKey` - special key handling
  - `TestHandler_QueueKey_FlushesBatch` - verifies batch flush on special key
  - `TestHandler_QueueLiteral_SessionChange` - session change flushes batch
  - `TestHandler_StopWorker` - graceful shutdown with flush
  - `TestHandler_QueueLiteral_ConcurrentAccess` - concurrent safety
  - `TestHandler_Queue_TypicalKeyboardInput` - simulates "ls -la<Enter>"
  - `TestHandler_Queue_AltKeyCombo` - Alt+key combinations

Fixes #313