### PR TITLE
Fix tmux instance unresponsiveness from goroutine leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Idle Tmux Connection Recovery** - Persistent tmux connection now auto-reconnects after becoming unresponsive during idle periods, preventing UI freezes when returning to a long-idle session
+- **Tmux Instance Unresponsiveness** - Fixed critical issue where tmux instances could become completely unresponsive after extended use or network interruptions. Root causes addressed: goroutine leaks in persistent sender drain loops, missing timeouts on tmux subprocess calls causing capture loop freezes, and orphaned write goroutines accumulating over time
 
 ## [0.3.0] - 2026-01-12
 


### PR DESCRIPTION
## Summary

Fixes a critical issue where tmux instances could become completely unresponsive after extended use or network interruptions. Users reported that both input and output would stop working, making the application appear frozen.

### Root Causes Addressed

- **Goroutine leaks in drain loops** - The `drainOutput()` goroutines never exited cleanly when connections closed, accumulating over reconnection cycles and eventually exhausting file descriptors
- **Missing timeouts on tmux subprocess calls** - Commands like `has-session`, `capture-pane`, and `display-message` had no timeout, causing the capture loop to freeze completely when tmux became unresponsive
- **Orphaned write goroutines** - Timeout handling in `writeWithTimeoutLocked()` abandoned goroutines that could accumulate over time

### Changes

**`internal/instance/input/persistent_sender.go`:**
- Added `drainCancel`, `drainWg`, and `activeWrites` fields for goroutine lifecycle management
- Replaced `drainOutput()` with `drainPipe()` using context cancellation
- Modified `connectLocked()` to set up cancellation context and track drain goroutines
- Modified `disconnectLocked()` to properly cancel and wait for goroutines to exit
- Added warning logging when goroutines don't exit within timeout

**`internal/instance/manager.go`:**
- Added 2-second timeout constant `tmuxCommandTimeout`
- Applied timeouts to all tmux subprocess calls using `exec.CommandContext`
- Distinguished between context timeouts and actual session termination to avoid false completions

**`internal/instance/input/persistent_sender_test.go`:**
- Added 4 new lifecycle tests to verify goroutine cleanup

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `gofmt -d .` shows no formatting issues
- [x] `go vet ./...` shows no issues
- [x] New lifecycle tests verify goroutine cleanup works correctly
- [ ] Manual testing: Start Claudio, use for extended period, verify no degradation
- [ ] Manual testing: Disconnect/reconnect network while running, verify recovery