### PR TITLE
Preserve scrollback during differential capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Cleanup Command Respects Worktree Config** - The `claudio cleanup` command and stale resource warnings now correctly use the configured worktree directory instead of the hardcoded default
+- **TUI Scrollback Display** - Fixed output scrollback being lost when using differential capture optimization. Visible-only captures (used for state detection) no longer replace the output buffer, preserving scrollback history from full captures
 
 ### Performance
 


### PR DESCRIPTION
## Summary

- Fixed TUI scrollback being lost during differential capture optimization
- Visible-only captures (used for state detection every 100ms) no longer replace the output buffer
- Only full captures (every 5 seconds) update the buffer, preserving scrollback history

## Problem

The differential capture optimization was designed to reduce CPU usage by only capturing the visible pane (~30 lines) on most ticks. However, both visible-only and full captures were replacing the output buffer, causing scrollback to be lost 98% of the time. This resulted in the line counter flashing between ~49 lines and 500+ lines, with users unable to scroll up.

## Solution

Now visible-only captures are used only for:
- Activity tracking (timeout detection)
- State detection (completion, waiting for input)

The output buffer is only updated during full captures, preserving scrollback history.

## Test plan

- [ ] Start Claudio with an instance that produces significant output
- [ ] Verify the line counter shows consistent scrollback count (not flashing)
- [ ] Verify scrolling up with `k` or arrow keys works reliably
- [ ] Verify state detection still works (completion, waiting for input indicators)