### PR TITLE
Fix layout duplication when displaying errors in footer

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -342,7 +342,7 @@ func (m *Model) ensureActiveVisible() {
 	// Calculate visible slots (same calculation as in renderSidebar)
 	// Reserve: 1 for title, 1 for blank line, 1 for add hint, 2 for scroll indicators, plus border padding
 	reservedLines := 6
-	dims := m.terminalManager.GetPaneDimensions()
+	dims := m.terminalManager.GetPaneDimensions(m.calculateExtraFooterLines())
 	availableSlots := dims.MainAreaHeight - reservedLines
 	if availableSlots < 3 {
 		availableSlots = 3
@@ -375,7 +375,7 @@ func (m *Model) ensureActiveVisible() {
 
 // getOutputMaxLines returns the maximum number of lines visible in the output area
 func (m Model) getOutputMaxLines() int {
-	dims := m.terminalManager.GetPaneDimensions()
+	dims := m.terminalManager.GetPaneDimensions(m.calculateExtraFooterLines())
 	// Output area is within main area, minus some reserved lines for header/status
 	maxLines := dims.MainAreaHeight - 6
 	if maxLines < 5 {
@@ -565,7 +565,7 @@ func (m Model) IsTerminalVisible() bool {
 
 // TerminalPaneHeight returns the current terminal pane height (0 if hidden).
 func (m Model) TerminalPaneHeight() int {
-	dims := m.terminalManager.GetPaneDimensions()
+	dims := m.terminalManager.GetPaneDimensions(0)
 	return dims.TerminalPaneHeight
 }
 
@@ -590,8 +590,8 @@ func (m *Model) toggleTerminalVisibility(sessionID string) {
 	if nowVisible {
 		// Initialize terminal process if needed (lazy initialization)
 		if m.terminalProcess == nil {
-			// Get content dimensions from manager
-			dims := m.terminalManager.GetPaneDimensions()
+			// Get content dimensions from manager (extra footer lines don't affect terminal pane size)
+			dims := m.terminalManager.GetPaneDimensions(0)
 			m.terminalProcess = terminal.NewProcess(sessionID, m.invocationDir, dims.TerminalPaneContentWidth, dims.TerminalPaneContentHeight)
 		}
 
@@ -676,7 +676,8 @@ func (m *Model) resizeTerminal() {
 	}
 
 	// Get content dimensions from manager (accounts for borders, padding, header)
-	dims := m.terminalManager.GetPaneDimensions()
+	// Extra footer lines don't affect terminal pane dimensions
+	dims := m.terminalManager.GetPaneDimensions(0)
 
 	if err := m.terminalProcess.Resize(dims.TerminalPaneContentWidth, dims.TerminalPaneContentHeight); err != nil {
 		if m.logger != nil {

--- a/internal/tui/terminal/manager.go
+++ b/internal/tui/terminal/manager.go
@@ -89,8 +89,10 @@ func (m *Manager) Height() int {
 }
 
 // GetPaneDimensions calculates and returns the dimensions for all UI panes
-// based on the current terminal size and layout mode.
-func (m *Manager) GetPaneDimensions() PaneDimensions {
+// based on the current terminal size and layout mode. The extraFooterLines
+// parameter specifies additional lines to reserve for dynamic footer elements
+// such as error messages, info messages, and conflict warnings.
+func (m *Manager) GetPaneDimensions(extraFooterLines int) PaneDimensions {
 	dims := PaneDimensions{
 		TerminalWidth:  m.width,
 		TerminalHeight: m.height,
@@ -109,8 +111,9 @@ func (m *Manager) GetPaneDimensions() PaneDimensions {
 
 	// Calculate main area height
 	// Base height minus header (2 lines), help bar (2 lines), and margins (2 lines) = 6
+	// Plus any extra footer lines for dynamic elements (error messages, conflict warnings)
 	const headerFooterReserved = 6
-	dims.MainAreaHeight = m.height - headerFooterReserved
+	dims.MainAreaHeight = m.height - headerFooterReserved - max(extraFooterLines, 0)
 
 	// Reduce main area when terminal pane is visible
 	if m.layout == LayoutVisible && dims.TerminalPaneHeight > 0 {


### PR DESCRIPTION
## Summary

- Fix TUI layout breaking and duplicating when error messages, info messages, or conflict warnings are displayed in the footer
- The terminal manager now accepts extra footer lines as a parameter to `GetPaneDimensions()` instead of storing state, keeping `View()` pure per Bubbletea's Elm architecture
- Add `calculateExtraFooterLines()` method to compute extra lines needed for dynamic footer elements

## Root Cause

The terminal manager reserved a static 6 lines for header/footer, but didn't account for dynamic elements:
- Error messages (1 line)
- Info messages (1 line)
- Conflict warnings (1 line)
- Verbose command help mode (adds 2 extra lines)

When these elements appeared, the main content area overflowed, causing layout duplication.

## Test plan

- [x] Run `go test ./...` - all tests pass
- [x] Run `go vet ./...` - no issues
- [x] Run `gofmt -d .` - no formatting issues
- [x] New tests added for `calculateExtraFooterLines()` and `GetPaneDimensions()` with extra footer lines
- [ ] Manual testing: trigger error messages in TUI and verify layout doesn't break