### PR TITLE
Add configurable worktree directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Configurable Worktree Directory** - Users can now configure where Claudio creates git worktrees via `paths.worktree_dir` in config. Supports absolute paths, relative paths, and `~` home directory expansion. Available in interactive config (`claudio config`) under the new "Paths" category.
+
+### Fixed
+
+- **Cleanup Command Respects Worktree Config** - The `claudio cleanup` command and stale resource warnings now correctly use the configured worktree directory instead of the hardcoded default
+
 ## [0.4.0] - 2026-01-12
 
 This release focuses on **tmux reliability** and **UX improvements**, with a major performance boost from persistent tmux connections and several quality-of-life enhancements for the TUI.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -170,6 +170,38 @@ Glob patterns are supported:
 
 ---
 
+### paths
+
+Controls where Claudio stores data.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `paths.worktree_dir` | string | `""` | Directory for git worktrees |
+
+**worktree_dir behavior:**
+- Empty string (default): Uses `.claudio/worktrees` relative to repository root
+- Absolute path: Uses the path as-is (e.g., `/fast-drive/worktrees`)
+- Relative path: Resolved relative to repository root (e.g., `.worktrees`)
+- Home expansion: Supports `~` prefix (e.g., `~/claudio-worktrees`)
+
+**Use cases:**
+- Store worktrees on a faster drive for better performance
+- Keep worktrees outside the repository to avoid cluttering project directory
+- Use a different directory convention (e.g., `.worktrees/` instead of `.claudio/worktrees/`)
+
+```yaml
+paths:
+  # Use default (.claudio/worktrees relative to repo root)
+  worktree_dir: ""
+
+  # Or use a custom location:
+  # worktree_dir: ~/claudio-worktrees
+  # worktree_dir: /fast-ssd/worktrees
+  # worktree_dir: .worktrees
+```
+
+---
+
 ### cleanup
 
 Controls cleanup behavior.
@@ -253,6 +285,7 @@ Replace dots with underscores and use uppercase:
 | `pr.use_ai` | `CLAUDIO_PR_USE_AI` |
 | `resources.cost_limit` | `CLAUDIO_RESOURCES_COST_LIMIT` |
 | `ultraplan.max_parallel` | `CLAUDIO_ULTRAPLAN_MAX_PARALLEL` |
+| `paths.worktree_dir` | `CLAUDIO_PATHS_WORKTREE_DIR` |
 
 **Priority:** Environment variables override config file values.
 
@@ -297,6 +330,10 @@ pr:
     by_path:
       "src/api/**": [backend-team]
       "src/frontend/**": [frontend-team]
+
+# File paths
+paths:
+  worktree_dir: ""  # Default: .claudio/worktrees
 
 # Cleanup behavior
 cleanup:

--- a/internal/cmd/cleanup.go
+++ b/internal/cmd/cleanup.go
@@ -131,11 +131,9 @@ func discoverStaleResources(baseDir string) (*CleanupResult, error) {
 		ActiveInstanceIDs: make(map[string]bool),
 	}
 
-	claudioDir := filepath.Join(baseDir, ".claudio")
-	worktreesDir := filepath.Join(claudioDir, "worktrees")
-
-	// Get the configured branch prefix
+	// Get configuration for worktree directory and branch prefix
 	cfg := config.Get()
+	worktreesDir := cfg.Paths.ResolveWorktreeDir(baseDir)
 	branchPrefix := cfg.Branch.Prefix
 	if branchPrefix == "" {
 		branchPrefix = "claudio"

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -572,7 +572,12 @@ func shutdownAllSessions() {
 
 // checkStaleResourcesWarning checks for stale resources and prints a warning if found
 func checkStaleResourcesWarning(baseDir string) {
-	worktreesDir := filepath.Join(baseDir, ".claudio", "worktrees")
+	cfg := config.Get()
+	worktreesDir := cfg.Paths.ResolveWorktreeDir(baseDir)
+	branchPrefix := cfg.Branch.Prefix
+	if branchPrefix == "" {
+		branchPrefix = "claudio"
+	}
 
 	var staleCount int
 
@@ -583,7 +588,7 @@ func checkStaleResourcesWarning(baseDir string) {
 	}
 
 	// Count stale branches
-	cmd := exec.Command("git", "-C", baseDir, "branch", "--list", "claudio/*")
+	cmd := exec.Command("git", "-C", baseDir, "branch", "--list", branchPrefix+"/*")
 	if output, err := cmd.Output(); err == nil {
 		branches := strings.Split(strings.TrimSpace(string(output)), "\n")
 		for _, b := range branches {

--- a/internal/tui/config/config.go
+++ b/internal/tui/config/config.go
@@ -311,6 +311,18 @@ func New() Model {
 				},
 			},
 		},
+		{
+			Name: "Paths",
+			Items: []ConfigItem{
+				{
+					Key:         "paths.worktree_dir",
+					Label:       "Worktree Directory",
+					Description: "Where git worktrees are created (empty = .claudio/worktrees, supports ~ and relative paths)",
+					Type:        "string",
+					Category:    "paths",
+				},
+			},
+		},
 	}
 
 	return Model{
@@ -774,6 +786,8 @@ func (m *Model) resetCurrentToDefault() {
 		"plan.output_format": defaults.Plan.OutputFormat,
 		"plan.multi_pass":    defaults.Plan.MultiPass,
 		"plan.output_file":   defaults.Plan.OutputFile,
+		// Paths
+		"paths.worktree_dir": defaults.Paths.WorktreeDir,
 	}
 
 	if defaultVal, ok := defaultValues[item.Key]; ok {


### PR DESCRIPTION
## Summary

- Allow users to configure where Claudio creates git worktrees via `paths.worktree_dir` setting
- Add the new option to the interactive config UI under a "Paths" category
- Fix the cleanup command and stale resource warnings to respect the configured directory

## Motivation

Different projects have different conventions for where worktrees should be stored. Some repos use `.worktrees/`, others may want worktrees on a faster drive or outside the repository entirely.

## Changes

- **`internal/tui/config/config.go`** - Added "Paths" category with `worktree_dir` setting
- **`internal/cmd/cleanup.go`** - Fixed to use `cfg.Paths.ResolveWorktreeDir()` instead of hardcoded path
- **`internal/cmd/start.go`** - Fixed `checkStaleResourcesWarning()` to use configured paths
- **`docs/reference/configuration.md`** - Added documentation for the new option
- **`CHANGELOG.md`** - Added changelog entries

## Configuration

Users can now set in `~/.config/claudio/config.yaml`:

```yaml
paths:
  worktree_dir: ".worktrees"  # Or ~/claudio-worktrees, /fast-ssd/worktrees, etc.
```

Or via environment variable: `CLAUDIO_PATHS_WORKTREE_DIR`

## Test plan

- [x] Build passes (`go build ./...`)
- [x] Tests pass (`go test ./...`)
- [x] `go vet` passes
- [x] Code formatted with `gofmt`
- [x] Interactive config shows new "Paths" category with "Worktree Directory" option