### PR TITLE
Disable completion timeout by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Persistent Tmux Connection** - Input mode now uses tmux control mode to maintain a persistent connection, eliminating subprocess spawn overhead (~50-200ms per character) for dramatically faster typing
 
+### Changed
+
+- **Completion Timeout Disabled by Default** - The `completion_timeout_minutes` setting now defaults to `0` (disabled) instead of `120` (2 hours). This prevents long-running tasks and UltraPlans from being interrupted. Users can still enable it by setting a non-zero value in their config.
+
 ### Fixed
 
 - **Idle Tmux Connection Recovery** - Persistent tmux connection now auto-reconnects after becoming unresponsive during idle periods, preventing UI freezes when returning to a long-idle session

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,8 +226,8 @@ func Default() *Config {
 			CaptureIntervalMs:        100,
 			TmuxWidth:                200,
 			TmuxHeight:               50,
-			ActivityTimeoutMinutes:   30,  // 30 minutes of no activity
-			CompletionTimeoutMinutes: 120, // 2 hours max runtime
+			ActivityTimeoutMinutes:   30, // 30 minutes of no activity
+			CompletionTimeoutMinutes: 0,  // Disabled by default (no max runtime limit)
 			StaleDetection:           true,
 		},
 		Branch: BranchConfig{

--- a/internal/instance/detect/timeout.go
+++ b/internal/instance/detect/timeout.go
@@ -53,9 +53,9 @@ type TimeoutConfig struct {
 // DefaultTimeoutConfig returns sensible default timeout thresholds.
 func DefaultTimeoutConfig() TimeoutConfig {
 	return TimeoutConfig{
-		ActivityTimeout:   30 * time.Minute,  // 30 minutes of no activity
-		CompletionTimeout: 120 * time.Minute, // 2 hours max runtime
-		StaleThreshold:    3000,              // ~5 minutes at 100ms capture interval
+		ActivityTimeout:   30 * time.Minute, // 30 minutes of no activity
+		CompletionTimeout: 0,                // Disabled by default (no max runtime limit)
+		StaleThreshold:    3000,             // ~5 minutes at 100ms capture interval
 	}
 }
 

--- a/internal/instance/detect/timeout_test.go
+++ b/internal/instance/detect/timeout_test.go
@@ -31,8 +31,8 @@ func TestDefaultTimeoutConfig(t *testing.T) {
 	if cfg.ActivityTimeout != 30*time.Minute {
 		t.Errorf("ActivityTimeout = %v, want 30m", cfg.ActivityTimeout)
 	}
-	if cfg.CompletionTimeout != 120*time.Minute {
-		t.Errorf("CompletionTimeout = %v, want 120m", cfg.CompletionTimeout)
+	if cfg.CompletionTimeout != 0 {
+		t.Errorf("CompletionTimeout = %v, want 0 (disabled)", cfg.CompletionTimeout)
 	}
 	if cfg.StaleThreshold != 3000 {
 		t.Errorf("StaleThreshold = %d, want 3000", cfg.StaleThreshold)
@@ -284,8 +284,19 @@ func TestTimeoutDetector_EnabledChecks(t *testing.T) {
 		wantStale  bool
 	}{
 		{
-			name:       "all enabled",
+			name:       "default config (completion disabled)",
 			cfg:        DefaultTimeoutConfig(),
+			wantActive: true,
+			wantComp:   false, // CompletionTimeout disabled by default
+			wantStale:  true,
+		},
+		{
+			name: "all enabled",
+			cfg: TimeoutConfig{
+				ActivityTimeout:   30 * time.Minute,
+				CompletionTimeout: 120 * time.Minute,
+				StaleThreshold:    3000,
+			},
 			wantActive: true,
 			wantComp:   true,
 			wantStale:  true,

--- a/internal/instance/manager.go
+++ b/internal/instance/manager.go
@@ -71,9 +71,9 @@ func DefaultManagerConfig() ManagerConfig {
 		OutputBufferSize:         100000, // 100KB
 		CaptureIntervalMs:        100,
 		TmuxWidth:                200,
-		TmuxHeight:               30,  // Shorter height so prompts scroll off and users see actual work
-		ActivityTimeoutMinutes:   30,  // 30 minutes of no activity
-		CompletionTimeoutMinutes: 120, // 2 hours max runtime
+		TmuxHeight:               30, // Shorter height so prompts scroll off and users see actual work
+		ActivityTimeoutMinutes:   30, // 30 minutes of no activity
+		CompletionTimeoutMinutes: 0,  // Disabled by default (no max runtime limit)
 		StaleDetection:           true,
 	}
 }

--- a/internal/instance/state/monitor.go
+++ b/internal/instance/state/monitor.go
@@ -32,7 +32,7 @@ type MonitorConfig struct {
 func DefaultMonitorConfig() MonitorConfig {
 	return MonitorConfig{
 		ActivityTimeoutMinutes:   30,   // 30 minutes of no activity
-		CompletionTimeoutMinutes: 120,  // 2 hours max runtime
+		CompletionTimeoutMinutes: 0,    // Disabled by default (no max runtime limit)
 		StaleDetection:           true, // Enable stale detection
 		StaleThreshold:           3000, // ~5 minutes at 100ms capture interval
 	}

--- a/internal/instance/state/monitor_test.go
+++ b/internal/instance/state/monitor_test.go
@@ -72,8 +72,8 @@ func TestDefaultMonitorConfig(t *testing.T) {
 		t.Errorf("ActivityTimeoutMinutes = %d, want 30", cfg.ActivityTimeoutMinutes)
 	}
 
-	if cfg.CompletionTimeoutMinutes != 120 {
-		t.Errorf("CompletionTimeoutMinutes = %d, want 120", cfg.CompletionTimeoutMinutes)
+	if cfg.CompletionTimeoutMinutes != 0 {
+		t.Errorf("CompletionTimeoutMinutes = %d, want 0 (disabled)", cfg.CompletionTimeoutMinutes)
 	}
 
 	if !cfg.StaleDetection {


### PR DESCRIPTION
## Summary

Disables the `completion_timeout_minutes` setting by default (changes from 120 minutes to 0/disabled).

### Problem

The previous 2-hour default could cause frustration for:
- Long-running UltraPlan tasks
- Complex refactoring operations
- Large codebase analysis
- Any task that legitimately takes more than 2 hours

When the timeout triggered, the instance would be marked as "timed out (max runtime exceeded)" and output capture would stop, requiring manual intervention (Ctrl+R to restart or Ctrl+K to kill).

### Solution

Set `completion_timeout_minutes` to `0` (disabled) by default. Users who want to enforce a maximum runtime limit can still enable it in their config:

```yaml
instance:
  completion_timeout_minutes: 120  # Re-enable 2-hour limit
```

### Files Changed

- `internal/config/config.go` - Default config
- `internal/instance/manager.go` - Manager default config
- `internal/instance/state/monitor.go` - Monitor default config  
- `internal/instance/detect/timeout.go` - Timeout detector default config
- `*_test.go` - Updated tests to reflect new defaults

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `gofmt -d .` shows no formatting issues