### PR TITLE
Add verbose command help and scrollable help panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **TUI Task Chaining** - Chain tasks via TUI using `:chain`, `:dep`, or `:depends` commands to add tasks that auto-start when the selected instance completes
 - **Local Claude Config Copying** - `CLAUDE.local.md` is now automatically copied to worktrees for consistent local settings (#318)
 - **Collapsible Task Groups** - UltraPlan sidebar now supports collapsible execution groups via `[g]` group navigation mode, with `[e]` expand all and `[c]` collapse all (#289)
+- **Verbose Command Mode Help** - Command mode now shows descriptive help with command explanations instead of just single letters; configurable via `tui.verbose_command_help` setting (enabled by default)
+- **Scrollable Help Panel** - The `:help` panel is now scrollable (j/k, Ctrl+D/U, g/G) with color-coded sections for better readability
 
 ### Performance
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,8 @@ type TUIConfig struct {
 	AutoFocusOnInput bool `mapstructure:"auto_focus_on_input"`
 	// MaxOutputLines limits how many lines of output to display per instance
 	MaxOutputLines int `mapstructure:"max_output_lines"`
+	// VerboseCommandHelp shows full command descriptions in command mode instead of single letters
+	VerboseCommandHelp bool `mapstructure:"verbose_command_help"`
 }
 
 // SessionConfig controls session behavior
@@ -214,8 +216,9 @@ func Default() *Config {
 			DefaultAction: "prompt",
 		},
 		TUI: TUIConfig{
-			AutoFocusOnInput: true,
-			MaxOutputLines:   1000,
+			AutoFocusOnInput:   true,
+			MaxOutputLines:     1000,
+			VerboseCommandHelp: true,
 		},
 		Session: SessionConfig{},
 		Instance: InstanceConfig{
@@ -305,6 +308,7 @@ func SetDefaults() {
 	// TUI defaults
 	viper.SetDefault("tui.auto_focus_on_input", defaults.TUI.AutoFocusOnInput)
 	viper.SetDefault("tui.max_output_lines", defaults.TUI.MaxOutputLines)
+	viper.SetDefault("tui.verbose_command_help", defaults.TUI.VerboseCommandHelp)
 
 	// Session defaults (currently empty)
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,6 +28,9 @@ func TestDefault(t *testing.T) {
 	if cfg.TUI.MaxOutputLines != 1000 {
 		t.Errorf("TUI.MaxOutputLines = %d, want 1000", cfg.TUI.MaxOutputLines)
 	}
+	if !cfg.TUI.VerboseCommandHelp {
+		t.Error("TUI.VerboseCommandHelp should be true by default")
+	}
 
 	// Verify default instance config
 	if cfg.Instance.OutputBufferSize != 100000 {
@@ -431,6 +434,32 @@ func TestPathsConfig_ResolveWorktreeDir(t *testing.T) {
 				t.Errorf("ResolveWorktreeDir(%q) = %q, want %q", tt.baseDir, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestTUIConfig_VerboseCommandHelp_ViperLoading(t *testing.T) {
+	// Test that verbose_command_help setting is properly loaded via viper
+	viper.Reset()
+	SetDefaults()
+
+	// After SetDefaults, tui.verbose_command_help should be true
+	verboseHelp := viper.GetBool("tui.verbose_command_help")
+	if !verboseHelp {
+		t.Error("viper.GetBool('tui.verbose_command_help') should be true by default")
+	}
+
+	// Test disabling via viper (simulates user preference for compact mode)
+	viper.Set("tui.verbose_command_help", false)
+	cfg := Get()
+	if cfg.TUI.VerboseCommandHelp {
+		t.Error("TUI.VerboseCommandHelp should be false after viper.Set(false)")
+	}
+
+	// Test re-enabling
+	viper.Set("tui.verbose_command_help", true)
+	cfg = Get()
+	if !cfg.TUI.VerboseCommandHelp {
+		t.Error("TUI.VerboseCommandHelp should be true after viper.Set(true)")
 	}
 }
 

--- a/internal/tui/command/handler.go
+++ b/internal/tui/command/handler.go
@@ -77,9 +77,28 @@ type Result struct {
 	TerminalDirMode   *int // 0 = invocation, 1 = worktree
 }
 
+// CommandInfo contains metadata about a command for help display.
+type CommandInfo struct {
+	// ShortKey is the single-letter shortcut (e.g., "s", "x")
+	ShortKey string
+	// LongKey is the full command name (e.g., "start", "stop")
+	LongKey string
+	// Description is a brief description of what the command does
+	Description string
+	// Category groups related commands together
+	Category string
+}
+
+// CommandCategory represents a group of related commands.
+type CommandCategory struct {
+	Name     string
+	Commands []CommandInfo
+}
+
 // Handler processes vim-style commands for the TUI.
 type Handler struct {
-	commands map[string]commandFunc
+	commands   map[string]commandFunc
+	categories []CommandCategory
 }
 
 // commandFunc is the signature for command implementations.
@@ -92,7 +111,13 @@ func New() *Handler {
 		commands: make(map[string]commandFunc),
 	}
 	h.registerCommands()
+	h.buildCategories()
 	return h
+}
+
+// Categories returns the command categories for help display.
+func (h *Handler) Categories() []CommandCategory {
+	return h.categories
 }
 
 // Execute parses and executes a command string.
@@ -176,6 +201,63 @@ func (h *Handler) registerCommands() {
 	h.commands["help"] = cmdHelp
 	h.commands["q"] = cmdQuit
 	h.commands["quit"] = cmdQuit
+}
+
+// buildCategories populates the categories slice with command metadata for help display.
+func (h *Handler) buildCategories() {
+	h.categories = []CommandCategory{
+		{
+			Name: "Instance Control",
+			Commands: []CommandInfo{
+				{ShortKey: "s", LongKey: "start", Description: "Start a stopped/new instance", Category: "control"},
+				{ShortKey: "x", LongKey: "stop", Description: "Stop instance and trigger auto-PR workflow", Category: "control"},
+				{ShortKey: "e", LongKey: "exit", Description: "Stop instance without auto-PR", Category: "control"},
+				{ShortKey: "p", LongKey: "pause", Description: "Pause/resume a running instance", Category: "control"},
+				{ShortKey: "R", LongKey: "reconnect", Description: "Reattach to a stopped instance's tmux session", Category: "control"},
+				{ShortKey: "", LongKey: "restart", Description: "Restart a stuck or timed-out instance", Category: "control"},
+			},
+		},
+		{
+			Name: "Instance Management",
+			Commands: []CommandInfo{
+				{ShortKey: "a", LongKey: "add", Description: "Create and add a new instance", Category: "management"},
+				{ShortKey: "", LongKey: "chain", Description: "Add task that auto-starts after selected instance", Category: "management"},
+				{ShortKey: "D", LongKey: "remove", Description: "Remove instance from session", Category: "management"},
+				{ShortKey: "", LongKey: "kill", Description: "Force kill instance process and remove from session", Category: "management"},
+				{ShortKey: "C", LongKey: "clear", Description: "Remove all completed instances", Category: "management"},
+			},
+		},
+		{
+			Name: "View",
+			Commands: []CommandInfo{
+				{ShortKey: "d", LongKey: "diff", Description: "Toggle diff preview panel", Category: "view"},
+				{ShortKey: "m", LongKey: "stats", Description: "Toggle metrics panel", Category: "view"},
+				{ShortKey: "c", LongKey: "conflicts", Description: "Toggle conflict view", Category: "view"},
+				{ShortKey: "f", LongKey: "filter", Description: "Open filter panel", Category: "view"},
+			},
+		},
+		{
+			Name: "Terminal",
+			Commands: []CommandInfo{
+				{ShortKey: "t", LongKey: "term", Description: "Focus/toggle terminal pane", Category: "terminal"},
+				{ShortKey: "", LongKey: "tmux", Description: "Show tmux attach command", Category: "terminal"},
+			},
+		},
+		{
+			Name: "Utility",
+			Commands: []CommandInfo{
+				{ShortKey: "r", LongKey: "pr", Description: "Show PR creation command", Category: "utility"},
+				{ShortKey: "", LongKey: "cancel", Description: "Cancel ultra-plan execution", Category: "utility"},
+			},
+		},
+		{
+			Name: "Session",
+			Commands: []CommandInfo{
+				{ShortKey: "h", LongKey: "help", Description: "Toggle help panel", Category: "session"},
+				{ShortKey: "q", LongKey: "quit", Description: "Quit Claudio", Category: "session"},
+			},
+		},
+	}
 }
 
 // Command implementations

--- a/internal/tui/command/handler_test.go
+++ b/internal/tui/command/handler_test.go
@@ -54,6 +54,84 @@ func TestNew(t *testing.T) {
 	if len(h.commands) == 0 {
 		t.Error("expected commands to be registered")
 	}
+	if len(h.categories) == 0 {
+		t.Error("expected categories to be populated")
+	}
+}
+
+func TestCategories(t *testing.T) {
+	h := New()
+	categories := h.Categories()
+
+	if len(categories) == 0 {
+		t.Fatal("expected at least one category")
+	}
+
+	// Verify expected categories exist
+	expectedCategories := []string{
+		"Instance Control",
+		"Instance Management",
+		"View",
+		"Terminal",
+		"Utility",
+		"Session",
+	}
+
+	for _, expected := range expectedCategories {
+		found := false
+		for _, cat := range categories {
+			if cat.Name == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected category %q not found", expected)
+		}
+	}
+
+	// Verify each category has commands
+	for _, cat := range categories {
+		if len(cat.Commands) == 0 {
+			t.Errorf("category %q has no commands", cat.Name)
+		}
+
+		// Verify each command has required fields
+		for _, cmd := range cat.Commands {
+			if cmd.LongKey == "" {
+				t.Errorf("command in category %q has empty LongKey", cat.Name)
+			}
+			if cmd.Description == "" {
+				t.Errorf("command %q in category %q has empty Description", cmd.LongKey, cat.Name)
+			}
+			if cmd.Category == "" {
+				t.Errorf("command %q in category %q has empty Category", cmd.LongKey, cat.Name)
+			}
+		}
+	}
+}
+
+func TestCategoriesContainAllShortcuts(t *testing.T) {
+	h := New()
+	categories := h.Categories()
+
+	// Collect all short keys from categories
+	shortKeys := make(map[string]bool)
+	for _, cat := range categories {
+		for _, cmd := range cat.Commands {
+			if cmd.ShortKey != "" {
+				shortKeys[cmd.ShortKey] = true
+			}
+		}
+	}
+
+	// Verify key shortcuts are documented
+	expectedShortcuts := []string{"s", "x", "e", "p", "R", "a", "D", "C", "d", "m", "c", "f", "t", "r", "h", "q"}
+	for _, key := range expectedShortcuts {
+		if !shortKeys[key] {
+			t.Errorf("shortcut %q not found in categories", key)
+		}
+	}
 }
 
 func TestExecuteEmptyCommand(t *testing.T) {

--- a/internal/tui/config/config.go
+++ b/internal/tui/config/config.go
@@ -84,6 +84,13 @@ func New() Model {
 					Type:        "int",
 					Category:    "tui",
 				},
+				{
+					Key:         "tui.verbose_command_help",
+					Label:       "Verbose Command Help",
+					Description: "Show full command descriptions in command mode (disable for compact view)",
+					Type:        "bool",
+					Category:    "tui",
+				},
 			},
 		},
 		{
@@ -731,8 +738,9 @@ func (m *Model) resetCurrentToDefault() {
 		// Completion
 		"completion.default_action": defaults.Completion.DefaultAction,
 		// TUI
-		"tui.auto_focus_on_input": defaults.TUI.AutoFocusOnInput,
-		"tui.max_output_lines":    defaults.TUI.MaxOutputLines,
+		"tui.auto_focus_on_input":  defaults.TUI.AutoFocusOnInput,
+		"tui.max_output_lines":     defaults.TUI.MaxOutputLines,
+		"tui.verbose_command_help": defaults.TUI.VerboseCommandHelp,
 		// Instance
 		"instance.output_buffer_size":         defaults.Instance.OutputBufferSize,
 		"instance.capture_interval_ms":        defaults.Instance.CaptureIntervalMs,

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -84,6 +84,7 @@ type Model struct {
 	ready           bool
 	quitting        bool
 	showHelp        bool
+	helpScroll      int  // Scroll offset for help panel
 	showConflicts   bool // When true, show detailed conflict view
 	addingTask      bool
 	taskInput       string


### PR DESCRIPTION
## Summary
- Add `tui.verbose_command_help` config option (enabled by default) that shows descriptive multi-line command help when in command mode instead of compact single-letter shortcuts
- Make the `:help` panel scrollable with j/k, Ctrl+D/U, Ctrl+B/F, g/G keys
- Add color-coded sections to help panel for better visual organization and readability
- Add scroll position indicators (▲/▼) when content extends beyond the viewport

## Test plan
- [ ] Enter command mode with `:` and verify verbose help appears with command descriptions
- [ ] Set `tui.verbose_command_help` to `false` in config and verify compact mode is used
- [ ] Open help panel with `:help` or `?` and verify scrolling works with j/k keys
- [ ] Verify Ctrl+D/U scrolls half page and Ctrl+B/F scrolls full page
- [ ] Verify g/G jumps to top/bottom of help content
- [ ] Verify scroll indicators appear when content is scrollable
- [ ] Verify help scroll resets when panel is closed and reopened
- [ ] Run `go test ./...` to verify all tests pass