### PR TITLE
Add branch selection when creating new instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Branch Selection for New Instances** - When adding a new task, press `Tab` to select which branch the instance should be created from, defaulting to main/master for clean isolation
 - **TUI Task Chaining** - Chain tasks via TUI using `:chain`, `:dep`, or `:depends` commands to add tasks that auto-start when the selected instance completes
 - **Local Claude Config Copying** - `CLAUDE.local.md` is now automatically copied to worktrees for consistent local settings (#318)
 - **Collapsible Task Groups** - UltraPlan sidebar now supports collapsible execution groups via `[g]` group navigation mode, with `[e]` expand all and `[c]` collapse all (#289)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1802,6 +1802,16 @@ func (o *Orchestrator) GetInstanceDiff(worktreePath string) (string, error) {
 	return o.wt.GetDiffAgainstMain(worktreePath)
 }
 
+// ListBranches returns all local git branches, sorted with main/master first
+func (o *Orchestrator) ListBranches() ([]worktree.BranchInfo, error) {
+	return o.wt.ListBranches()
+}
+
+// GetMainBranch returns the name of the main branch (main or master)
+func (o *Orchestrator) GetMainBranch() string {
+	return o.wt.FindMainBranch()
+}
+
 // ReconnectInstance attempts to reconnect to a stopped or paused instance
 // If the tmux session still exists, it reconnects to it
 // If not, it restarts Claude with the same task in the existing worktree

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -107,6 +107,12 @@ type Model struct {
 	templateSelected int    // Currently highlighted template index
 	templateSuffix   string // Suffix to append on submission (from selected template)
 
+	// Branch selection state (for selecting base branch when adding task)
+	showBranchSelector bool     // Whether the branch selector is visible
+	branchList         []string // Cached list of branch names
+	branchSelected     int      // Currently highlighted branch index (0 = main branch)
+	selectedBaseBranch string   // The selected base branch for the new instance
+
 	// File conflict tracking
 	conflicts []conflict.FileConflict
 


### PR DESCRIPTION
## Summary

- Users can now select which branch to create a new instance from by pressing **Tab** in the add task dialog
- The branch selector shows all local branches with main/master listed first (marked as default)
- When no branch is selected, instances are created from the current HEAD (existing behavior)
- When a branch is selected, instances are created from that branch using `AddInstanceFromBranch()`

## Changes

- **worktree/worktree.go**: Added `BranchInfo` struct and `ListBranches()` function
- **orchestrator/orchestrator.go**: Added `ListBranches()` and `GetMainBranch()` wrapper methods
- **tui/model.go**: Added branch selection state fields
- **tui/app.go**: Added branch selector handling (`openBranchSelector`, `handleBranchSelector`)
- **tui/view/input.go**: Added branch selector UI rendering with keyboard hints

## Test plan

- [x] Build succeeds (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [x] New tests added for `ListBranches` functionality
- [ ] Manual testing: Press `a` to add task, then `Tab` to open branch selector
- [ ] Verify up/down navigation works in branch selector
- [ ] Verify Enter/Tab selects branch and closes dropdown
- [ ] Verify Esc closes dropdown without selection
- [ ] Verify task created from selected branch has correct base