### PR TITLE
Add keystroke batching for improved typing performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Cleanup Command Respects Worktree Config** - The `claudio cleanup` command and stale resource warnings now correctly use the configured worktree directory instead of the hardcoded default
 
+### Performance
+
+- **Keystroke Batching** - Input mode now coalesces rapid keystrokes into batches before sending to tmux, reducing command overhead by 5-10x for fast typists (250+ WPM)
+
 ## [0.4.0] - 2026-01-12
 
 This release focuses on **tmux reliability** and **UX improvements**, with a major performance boost from persistent tmux connections and several quality-of-life enhancements for the TUI.

--- a/internal/instance/manager.go
+++ b/internal/instance/manager.go
@@ -164,7 +164,10 @@ func NewManagerWithConfig(id, workdir, task string, cfg ManagerConfig) *Manager 
 		detector:      detect.NewDetector(),
 		currentState:  detect.StateWorking,
 		metricsParser: metrics.NewMetricsParser(),
-		inputHandler:  input.NewHandler(input.WithPersistentSender(sessionName)),
+		inputHandler: input.NewHandler(
+			input.WithPersistentSender(sessionName),
+			input.WithBatching(sessionName, input.DefaultBatchConfig()),
+		),
 	}
 }
 
@@ -192,7 +195,10 @@ func NewManagerWithSession(sessionID, id, workdir, task string, cfg ManagerConfi
 		detector:      detect.NewDetector(),
 		currentState:  detect.StateWorking,
 		metricsParser: metrics.NewMetricsParser(),
-		inputHandler:  input.NewHandler(input.WithPersistentSender(sessionName)),
+		inputHandler: input.NewHandler(
+			input.WithPersistentSender(sessionName),
+			input.WithBatching(sessionName, input.DefaultBatchConfig()),
+		),
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add time-based keystroke coalescing to reduce tmux command overhead for fast typists (250+ WPM)
- Consecutive literal characters are now batched together before sending to tmux, reducing command overhead by 5-10x
- Batches flush on: timer expiry (8ms), special keys (Enter/Tab/etc), or max size (100 chars)

## Changes

- **BatchConfig type**: Configurable flush interval and max batch size with sensible defaults
- **Background batcher goroutine**: Coalesces keystrokes using a channel-based design
- **Error logging**: Send failures are now logged instead of silently dropped
- **Race protection**: Uses `sync.Once` to prevent double-close panics
- **Input validation**: Rejects invalid BatchConfig values at construction time
- **Comprehensive tests**: Full coverage for coalescing, ordering, timer flush, max size flush, concurrent access, and close behavior

## Test plan

- [x] All existing tests pass
- [x] New batching tests cover: literal coalescing, special key flushing, timer-based flush, max size flush, ordering preservation, close-time flush, concurrent access
- [x] `go vet ./...` passes
- [x] `golangci-lint run` passes
- [x] Build succeeds