### PR TITLE
Fix idle tmux connection becoming unresponsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Persistent Tmux Connection** - Input mode now uses tmux control mode to maintain a persistent connection, eliminating subprocess spawn overhead (~50-200ms per character) for dramatically faster typing
 
+### Fixed
+
+- **Idle Tmux Connection Recovery** - Persistent tmux connection now auto-reconnects after becoming unresponsive during idle periods, preventing UI freezes when returning to a long-idle session
+
 ## [0.3.0] - 2026-01-12
 
 This release brings **deep GitHub Issues integration**, **plan import from URLs**, **a persistent terminal pane**, major **architecture improvements**, and numerous reliability enhancements across the board.

--- a/internal/instance/input/persistent_sender.go
+++ b/internal/instance/input/persistent_sender.go
@@ -3,13 +3,22 @@ package input
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os/exec"
 	"strings"
 	"sync"
 	"time"
 )
+
+// writeTimeout is the maximum time to wait for a write to the tmux control mode
+// connection before considering it stuck and attempting reconnection.
+const writeTimeout = 500 * time.Millisecond
+
+// errWriteTimeout is returned when a write operation times out.
+var errWriteTimeout = errors.New("write timeout: tmux connection may be stuck")
 
 // PersistentTmuxSender maintains a persistent control-mode connection to tmux.
 // It implements the TmuxSender interface but uses a persistent pipe instead of
@@ -62,7 +71,8 @@ func NewPersistentTmuxSender(sessionName string, opts ...PersistentOption) *Pers
 
 // SendKeys implements TmuxSender interface.
 // It writes send-keys commands to the persistent tmux control mode connection.
-// If the connection fails, it falls back to subprocess spawning.
+// If the connection fails or times out, it attempts to reconnect automatically.
+// If reconnection fails, it falls back to subprocess spawning.
 func (p *PersistentTmuxSender) SendKeys(sessionName string, keys string, literal bool) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -74,30 +84,86 @@ func (p *PersistentTmuxSender) SendKeys(sessionName string, keys string, literal
 
 	// Ensure connected
 	if !p.connected {
-		if err := p.connectLocked(); err != nil {
+		if connErr := p.connectLocked(); connErr != nil {
 			// Fall back to subprocess on connection failure
+			log.Printf("WARNING: persistent tmux connection failed for session %s: %v, using subprocess fallback",
+				p.sessionName, connErr)
 			return p.fallback.SendKeys(sessionName, keys, literal)
 		}
 	}
 
 	// Build the send-keys command for tmux control mode
-	var cmd string
-	if literal {
-		// Escape the keys for tmux control mode protocol
-		escaped := escapeForControlMode(keys)
-		cmd = fmt.Sprintf("send-keys -t %s -l %s\n", p.sessionName, escaped)
-	} else {
-		cmd = fmt.Sprintf("send-keys -t %s %s\n", p.sessionName, keys)
-	}
+	cmd := p.buildCommand(keys, literal)
 
-	// Write to stdin
-	if _, err := p.stdin.Write([]byte(cmd)); err != nil {
-		// Connection lost, mark as disconnected and fall back
+	// Try to write with timeout
+	if writeErr := p.writeWithTimeoutLocked([]byte(cmd)); writeErr != nil {
+		// Connection is stuck or dead - disconnect and try to reconnect
+		log.Printf("WARNING: tmux write failed for session %s: %v, attempting reconnect", p.sessionName, writeErr)
 		p.disconnectLocked()
+
+		// Attempt to reconnect
+		if reconnErr := p.connectLocked(); reconnErr == nil {
+			// Reconnected! Try sending again
+			if retryErr := p.writeWithTimeoutLocked([]byte(cmd)); retryErr == nil {
+				log.Printf("INFO: tmux reconnection successful for session %s", p.sessionName)
+				return nil
+			}
+			// Still failing after reconnect, disconnect again
+			log.Printf("WARNING: tmux write failed after reconnect for session %s, falling back to subprocess",
+				p.sessionName)
+			p.disconnectLocked()
+		} else {
+			log.Printf("WARNING: tmux reconnect failed for session %s: %v, falling back to subprocess",
+				p.sessionName, reconnErr)
+		}
+
+		// Fall back to subprocess for this operation
 		return p.fallback.SendKeys(sessionName, keys, literal)
 	}
 
 	return nil
+}
+
+// buildCommand constructs the tmux control mode command for send-keys.
+func (p *PersistentTmuxSender) buildCommand(keys string, literal bool) string {
+	if literal {
+		escaped := escapeForControlMode(keys)
+		return fmt.Sprintf("send-keys -t %s -l %s\n", p.sessionName, escaped)
+	}
+	return fmt.Sprintf("send-keys -t %s %s\n", p.sessionName, keys)
+}
+
+// writeWithTimeoutLocked writes data to stdin with a timeout.
+// If the write doesn't complete within writeTimeout, it returns errWriteTimeout.
+// Caller must hold p.mu. The timeout is implemented by closing the pipe if the
+// write blocks too long, which unblocks the stuck write goroutine.
+func (p *PersistentTmuxSender) writeWithTimeoutLocked(data []byte) error {
+	if p.stdin == nil {
+		return fmt.Errorf("stdin is nil")
+	}
+
+	// Capture stdin locally since we'll check it after timeout
+	stdin := p.stdin
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := stdin.Write(data)
+		// Use non-blocking send to prevent goroutine leak if timeout already fired.
+		// If timeout fired, the caller will call disconnectLocked() which closes
+		// stdin and unblocks any future writes.
+		select {
+		case done <- err:
+		default:
+			// Timeout already occurred, result is discarded
+		}
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(writeTimeout):
+		return errWriteTimeout
+	}
 }
 
 // Close shuts down the persistent connection and releases resources.


### PR DESCRIPTION
## Summary

- Persistent tmux connections could become unresponsive when left idle for extended periods (SSH timeout, network issues, etc.)
- When users returned to Claudio after being away, keypresses would queue up in blocked goroutines and never reach Claude
- This adds timeout detection, automatic reconnection, and graceful fallback to subprocess mode

## Changes

- Added 500ms write timeout to detect stuck connections
- Added automatic reconnection attempt when timeout occurs
- Added fallback to subprocess mode if reconnection fails
- Added logging for visibility into timeout/reconnect/fallback events
- Fixed potential goroutine leak with non-blocking channel send

## Test plan

- [x] All existing tests pass
- [x] New tests added for `buildCommand`, `writeWithTimeoutLocked`, and reconnect behavior
- [x] `go vet` passes
- [x] `gofmt` shows no formatting issues
- [ ] Manual testing: start Claudio in tmux, leave idle, return and verify responsiveness