### PR TITLE
Fix tmux scrollback history limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Idle Tmux Connection Recovery** - Persistent tmux connection now auto-reconnects after becoming unresponsive during idle periods, preventing UI freezes when returning to a long-idle session
 - **Tmux Instance Unresponsiveness** - Fixed critical issue where tmux instances could become completely unresponsive after extended use or network interruptions. Root causes addressed: goroutine leaks in persistent sender drain loops, missing timeouts on tmux subprocess calls causing capture loop freezes, and orphaned write goroutines accumulating over time
+- **Tmux Scrollback History** - Fixed tmux sessions only keeping ~2000 lines of scrollback by setting `history-limit` before creating sessions. New default is 50,000 lines, configurable via `instance.tmux_history_limit`
 
 ## [0.3.0] - 2026-01-12
 

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -142,6 +142,7 @@ func runConfigShow(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  capture_interval_ms: %d\n", cfg.Instance.CaptureIntervalMs)
 	fmt.Printf("  tmux_width: %d\n", cfg.Instance.TmuxWidth)
 	fmt.Printf("  tmux_height: %d\n", cfg.Instance.TmuxHeight)
+	fmt.Printf("  tmux_history_limit: %d\n", cfg.Instance.TmuxHistoryLimit)
 
 	// PR settings
 	fmt.Println("pr:")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,8 @@ type InstanceConfig struct {
 	TmuxWidth int `mapstructure:"tmux_width"`
 	// TmuxHeight is the height of the tmux pane
 	TmuxHeight int `mapstructure:"tmux_height"`
+	// TmuxHistoryLimit is the number of lines of scrollback to keep in tmux (default: 50000)
+	TmuxHistoryLimit int `mapstructure:"tmux_history_limit"`
 	// ActivityTimeoutMinutes is the number of minutes of no new output before marking as stuck (0 = disabled)
 	ActivityTimeoutMinutes int `mapstructure:"activity_timeout_minutes"`
 	// CompletionTimeoutMinutes is the maximum total runtime in minutes before marking as timeout (0 = disabled)
@@ -226,8 +228,9 @@ func Default() *Config {
 			CaptureIntervalMs:        100,
 			TmuxWidth:                200,
 			TmuxHeight:               50,
-			ActivityTimeoutMinutes:   30, // 30 minutes of no activity
-			CompletionTimeoutMinutes: 0,  // Disabled by default (no max runtime limit)
+			TmuxHistoryLimit:         50000, // 50k lines of scrollback
+			ActivityTimeoutMinutes:   30,    // 30 minutes of no activity
+			CompletionTimeoutMinutes: 0,     // Disabled by default (no max runtime limit)
 			StaleDetection:           true,
 		},
 		Branch: BranchConfig{
@@ -317,6 +320,7 @@ func SetDefaults() {
 	viper.SetDefault("instance.capture_interval_ms", defaults.Instance.CaptureIntervalMs)
 	viper.SetDefault("instance.tmux_width", defaults.Instance.TmuxWidth)
 	viper.SetDefault("instance.tmux_height", defaults.Instance.TmuxHeight)
+	viper.SetDefault("instance.tmux_history_limit", defaults.Instance.TmuxHistoryLimit)
 	viper.SetDefault("instance.activity_timeout_minutes", defaults.Instance.ActivityTimeoutMinutes)
 	viper.SetDefault("instance.completion_timeout_minutes", defaults.Instance.CompletionTimeoutMinutes)
 	viper.SetDefault("instance.stale_detection", defaults.Instance.StaleDetection)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -45,6 +45,9 @@ func TestDefault(t *testing.T) {
 	if cfg.Instance.TmuxHeight != 50 {
 		t.Errorf("Instance.TmuxHeight = %d, want 50", cfg.Instance.TmuxHeight)
 	}
+	if cfg.Instance.TmuxHistoryLimit != 50000 {
+		t.Errorf("Instance.TmuxHistoryLimit = %d, want 50000", cfg.Instance.TmuxHistoryLimit)
+	}
 
 	// Verify default PR config
 	if cfg.PR.Draft {

--- a/internal/instance/manager_test.go
+++ b/internal/instance/manager_test.go
@@ -242,6 +242,10 @@ func TestDefaultManagerConfig(t *testing.T) {
 	if cfg.TmuxHeight <= 0 {
 		t.Errorf("TmuxHeight should be positive, got %d", cfg.TmuxHeight)
 	}
+
+	if cfg.TmuxHistoryLimit <= 0 {
+		t.Errorf("TmuxHistoryLimit should be positive, got %d", cfg.TmuxHistoryLimit)
+	}
 }
 
 func TestManager_DifferentialCaptureFieldsInitialized(t *testing.T) {
@@ -397,6 +401,7 @@ func TestManager_LifecycleConfig(t *testing.T) {
 		CaptureIntervalMs: 50,
 		TmuxWidth:         180,
 		TmuxHeight:        25,
+		TmuxHistoryLimit:  75000,
 	}
 	mgr := NewManagerWithConfig("test", "/tmp", "task", cfg)
 
@@ -406,5 +411,8 @@ func TestManager_LifecycleConfig(t *testing.T) {
 	}
 	if lcConfig.TmuxHeight != 25 {
 		t.Errorf("LifecycleConfig().TmuxHeight = %d, want %d", lcConfig.TmuxHeight, 25)
+	}
+	if lcConfig.TmuxHistoryLimit != 75000 {
+		t.Errorf("LifecycleConfig().TmuxHistoryLimit = %d, want %d", lcConfig.TmuxHistoryLimit, 75000)
 	}
 }

--- a/internal/instance/process/interface.go
+++ b/internal/instance/process/interface.go
@@ -42,13 +42,17 @@ type Config struct {
 
 	// Height is the terminal height in rows (default: 30).
 	Height int
+
+	// HistoryLimit is the number of lines of scrollback to keep in tmux (default: 50000).
+	HistoryLimit int
 }
 
 // DefaultConfig returns a Config with sensible defaults.
 func DefaultConfig() Config {
 	return Config{
-		Width:  200,
-		Height: 30,
+		Width:        200,
+		Height:       30,
+		HistoryLimit: 50000,
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1180,6 +1180,7 @@ func (o *Orchestrator) instanceManagerConfig() instance.ManagerConfig {
 		CaptureIntervalMs:        o.config.Instance.CaptureIntervalMs,
 		TmuxWidth:                width,
 		TmuxHeight:               height,
+		TmuxHistoryLimit:         o.config.Instance.TmuxHistoryLimit,
 		ActivityTimeoutMinutes:   o.config.Instance.ActivityTimeoutMinutes,
 		CompletionTimeoutMinutes: o.config.Instance.CompletionTimeoutMinutes,
 		StaleDetection:           o.config.Instance.StaleDetection,


### PR DESCRIPTION
## Summary

- Fixes tmux sessions only keeping ~2000 lines of scrollback by setting `history-limit` before creating sessions
- Adds configurable `instance.tmux_history_limit` option (default: 50,000 lines)
- Adds proper warning logs when history-limit command fails

## Problem

tmux's `history-limit` option only affects **newly created panes**, not existing ones. The previous code was setting it *after* the session was created, which had no effect. Users were limited to tmux's default scrollback (~2000 lines).

## Solution

Set `tmux set-option -g history-limit` **before** running `tmux new-session` so the new pane inherits the configured limit.

## Changes

- **Config**: Add `TmuxHistoryLimit` to `InstanceConfig` with 50,000 line default
- **Tmux sessions**: Update all 5 session creation points to set history-limit first
- **Error handling**: Add warning logs when the tmux command fails (previously silent)
- **Tests**: Add coverage for new config option

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes  
- [x] `go vet ./...` passes
- [x] `gofmt -d .` shows no changes
- [ ] Manual test: Create a Claude instance, verify scrollback works beyond 2000 lines