### PR TITLE
Fix outdated navigation hints in dashboard

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2253,7 +2253,7 @@ func (m Model) renderContent(width int) string {
 	inst := m.activeInstance()
 	if inst == nil {
 		return styles.ContentBox.Width(width - 4).Render(
-			"No instance selected.\n\nPress [a] to add a new Claude instance.",
+			"No instance selected.\n\nPress [:a] to add a new Claude instance.",
 		)
 	}
 

--- a/internal/tui/view/dashboard.go
+++ b/internal/tui/view/dashboard.go
@@ -68,7 +68,7 @@ func (dv *DashboardView) RenderSidebar(state DashboardState, width, height int) 
 	if instanceCount == 0 && !isAddingTask {
 		b.WriteString(styles.Muted.Render("No instances"))
 		b.WriteString("\n")
-		b.WriteString(styles.Muted.Render("Press [a] to add"))
+		b.WriteString(styles.Muted.Render("Press [:a] to add"))
 	} else {
 		// Calculate available slots for instances
 		// Reserve: 1 for title, 1 for blank line, 1 for add hint, 2 for scroll indicators, plus border padding
@@ -126,11 +126,11 @@ func (dv *DashboardView) RenderSidebar(state DashboardState, width, height int) 
 	b.WriteString("\n")
 	// Add instance hint with navigation help when paginated
 	if instanceCount > 0 {
-		addHint := styles.Muted.Render("[a]") + " " + styles.Muted.Render("add") + "  " +
-			styles.Muted.Render("[↑↓]") + " " + styles.Muted.Render("nav")
+		addHint := styles.Muted.Render("[:a]") + " " + styles.Muted.Render("add") + "  " +
+			styles.Muted.Render("[Tab]") + " " + styles.Muted.Render("nav")
 		b.WriteString(addHint)
 	} else {
-		addHint := styles.Muted.Render("[a]") + " " + styles.Muted.Render("Add new")
+		addHint := styles.Muted.Render("[:a]") + " " + styles.Muted.Render("Add new")
 		b.WriteString(addHint)
 	}
 

--- a/internal/tui/view/dashboard_test.go
+++ b/internal/tui/view/dashboard_test.go
@@ -122,9 +122,9 @@ func TestRenderSidebar_EmptyState(t *testing.T) {
 		t.Error("empty state should show 'No instances' message")
 	}
 
-	// Should contain add hint
-	if !strings.Contains(result, "[a]") {
-		t.Error("empty state should show '[a]' hint")
+	// Should contain add hint (with colon prefix for command mode)
+	if !strings.Contains(result, "[:a]") {
+		t.Error("empty state should show '[:a]' hint")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Update `[a]` hints to `[:a]` to reflect that adding instances requires entering command mode first
- Change `[↑↓] nav` to `[Tab] nav` since arrow keys scroll output rather than navigate between instances
- Update corresponding test expectations

## Test plan

- [ ] Verify hints display correctly in empty state (no instances)
- [ ] Verify hints display correctly when instances exist
- [ ] Run `go test ./internal/tui/view/...` to confirm tests pass