### PR TITLE
Implement Group 2 prompt builders and panel renderers

### DIFF
--- a/internal/orchestrator/prompt/builder_test.go
+++ b/internal/orchestrator/prompt/builder_test.go
@@ -51,6 +51,13 @@ func TestContext_Validate(t *testing.T) {
 				ID:      "plan-1",
 				Summary: "Test plan",
 			}
+		case PhasePlanSelection:
+			ctx.CandidatePlans = []CandidatePlanInfo{
+				{
+					Strategy: "test-strategy",
+					Summary:  "Test candidate plan",
+				},
+			}
 		}
 
 		return ctx

--- a/internal/orchestrator/prompt/consolidation.go
+++ b/internal/orchestrator/prompt/consolidation.go
@@ -1,0 +1,426 @@
+// Package prompt provides interfaces and types for building prompts
+// in the ultra-plan orchestration system.
+package prompt
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ConsolidationCompletionFileName is the filename for consolidation phase completion.
+const ConsolidationCompletionFileName = ".claudio-consolidation-complete.json"
+
+// GroupConsolidationCompletionFileName is the filename for per-group consolidation completion.
+const GroupConsolidationCompletionFileName = ".claudio-group-consolidation-complete.json"
+
+// ConsolidationBuilder builds prompts for the main consolidation phase.
+// It formats branch information and instructions for merging all task branches.
+type ConsolidationBuilder struct{}
+
+// NewConsolidationBuilder creates a new ConsolidationBuilder.
+func NewConsolidationBuilder() *ConsolidationBuilder {
+	return &ConsolidationBuilder{}
+}
+
+// Build generates the consolidation prompt from the context.
+func (b *ConsolidationBuilder) Build(ctx *Context) (string, error) {
+	if err := b.validate(ctx); err != nil {
+		return "", err
+	}
+
+	groupsInfo := b.buildGroupsInfo(ctx)
+	worktreeInfo := b.buildWorktreeInfo(ctx)
+	synthesisContext := b.buildSynthesisContext(ctx)
+
+	return fmt.Sprintf(consolidationPromptTemplate,
+		ctx.Objective,
+		ctx.Consolidation.BranchPrefix,
+		ctx.Consolidation.MainBranch,
+		ctx.Consolidation.Mode,
+		"true", // createDrafts placeholder
+		groupsInfo,
+		worktreeInfo,
+		synthesisContext,
+		ctx.Consolidation.Mode,
+	), nil
+}
+
+// validate checks that the context has all required fields.
+func (b *ConsolidationBuilder) validate(ctx *Context) error {
+	if ctx == nil {
+		return ErrNilContext
+	}
+	if ctx.Phase != PhaseConsolidation {
+		return fmt.Errorf("%w: expected %s, got %s", ErrInvalidPhase, PhaseConsolidation, ctx.Phase)
+	}
+	if ctx.Plan == nil {
+		return ErrMissingPlan
+	}
+	if ctx.Consolidation == nil {
+		return ErrMissingConsolidation
+	}
+	return nil
+}
+
+// buildGroupsInfo builds information about execution groups.
+func (b *ConsolidationBuilder) buildGroupsInfo(ctx *Context) string {
+	var sb strings.Builder
+
+	for groupIdx, taskIDs := range ctx.Plan.ExecutionOrder {
+		sb.WriteString(fmt.Sprintf("\n### Group %d\n", groupIdx+1))
+
+		// Check for pre-consolidated branch
+		if ctx.Consolidation != nil && groupIdx < len(ctx.Consolidation.GroupBranches) {
+			consolidatedBranch := ctx.Consolidation.GroupBranches[groupIdx]
+			if consolidatedBranch != "" {
+				sb.WriteString(fmt.Sprintf("**CONSOLIDATED BRANCH (ALREADY MERGED)**: %s\n", consolidatedBranch))
+				sb.WriteString("The tasks in this group have already been consolidated into this branch.\n")
+			}
+		}
+
+		sb.WriteString("Tasks in this group:\n")
+		for _, taskID := range taskIDs {
+			task := b.findTask(ctx.Plan.Tasks, taskID)
+			if task == nil {
+				// Task referenced in execution order but not found in task list
+				// Include warning in output so it's visible during consolidation
+				sb.WriteString(fmt.Sprintf("- Task: [NOT FOUND] (%s) - WARNING: task data missing\n", taskID))
+				continue
+			}
+			sb.WriteString(fmt.Sprintf("- Task: %s (%s)\n", task.Title, taskID))
+		}
+	}
+
+	return sb.String()
+}
+
+// buildWorktreeInfo builds information about task worktrees.
+func (b *ConsolidationBuilder) buildWorktreeInfo(ctx *Context) string {
+	var sb strings.Builder
+
+	if ctx.Consolidation != nil && len(ctx.Consolidation.TaskWorktrees) > 0 {
+		for _, twi := range ctx.Consolidation.TaskWorktrees {
+			sb.WriteString(fmt.Sprintf("- **%s** (%s)\n", twi.TaskTitle, twi.TaskID))
+			sb.WriteString(fmt.Sprintf("  - Worktree: %s\n", twi.WorktreePath))
+			sb.WriteString(fmt.Sprintf("  - Branch: %s\n", twi.Branch))
+		}
+	}
+
+	// Add note about pre-consolidated branches
+	if ctx.Consolidation != nil && ctx.Consolidation.PreConsolidatedBranch != "" {
+		sb.WriteString("\n## Pre-Consolidated Branches\n")
+		sb.WriteString("**IMPORTANT**: Groups have already been incrementally consolidated.\n")
+		sb.WriteString(fmt.Sprintf("Pre-consolidated branch: %s\n", ctx.Consolidation.PreConsolidatedBranch))
+	}
+
+	return sb.String()
+}
+
+// buildSynthesisContext builds context from synthesis phase.
+func (b *ConsolidationBuilder) buildSynthesisContext(ctx *Context) string {
+	var sb strings.Builder
+
+	if ctx.Synthesis != nil {
+		if len(ctx.Synthesis.Notes) > 0 {
+			sb.WriteString("Notes:\n")
+			for _, note := range ctx.Synthesis.Notes {
+				sb.WriteString(fmt.Sprintf("- %s\n", note))
+			}
+		}
+		if len(ctx.Synthesis.Recommendations) > 0 {
+			sb.WriteString("Recommendations:\n")
+			for _, rec := range ctx.Synthesis.Recommendations {
+				sb.WriteString(fmt.Sprintf("- %s\n", rec))
+			}
+		}
+		if len(ctx.Synthesis.Issues) > 0 {
+			sb.WriteString(fmt.Sprintf("Issues Found: %d\n", len(ctx.Synthesis.Issues)))
+			for _, issue := range ctx.Synthesis.Issues {
+				sb.WriteString(fmt.Sprintf("- %s\n", issue))
+			}
+		}
+	} else {
+		sb.WriteString("No synthesis context available\n")
+	}
+
+	return sb.String()
+}
+
+// findTask finds a task by ID.
+func (b *ConsolidationBuilder) findTask(tasks []TaskInfo, id string) *TaskInfo {
+	for i := range tasks {
+		if tasks[i].ID == id {
+			return &tasks[i]
+		}
+	}
+	return nil
+}
+
+// consolidationPromptTemplate is the prompt for the consolidation phase.
+const consolidationPromptTemplate = `You are consolidating work from multiple parallel task branches.
+
+## Original Objective
+%s
+
+## Branch Configuration
+- **Branch Prefix**: %s
+- **Main Branch**: %s
+- **Consolidation Mode**: %s
+- **Create Draft PRs**: %s
+
+## Execution Groups
+%s
+
+## Task Worktrees
+%s
+
+## Synthesis Context
+%s
+
+## Instructions
+
+1. **Review** all completed task branches
+2. **Create** consolidated branches according to the consolidation mode
+3. **Resolve** any merge conflicts
+4. **Run** verification (build, lint, tests)
+5. **Create** pull requests
+
+## Completion Protocol
+
+When consolidation is complete, write ` + "`" + ConsolidationCompletionFileName + "`" + `:
+
+` + "```json" + `
+{
+  "status": "complete",
+  "mode": "%s",
+  "branches_created": ["branch-1", "branch-2"],
+  "prs_created": [
+    {"number": 123, "url": "https://github.com/..."}
+  ],
+  "conflicts_resolved": [
+    {"file": "path/to/file.go", "resolution": "Description"}
+  ],
+  "verification": {
+    "build": true,
+    "lint": true,
+    "tests": true
+  },
+  "notes": "Any observations"
+}
+` + "```"
+
+// GroupConsolidatorBuilder builds prompts for per-group consolidation.
+// Each execution group gets its own consolidator to merge task branches.
+type GroupConsolidatorBuilder struct{}
+
+// NewGroupConsolidatorBuilder creates a new GroupConsolidatorBuilder.
+func NewGroupConsolidatorBuilder() *GroupConsolidatorBuilder {
+	return &GroupConsolidatorBuilder{}
+}
+
+// Build generates the group consolidator prompt.
+func (b *GroupConsolidatorBuilder) Build(ctx *Context) (string, error) {
+	if err := b.validate(ctx); err != nil {
+		return "", err
+	}
+
+	taskBranches := b.getTaskBranchesForGroup(ctx)
+	baseBranch := b.determineBaseBranch(ctx)
+	consolidatedBranch := b.generateConsolidatedBranchName(ctx)
+
+	var sb strings.Builder
+
+	// Header
+	sb.WriteString(fmt.Sprintf("# Group %d Consolidation\n\n", ctx.GroupIndex+1))
+	sb.WriteString(fmt.Sprintf("## Part of Ultra-Plan: %s\n\n", ctx.Plan.Summary))
+
+	// Objective
+	sb.WriteString("## Objective\n\n")
+	sb.WriteString("Consolidate all completed task branches from this group into a single stable branch.\n")
+	sb.WriteString("You must resolve any merge conflicts, verify the consolidated code works, and pass context to the next group.\n\n")
+
+	// Tasks completed in this group
+	sb.WriteString("## Tasks Completed in This Group\n\n")
+	for _, branch := range taskBranches {
+		sb.WriteString(fmt.Sprintf("### %s: %s\n", branch.TaskID, branch.TaskTitle))
+		sb.WriteString(fmt.Sprintf("- Branch: `%s`\n", branch.Branch))
+		sb.WriteString(fmt.Sprintf("- Worktree: `%s`\n", branch.WorktreePath))
+		sb.WriteString("\n")
+	}
+
+	// Context from previous group
+	if ctx.GroupIndex > 0 && ctx.PreviousGroup != nil {
+		sb.WriteString("## Context from Previous Group's Consolidator\n\n")
+		if ctx.PreviousGroup.Notes != "" {
+			sb.WriteString(fmt.Sprintf("**Notes**: %s\n\n", ctx.PreviousGroup.Notes))
+		}
+		if len(ctx.PreviousGroup.IssuesForNextGroup) > 0 {
+			sb.WriteString("**Issues/Warnings to Address**:\n")
+			for _, issue := range ctx.PreviousGroup.IssuesForNextGroup {
+				sb.WriteString(fmt.Sprintf("- %s\n", issue))
+			}
+			sb.WriteString("\n")
+		}
+	}
+
+	// Branch configuration
+	sb.WriteString("## Branch Configuration\n\n")
+	sb.WriteString(fmt.Sprintf("- **Base branch**: `%s`\n", baseBranch))
+	sb.WriteString(fmt.Sprintf("- **Target consolidated branch**: `%s`\n", consolidatedBranch))
+	sb.WriteString(fmt.Sprintf("- **Task branches to consolidate**: %d\n\n", len(taskBranches)))
+
+	// Instructions
+	b.writeInstructions(&sb, consolidatedBranch, baseBranch)
+
+	// Completion protocol
+	b.writeCompletionProtocol(&sb, ctx.GroupIndex, consolidatedBranch)
+
+	return sb.String(), nil
+}
+
+// validate checks context for group consolidator.
+func (b *GroupConsolidatorBuilder) validate(ctx *Context) error {
+	if ctx == nil {
+		return ErrNilContext
+	}
+	if ctx.Phase != PhaseConsolidation {
+		return fmt.Errorf("%w: expected %s, got %s", ErrInvalidPhase, PhaseConsolidation, ctx.Phase)
+	}
+	if ctx.Plan == nil {
+		return ErrMissingPlan
+	}
+	if ctx.Consolidation == nil {
+		return ErrMissingConsolidation
+	}
+	if ctx.GroupIndex < 0 {
+		return fmt.Errorf("group index must be non-negative")
+	}
+	return nil
+}
+
+// getTaskBranchesForGroup returns task worktree info for the current group.
+func (b *GroupConsolidatorBuilder) getTaskBranchesForGroup(ctx *Context) []TaskWorktreeInfo {
+	if ctx.Consolidation == nil {
+		return nil
+	}
+
+	// Get task IDs for this group
+	var taskIDs []string
+	if ctx.GroupIndex < len(ctx.Plan.ExecutionOrder) {
+		taskIDs = ctx.Plan.ExecutionOrder[ctx.GroupIndex]
+	}
+
+	// Filter worktrees for tasks in this group
+	taskIDSet := make(map[string]bool)
+	for _, id := range taskIDs {
+		taskIDSet[id] = true
+	}
+
+	var result []TaskWorktreeInfo
+	for _, tw := range ctx.Consolidation.TaskWorktrees {
+		if taskIDSet[tw.TaskID] {
+			result = append(result, tw)
+		}
+	}
+
+	return result
+}
+
+// determineBaseBranch determines the base branch for this group.
+func (b *GroupConsolidatorBuilder) determineBaseBranch(ctx *Context) string {
+	if ctx.GroupIndex == 0 {
+		if ctx.Consolidation != nil && ctx.Consolidation.MainBranch != "" {
+			return ctx.Consolidation.MainBranch
+		}
+		return "main"
+	}
+
+	// For subsequent groups, use the previous group's consolidated branch
+	if ctx.Consolidation != nil && ctx.GroupIndex-1 < len(ctx.Consolidation.GroupBranches) {
+		if branch := ctx.Consolidation.GroupBranches[ctx.GroupIndex-1]; branch != "" {
+			return branch
+		}
+	}
+
+	if ctx.Consolidation != nil && ctx.Consolidation.MainBranch != "" {
+		return ctx.Consolidation.MainBranch
+	}
+	return "main"
+}
+
+// generateConsolidatedBranchName creates the branch name for consolidated output.
+func (b *GroupConsolidatorBuilder) generateConsolidatedBranchName(ctx *Context) string {
+	prefix := "Iron-Ham"
+	if ctx.Consolidation != nil && ctx.Consolidation.BranchPrefix != "" {
+		prefix = ctx.Consolidation.BranchPrefix
+	}
+
+	planID := ctx.SessionID
+	if planID == "" {
+		planID = "unknown"
+	} else if len(planID) > 8 {
+		planID = planID[:8]
+	}
+
+	return fmt.Sprintf("%s/ultraplan-%s-group-%d", prefix, planID, ctx.GroupIndex+1)
+}
+
+// writeInstructions writes the consolidation instructions.
+func (b *GroupConsolidatorBuilder) writeInstructions(sb *strings.Builder, consolidatedBranch, baseBranch string) {
+	sb.WriteString("## Your Tasks\n\n")
+	sb.WriteString("1. **Create the consolidated branch** from the base branch:\n")
+	fmt.Fprintf(sb, "   ```bash\n   git checkout -b %s %s\n   ```\n\n", consolidatedBranch, baseBranch)
+
+	sb.WriteString("2. **Cherry-pick commits** from each task branch in order. For each branch:\n")
+	sb.WriteString("   - Review the commits on the branch\n")
+	sb.WriteString("   - Cherry-pick them onto the consolidated branch\n")
+	sb.WriteString("   - Resolve any conflicts intelligently using your understanding of the code\n\n")
+
+	sb.WriteString("3. **Run verification** to ensure the consolidated code is stable:\n")
+	sb.WriteString("   - Detect the project type (Go, Node, Python, iOS, etc.)\n")
+	sb.WriteString("   - Run appropriate build/compile commands\n")
+	sb.WriteString("   - Run linting if available\n")
+	sb.WriteString("   - Run tests if available\n")
+	sb.WriteString("   - Fix any issues that arise\n\n")
+
+	sb.WriteString("4. **Push the consolidated branch** to the remote\n\n")
+
+	sb.WriteString("5. **Write the completion file** to signal success\n\n")
+
+	// Conflict resolution guidelines
+	sb.WriteString("## Conflict Resolution Guidelines\n\n")
+	sb.WriteString("- Prefer changes that preserve functionality from all tasks\n")
+	sb.WriteString("- If there are conflicting approaches, choose the more robust one\n")
+	sb.WriteString("- Document your resolution reasoning in the completion file\n")
+	sb.WriteString("- If you cannot resolve a conflict, document it as an issue\n\n")
+}
+
+// writeCompletionProtocol writes the completion protocol for group consolidation.
+func (b *GroupConsolidatorBuilder) writeCompletionProtocol(sb *strings.Builder, groupIndex int, consolidatedBranch string) {
+	sb.WriteString("## Completion Protocol\n\n")
+	fmt.Fprintf(sb, "When consolidation is complete, write `%s` in your worktree root:\n\n", GroupConsolidationCompletionFileName)
+	sb.WriteString("```json\n")
+	sb.WriteString("{\n")
+	fmt.Fprintf(sb, "  \"group_index\": %d,\n", groupIndex)
+	sb.WriteString("  \"status\": \"complete\",\n")
+	fmt.Fprintf(sb, "  \"branch_name\": \"%s\",\n", consolidatedBranch)
+	sb.WriteString("  \"tasks_consolidated\": [\"task-id-1\", \"task-id-2\"],\n")
+	sb.WriteString("  \"conflicts_resolved\": [\n")
+	sb.WriteString("    {\"file\": \"path/to/file.go\", \"resolution\": \"Kept both changes, merged logic\"}\n")
+	sb.WriteString("  ],\n")
+	sb.WriteString("  \"verification\": {\n")
+	sb.WriteString("    \"project_type\": \"go\",\n")
+	sb.WriteString("    \"commands_run\": [\n")
+	sb.WriteString("      {\"name\": \"build\", \"command\": \"go build ./...\", \"success\": true},\n")
+	sb.WriteString("      {\"name\": \"lint\", \"command\": \"golangci-lint run\", \"success\": true},\n")
+	sb.WriteString("      {\"name\": \"test\", \"command\": \"go test ./...\", \"success\": true}\n")
+	sb.WriteString("    ],\n")
+	sb.WriteString("    \"overall_success\": true,\n")
+	sb.WriteString("    \"summary\": \"All checks passed\"\n")
+	sb.WriteString("  },\n")
+	sb.WriteString("  \"notes\": \"Any observations about the consolidated code\",\n")
+	sb.WriteString("  \"issues_for_next_group\": [\"Any warnings or concerns for the next group\"]\n")
+	sb.WriteString("}\n")
+	sb.WriteString("```\n\n")
+	sb.WriteString("Use status \"failed\" if consolidation cannot be completed.\n")
+}

--- a/internal/orchestrator/prompt/consolidation_test.go
+++ b/internal/orchestrator/prompt/consolidation_test.go
@@ -1,0 +1,397 @@
+package prompt
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConsolidationBuilder_Build(t *testing.T) {
+	tests := []struct {
+		name        string
+		ctx         *Context
+		wantErr     bool
+		errContains string
+		contains    []string
+	}{
+		{
+			name: "valid context with full info",
+			ctx: &Context{
+				Phase:     PhaseConsolidation,
+				SessionID: "test-session",
+				Objective: "Build authentication",
+				Plan: &PlanInfo{
+					Summary: "Auth plan",
+					Tasks: []TaskInfo{
+						{ID: "task-1", Title: "Create model"},
+						{ID: "task-2", Title: "Add endpoint"},
+					},
+					ExecutionOrder: [][]string{{"task-1"}, {"task-2"}},
+				},
+				Consolidation: &ConsolidationInfo{
+					Mode:         "stacked",
+					BranchPrefix: "Iron-Ham",
+					MainBranch:   "main",
+					TaskWorktrees: []TaskWorktreeInfo{
+						{TaskID: "task-1", TaskTitle: "Create model", Branch: "branch-1", WorktreePath: "/path/1"},
+						{TaskID: "task-2", TaskTitle: "Add endpoint", Branch: "branch-2", WorktreePath: "/path/2"},
+					},
+				},
+				Synthesis: &SynthesisInfo{
+					Notes:           []string{"All tasks completed"},
+					Recommendations: []string{"Merge in order"},
+				},
+			},
+			wantErr: false,
+			contains: []string{
+				"## Original Objective",
+				"Build authentication",
+				"## Branch Configuration",
+				"Branch Prefix**: Iron-Ham",
+				"Main Branch**: main",
+				"Consolidation Mode**: stacked",
+				"## Execution Groups",
+				"Group 1",
+				"Group 2",
+				"## Task Worktrees",
+				"Create model",
+				"Add endpoint",
+				"## Synthesis Context",
+				"All tasks completed",
+				"Merge in order",
+				"## Completion Protocol",
+				ConsolidationCompletionFileName,
+			},
+		},
+		{
+			name: "context with pre-consolidated branches",
+			ctx: &Context{
+				Phase:     PhaseConsolidation,
+				SessionID: "test-session",
+				Objective: "Test",
+				Plan: &PlanInfo{
+					ExecutionOrder: [][]string{{"t1"}, {"t2"}},
+				},
+				Consolidation: &ConsolidationInfo{
+					Mode:                  "stacked",
+					BranchPrefix:          "prefix",
+					MainBranch:            "main",
+					GroupBranches:         []string{"group-1-branch", ""},
+					PreConsolidatedBranch: "pre-consolidated",
+				},
+			},
+			wantErr: false,
+			contains: []string{
+				"ALREADY MERGED",
+				"group-1-branch",
+				"Pre-Consolidated Branches",
+				"pre-consolidated",
+			},
+		},
+		{
+			name:        "nil context",
+			ctx:         nil,
+			wantErr:     true,
+			errContains: "nil",
+		},
+		{
+			name: "missing plan",
+			ctx: &Context{
+				Phase:         PhaseConsolidation,
+				SessionID:     "test-session",
+				Consolidation: &ConsolidationInfo{},
+			},
+			wantErr:     true,
+			errContains: "plan",
+		},
+		{
+			name: "missing consolidation info",
+			ctx: &Context{
+				Phase:     PhaseConsolidation,
+				SessionID: "test-session",
+				Plan:      &PlanInfo{},
+			},
+			wantErr:     true,
+			errContains: "consolidation",
+		},
+		{
+			name: "wrong phase",
+			ctx: &Context{
+				Phase:         PhaseTask,
+				SessionID:     "test-session",
+				Plan:          &PlanInfo{},
+				Consolidation: &ConsolidationInfo{},
+			},
+			wantErr:     true,
+			errContains: "invalid",
+		},
+	}
+
+	builder := NewConsolidationBuilder()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := builder.Build(tt.ctx)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Build() expected error, got nil")
+					return
+				}
+				if tt.errContains != "" && !strings.Contains(strings.ToLower(err.Error()), tt.errContains) {
+					t.Errorf("Build() error = %v, want error containing %q", err, tt.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Build() unexpected error: %v", err)
+				return
+			}
+
+			for _, want := range tt.contains {
+				if !strings.Contains(result, want) {
+					t.Errorf("Build() result missing %q\nGot:\n%s", want, result)
+				}
+			}
+		})
+	}
+}
+
+func TestGroupConsolidatorBuilder_Build(t *testing.T) {
+	tests := []struct {
+		name        string
+		ctx         *Context
+		wantErr     bool
+		errContains string
+		contains    []string
+	}{
+		{
+			name: "valid context for group 0",
+			ctx: &Context{
+				Phase:      PhaseConsolidation,
+				SessionID:  "abcd1234-5678",
+				Objective:  "Build feature",
+				GroupIndex: 0,
+				Plan: &PlanInfo{
+					Summary: "Feature plan",
+					Tasks: []TaskInfo{
+						{ID: "task-1", Title: "Task One"},
+						{ID: "task-2", Title: "Task Two"},
+					},
+					ExecutionOrder: [][]string{{"task-1", "task-2"}},
+				},
+				Consolidation: &ConsolidationInfo{
+					Mode:         "stacked",
+					BranchPrefix: "Iron-Ham",
+					MainBranch:   "main",
+					TaskWorktrees: []TaskWorktreeInfo{
+						{TaskID: "task-1", TaskTitle: "Task One", Branch: "branch-1", WorktreePath: "/path/1"},
+						{TaskID: "task-2", TaskTitle: "Task Two", Branch: "branch-2", WorktreePath: "/path/2"},
+					},
+				},
+			},
+			wantErr: false,
+			contains: []string{
+				"# Group 1 Consolidation",
+				"## Part of Ultra-Plan: Feature plan",
+				"## Tasks Completed in This Group",
+				"### task-1: Task One",
+				"### task-2: Task Two",
+				"## Branch Configuration",
+				"Base branch**: `main`",
+				"Iron-Ham/ultraplan-abcd1234-group-1",
+				"Task branches to consolidate**: 2",
+				"## Your Tasks",
+				"git checkout -b",
+				"Cherry-pick commits",
+				"Run verification",
+				"## Conflict Resolution Guidelines",
+				"## Completion Protocol",
+				GroupConsolidationCompletionFileName,
+				`"group_index": 0`,
+			},
+		},
+		{
+			name: "valid context for group 1 with previous group context",
+			ctx: &Context{
+				Phase:      PhaseConsolidation,
+				SessionID:  "test-session",
+				Objective:  "Build feature",
+				GroupIndex: 1,
+				Plan: &PlanInfo{
+					Summary:        "Feature plan",
+					ExecutionOrder: [][]string{{"t1"}, {"t2"}},
+				},
+				Consolidation: &ConsolidationInfo{
+					MainBranch:    "main",
+					GroupBranches: []string{"group-1-branch"},
+				},
+				PreviousGroup: &GroupContext{
+					GroupIndex:         0,
+					Notes:              "Database setup complete",
+					IssuesForNextGroup: []string{"Watch for connection limits"},
+					VerificationPassed: true,
+				},
+			},
+			wantErr: false,
+			contains: []string{
+				"# Group 2 Consolidation",
+				"## Context from Previous Group's Consolidator",
+				"Database setup complete",
+				"Watch for connection limits",
+				"Base branch**: `group-1-branch`",
+			},
+		},
+		{
+			name: "uses default branch prefix when not specified",
+			ctx: &Context{
+				Phase:      PhaseConsolidation,
+				SessionID:  "test1234",
+				GroupIndex: 0,
+				Plan: &PlanInfo{
+					ExecutionOrder: [][]string{{"t1"}},
+				},
+				Consolidation: &ConsolidationInfo{
+					MainBranch: "main",
+				},
+			},
+			wantErr: false,
+			contains: []string{
+				"Iron-Ham/ultraplan-test1234-group-1",
+			},
+		},
+		{
+			name:        "nil context",
+			ctx:         nil,
+			wantErr:     true,
+			errContains: "nil",
+		},
+		{
+			name: "missing plan",
+			ctx: &Context{
+				Phase:      PhaseConsolidation,
+				SessionID:  "test",
+				GroupIndex: 0,
+			},
+			wantErr:     true,
+			errContains: "plan",
+		},
+		{
+			name: "negative group index",
+			ctx: &Context{
+				Phase:         PhaseConsolidation,
+				SessionID:     "test",
+				GroupIndex:    -1,
+				Plan:          &PlanInfo{},
+				Consolidation: &ConsolidationInfo{},
+			},
+			wantErr:     true,
+			errContains: "non-negative",
+		},
+		{
+			name: "wrong phase",
+			ctx: &Context{
+				Phase:      PhaseTask,
+				SessionID:  "test",
+				GroupIndex: 0,
+				Plan:       &PlanInfo{},
+			},
+			wantErr:     true,
+			errContains: "invalid",
+		},
+	}
+
+	builder := NewGroupConsolidatorBuilder()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := builder.Build(tt.ctx)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Build() expected error, got nil")
+					return
+				}
+				if tt.errContains != "" && !strings.Contains(strings.ToLower(err.Error()), tt.errContains) {
+					t.Errorf("Build() error = %v, want error containing %q", err, tt.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Build() unexpected error: %v", err)
+				return
+			}
+
+			for _, want := range tt.contains {
+				if !strings.Contains(result, want) {
+					t.Errorf("Build() result missing %q\nGot:\n%s", want, result)
+				}
+			}
+		})
+	}
+}
+
+func TestGroupConsolidatorBuilder_getTaskBranchesForGroup(t *testing.T) {
+	builder := NewGroupConsolidatorBuilder()
+
+	ctx := &Context{
+		GroupIndex: 0,
+		Plan: &PlanInfo{
+			ExecutionOrder: [][]string{{"t1", "t2"}, {"t3"}},
+		},
+		Consolidation: &ConsolidationInfo{
+			TaskWorktrees: []TaskWorktreeInfo{
+				{TaskID: "t1", TaskTitle: "Task 1"},
+				{TaskID: "t2", TaskTitle: "Task 2"},
+				{TaskID: "t3", TaskTitle: "Task 3"},
+			},
+		},
+	}
+
+	// Test group 0
+	branches := builder.getTaskBranchesForGroup(ctx)
+	if len(branches) != 2 {
+		t.Errorf("getTaskBranchesForGroup() returned %d branches, want 2", len(branches))
+	}
+
+	// Test group 1
+	ctx.GroupIndex = 1
+	branches = builder.getTaskBranchesForGroup(ctx)
+	if len(branches) != 1 {
+		t.Errorf("getTaskBranchesForGroup() returned %d branches, want 1", len(branches))
+	}
+	if branches[0].TaskID != "t3" {
+		t.Errorf("getTaskBranchesForGroup() returned wrong task, got %s", branches[0].TaskID)
+	}
+}
+
+func TestNewConsolidationBuilder(t *testing.T) {
+	builder := NewConsolidationBuilder()
+	if builder == nil {
+		t.Error("NewConsolidationBuilder() returned nil")
+	}
+}
+
+func TestNewGroupConsolidatorBuilder(t *testing.T) {
+	builder := NewGroupConsolidatorBuilder()
+	if builder == nil {
+		t.Error("NewGroupConsolidatorBuilder() returned nil")
+	}
+}
+
+func TestConsolidationCompletionFileNames(t *testing.T) {
+	if ConsolidationCompletionFileName == "" {
+		t.Error("ConsolidationCompletionFileName should not be empty")
+	}
+	if !strings.HasSuffix(ConsolidationCompletionFileName, ".json") {
+		t.Errorf("ConsolidationCompletionFileName should end with .json")
+	}
+
+	if GroupConsolidationCompletionFileName == "" {
+		t.Error("GroupConsolidationCompletionFileName should not be empty")
+	}
+	if !strings.HasSuffix(GroupConsolidationCompletionFileName, ".json") {
+		t.Errorf("GroupConsolidationCompletionFileName should end with .json")
+	}
+}

--- a/internal/orchestrator/prompt/planning.go
+++ b/internal/orchestrator/prompt/planning.go
@@ -1,0 +1,216 @@
+// Package prompt provides interfaces and types for building prompts
+// in the ultra-plan orchestration system.
+package prompt
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// PlanFileName is the standard filename for plan output.
+const PlanFileName = ".claudio-plan.json"
+
+// PlanningBuilder builds prompts for the plan selection phase.
+// It formats candidate plans from multiple planning strategies for comparison
+// and selection by the plan manager coordinator.
+type PlanningBuilder struct{}
+
+// NewPlanningBuilder creates a new PlanningBuilder.
+func NewPlanningBuilder() *PlanningBuilder {
+	return &PlanningBuilder{}
+}
+
+// Build generates the plan manager prompt from the context.
+// It formats all candidate plans for comparison and includes evaluation criteria.
+func (b *PlanningBuilder) Build(ctx *Context) (string, error) {
+	if err := b.validate(ctx); err != nil {
+		return "", err
+	}
+
+	plansSection := b.formatCandidatePlans(ctx.CandidatePlans)
+	return fmt.Sprintf(planManagerPromptTemplate, ctx.Objective, plansSection), nil
+}
+
+// validate checks that the context has all required fields for planning.
+func (b *PlanningBuilder) validate(ctx *Context) error {
+	if ctx == nil {
+		return ErrNilContext
+	}
+	if ctx.Phase != PhasePlanSelection && ctx.Phase != PhasePlanning {
+		return fmt.Errorf("%w: expected %s or %s, got %s",
+			ErrInvalidPhase, PhasePlanSelection, PhasePlanning, ctx.Phase)
+	}
+	if ctx.Objective == "" {
+		return ErrEmptyObjective
+	}
+	if len(ctx.CandidatePlans) == 0 {
+		return ErrMissingCandidatePlans
+	}
+	return nil
+}
+
+// formatCandidatePlans formats all candidate plans for comparison.
+func (b *PlanningBuilder) formatCandidatePlans(plans []CandidatePlanInfo) string {
+	var sb strings.Builder
+
+	for i, plan := range plans {
+		strategyName := plan.Strategy
+		if strategyName == "" {
+			strategyName = fmt.Sprintf("strategy-%d", i+1)
+		}
+
+		sb.WriteString(fmt.Sprintf("### Plan %d: %s\n\n", i+1, strategyName))
+		sb.WriteString(fmt.Sprintf("**Summary**: %s\n\n", plan.Summary))
+
+		// Task count and parallelism stats
+		sb.WriteString(fmt.Sprintf("**Task Count**: %d tasks\n", len(plan.Tasks)))
+		if len(plan.ExecutionOrder) > 0 {
+			sb.WriteString(fmt.Sprintf("**Execution Groups**: %d groups\n", len(plan.ExecutionOrder)))
+			// Calculate max parallelism (largest group)
+			maxParallel := 0
+			for _, group := range plan.ExecutionOrder {
+				if len(group) > maxParallel {
+					maxParallel = len(group)
+				}
+			}
+			sb.WriteString(fmt.Sprintf("**Max Parallelism**: %d concurrent tasks\n", maxParallel))
+		}
+		sb.WriteString("\n")
+
+		// Insights
+		if len(plan.Insights) > 0 {
+			sb.WriteString("**Insights**:\n")
+			for _, insight := range plan.Insights {
+				sb.WriteString(fmt.Sprintf("- %s\n", insight))
+			}
+			sb.WriteString("\n")
+		}
+
+		// Constraints
+		if len(plan.Constraints) > 0 {
+			sb.WriteString("**Constraints**:\n")
+			for _, constraint := range plan.Constraints {
+				sb.WriteString(fmt.Sprintf("- %s\n", constraint))
+			}
+			sb.WriteString("\n")
+		}
+
+		// Full task list in JSON format for detailed comparison
+		sb.WriteString("**Tasks (JSON)**:\n```json\n")
+		tasksJSON, err := json.MarshalIndent(plan.Tasks, "", "  ")
+		if err != nil {
+			sb.WriteString(fmt.Sprintf("Error marshaling tasks: %v\n", err))
+		} else {
+			sb.WriteString(string(tasksJSON))
+		}
+		sb.WriteString("\n```\n\n")
+
+		// Execution order visualization
+		if len(plan.ExecutionOrder) > 0 {
+			sb.WriteString("**Execution Order**:\n")
+			for groupIdx, group := range plan.ExecutionOrder {
+				sb.WriteString(fmt.Sprintf("- Group %d: %s\n", groupIdx+1, strings.Join(group, ", ")))
+			}
+			sb.WriteString("\n")
+		}
+
+		sb.WriteString("---\n\n")
+	}
+
+	return sb.String()
+}
+
+// FormatCompactPlans formats candidate plans in a compact format
+// suitable for the initial plan manager prompt.
+func (b *PlanningBuilder) FormatCompactPlans(plans []CandidatePlanInfo) string {
+	var sb strings.Builder
+
+	for i, plan := range plans {
+		strategyName := plan.Strategy
+		if strategyName == "" {
+			strategyName = "unknown"
+		}
+
+		sb.WriteString(fmt.Sprintf("\n### Plan %d: %s Strategy\n\n", i+1, strategyName))
+		sb.WriteString(fmt.Sprintf("**Summary:** %s\n\n", plan.Summary))
+		sb.WriteString(fmt.Sprintf("**Tasks (%d total):**\n", len(plan.Tasks)))
+		for _, task := range plan.Tasks {
+			deps := "none"
+			if len(task.DependsOn) > 0 {
+				deps = strings.Join(task.DependsOn, ", ")
+			}
+			sb.WriteString(fmt.Sprintf("- [%s] %s (complexity: %s, depends: %s)\n",
+				task.ID, task.Title, task.EstComplexity, deps))
+		}
+		sb.WriteString(fmt.Sprintf("\n**Execution Groups:** %d parallel groups\n", len(plan.ExecutionOrder)))
+		for groupIdx, group := range plan.ExecutionOrder {
+			sb.WriteString(fmt.Sprintf("  - Group %d: %s\n", groupIdx+1, strings.Join(group, ", ")))
+		}
+
+		if len(plan.Insights) > 0 {
+			sb.WriteString("\n**Insights:**\n")
+			for _, insight := range plan.Insights {
+				sb.WriteString(fmt.Sprintf("- %s\n", insight))
+			}
+		}
+
+		if len(plan.Constraints) > 0 {
+			sb.WriteString("\n**Constraints:**\n")
+			for _, constraint := range plan.Constraints {
+				sb.WriteString(fmt.Sprintf("- %s\n", constraint))
+			}
+		}
+		sb.WriteString("\n---\n")
+	}
+
+	return sb.String()
+}
+
+// planManagerPromptTemplate is the prompt for the coordinator-manager in multi-pass mode.
+// It receives all candidate plans and must select the best one or merge them.
+const planManagerPromptTemplate = `You are a senior technical lead evaluating multiple implementation plans.
+
+## Objective
+%s
+
+## Candidate Plans
+Three different planning strategies have produced the following plans:
+
+%s
+
+## Your Task
+
+Evaluate each plan based on:
+1. **Parallelism potential**: How many tasks can run concurrently?
+2. **Task granularity**: Are tasks appropriately sized (prefer smaller, focused tasks)?
+3. **Dependency structure**: Is the dependency graph sensible and minimal?
+4. **File ownership**: Do tasks have clear, non-overlapping file assignments?
+5. **Completeness**: Does the plan fully address the objective?
+6. **Risk mitigation**: Are constraints and risks properly identified?
+
+## Decision
+
+You must either:
+1. **Select** the best plan as-is, OR
+2. **Merge** the best elements from multiple plans into a superior plan
+
+## Output
+
+Write your final plan to ` + "`" + PlanFileName + "`" + ` using the standard plan JSON schema.
+
+Before the plan file, output your reasoning in this format:
+<plan_decision>
+{
+  "action": "select" or "merge",
+  "selected_index": 0-2 (if select) or -1 (if merge),
+  "reasoning": "Brief explanation of your decision",
+  "plan_scores": [
+    {"strategy": "maximize-parallelism", "score": 1-10, "strengths": "...", "weaknesses": "..."},
+    {"strategy": "minimize-complexity", "score": 1-10, "strengths": "...", "weaknesses": "..."},
+    {"strategy": "balanced-approach", "score": 1-10, "strengths": "...", "weaknesses": "..."}
+  ]
+}
+</plan_decision>
+
+Then write the final plan file.`

--- a/internal/orchestrator/prompt/planning_test.go
+++ b/internal/orchestrator/prompt/planning_test.go
@@ -1,0 +1,415 @@
+package prompt
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestPlanningBuilder_Build(t *testing.T) {
+	tests := []struct {
+		name        string
+		ctx         *Context
+		wantErr     bool
+		errContains string
+		contains    []string
+	}{
+		{
+			name: "valid context with multiple plans",
+			ctx: &Context{
+				Phase:     PhasePlanSelection,
+				SessionID: "test-session",
+				Objective: "Implement user authentication",
+				CandidatePlans: []CandidatePlanInfo{
+					{
+						Strategy: "maximize-parallelism",
+						Summary:  "Focus on parallel execution",
+						Tasks: []TaskInfo{
+							{ID: "task-1", Title: "Setup auth module", EstComplexity: "medium"},
+							{ID: "task-2", Title: "Create login endpoint", EstComplexity: "low"},
+						},
+						ExecutionOrder: [][]string{{"task-1"}, {"task-2"}},
+						Insights:       []string{"Can parallelize more"},
+						Constraints:    []string{"Need database setup first"},
+					},
+					{
+						Strategy: "minimize-complexity",
+						Summary:  "Focus on simplicity",
+						Tasks: []TaskInfo{
+							{ID: "task-a", Title: "Combined auth task", EstComplexity: "high"},
+						},
+						ExecutionOrder: [][]string{{"task-a"}},
+					},
+				},
+			},
+			wantErr: false,
+			contains: []string{
+				"Implement user authentication",
+				"maximize-parallelism",
+				"minimize-complexity",
+				"Focus on parallel execution",
+				"Focus on simplicity",
+				"task-1",
+				"task-2",
+				"task-a",
+				"Evaluate each plan",
+				"Parallelism potential",
+			},
+		},
+		{
+			name: "valid context with PhasePlanning",
+			ctx: &Context{
+				Phase:     PhasePlanning,
+				SessionID: "test-session",
+				Objective: "Build API",
+				CandidatePlans: []CandidatePlanInfo{
+					{
+						Strategy: "balanced",
+						Summary:  "Balanced approach",
+						Tasks:    []TaskInfo{{ID: "t1", Title: "Task 1"}},
+					},
+				},
+			},
+			wantErr:  false,
+			contains: []string{"Build API", "balanced", "Task 1"},
+		},
+		{
+			name:        "nil context",
+			ctx:         nil,
+			wantErr:     true,
+			errContains: "nil",
+		},
+		{
+			name: "missing objective",
+			ctx: &Context{
+				Phase:     PhasePlanSelection,
+				SessionID: "test-session",
+				CandidatePlans: []CandidatePlanInfo{
+					{Strategy: "test", Summary: "test"},
+				},
+			},
+			wantErr:     true,
+			errContains: "objective",
+		},
+		{
+			name: "missing candidate plans",
+			ctx: &Context{
+				Phase:     PhasePlanSelection,
+				SessionID: "test-session",
+				Objective: "Test objective",
+			},
+			wantErr:     true,
+			errContains: "candidate plans",
+		},
+		{
+			name: "wrong phase",
+			ctx: &Context{
+				Phase:     PhaseTask,
+				SessionID: "test-session",
+				Objective: "Test objective",
+				CandidatePlans: []CandidatePlanInfo{
+					{Strategy: "test", Summary: "test"},
+				},
+			},
+			wantErr:     true,
+			errContains: "invalid",
+		},
+	}
+
+	builder := NewPlanningBuilder()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := builder.Build(tt.ctx)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Build() expected error, got nil")
+					return
+				}
+				if tt.errContains != "" && !strings.Contains(strings.ToLower(err.Error()), tt.errContains) {
+					t.Errorf("Build() error = %v, want error containing %q", err, tt.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Build() unexpected error: %v", err)
+				return
+			}
+
+			for _, want := range tt.contains {
+				if !strings.Contains(result, want) {
+					t.Errorf("Build() result missing %q\nGot:\n%s", want, result)
+				}
+			}
+		})
+	}
+}
+
+func TestPlanningBuilder_formatCandidatePlans(t *testing.T) {
+	builder := NewPlanningBuilder()
+
+	tests := []struct {
+		name     string
+		plans    []CandidatePlanInfo
+		contains []string
+	}{
+		{
+			name: "formats strategy names",
+			plans: []CandidatePlanInfo{
+				{Strategy: "maximize-parallelism", Summary: "Parallel focus"},
+				{Strategy: "minimize-complexity", Summary: "Simple focus"},
+			},
+			contains: []string{
+				"Plan 1: maximize-parallelism",
+				"Plan 2: minimize-complexity",
+				"Parallel focus",
+				"Simple focus",
+			},
+		},
+		{
+			name: "uses default strategy name when empty",
+			plans: []CandidatePlanInfo{
+				{Strategy: "", Summary: "No strategy name"},
+			},
+			contains: []string{
+				"Plan 1: strategy-1",
+			},
+		},
+		{
+			name: "includes task count",
+			plans: []CandidatePlanInfo{
+				{
+					Strategy: "test",
+					Summary:  "Test",
+					Tasks: []TaskInfo{
+						{ID: "t1", Title: "Task 1"},
+						{ID: "t2", Title: "Task 2"},
+						{ID: "t3", Title: "Task 3"},
+					},
+				},
+			},
+			contains: []string{
+				"**Task Count**: 3 tasks",
+			},
+		},
+		{
+			name: "includes execution groups and max parallelism",
+			plans: []CandidatePlanInfo{
+				{
+					Strategy:       "test",
+					Summary:        "Test",
+					ExecutionOrder: [][]string{{"t1", "t2"}, {"t3"}},
+				},
+			},
+			contains: []string{
+				"**Execution Groups**: 2 groups",
+				"**Max Parallelism**: 2 concurrent tasks",
+				"Group 1: t1, t2",
+				"Group 2: t3",
+			},
+		},
+		{
+			name: "includes insights",
+			plans: []CandidatePlanInfo{
+				{
+					Strategy: "test",
+					Summary:  "Test",
+					Insights: []string{"Insight one", "Insight two"},
+				},
+			},
+			contains: []string{
+				"**Insights**:",
+				"- Insight one",
+				"- Insight two",
+			},
+		},
+		{
+			name: "includes constraints",
+			plans: []CandidatePlanInfo{
+				{
+					Strategy:    "test",
+					Summary:     "Test",
+					Constraints: []string{"Constraint one"},
+				},
+			},
+			contains: []string{
+				"**Constraints**:",
+				"- Constraint one",
+			},
+		},
+		{
+			name: "includes JSON tasks",
+			plans: []CandidatePlanInfo{
+				{
+					Strategy: "test",
+					Summary:  "Test",
+					Tasks: []TaskInfo{
+						{ID: "task-1", Title: "First task"},
+					},
+				},
+			},
+			contains: []string{
+				"**Tasks (JSON)**:",
+				"```json",
+				`"ID": "task-1"`,
+				`"Title": "First task"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := builder.formatCandidatePlans(tt.plans)
+
+			for _, want := range tt.contains {
+				if !strings.Contains(result, want) {
+					t.Errorf("formatCandidatePlans() missing %q\nGot:\n%s", want, result)
+				}
+			}
+		})
+	}
+}
+
+func TestPlanningBuilder_FormatCompactPlans(t *testing.T) {
+	builder := NewPlanningBuilder()
+
+	plans := []CandidatePlanInfo{
+		{
+			Strategy: "maximize-parallelism",
+			Summary:  "Focus on parallel execution",
+			Tasks: []TaskInfo{
+				{ID: "task-1", Title: "Task One", EstComplexity: "medium", DependsOn: nil},
+				{ID: "task-2", Title: "Task Two", EstComplexity: "low", DependsOn: []string{"task-1"}},
+			},
+			ExecutionOrder: [][]string{{"task-1"}, {"task-2"}},
+			Insights:       []string{"Good parallelism"},
+			Constraints:    []string{"Resource constraint"},
+		},
+	}
+
+	result := builder.FormatCompactPlans(plans)
+
+	expectedParts := []string{
+		"Plan 1: maximize-parallelism Strategy",
+		"**Summary:** Focus on parallel execution",
+		"**Tasks (2 total):**",
+		"[task-1] Task One (complexity: medium, depends: none)",
+		"[task-2] Task Two (complexity: low, depends: task-1)",
+		"**Execution Groups:** 2 parallel groups",
+		"Group 1: task-1",
+		"Group 2: task-2",
+		"**Insights:**",
+		"- Good parallelism",
+		"**Constraints:**",
+		"- Resource constraint",
+	}
+
+	for _, part := range expectedParts {
+		if !strings.Contains(result, part) {
+			t.Errorf("FormatCompactPlans() missing %q\nGot:\n%s", part, result)
+		}
+	}
+}
+
+func TestPlanningBuilder_JSONValidity(t *testing.T) {
+	builder := NewPlanningBuilder()
+
+	plan := CandidatePlanInfo{
+		Strategy: "test",
+		Summary:  "Test plan",
+		Tasks: []TaskInfo{
+			{
+				ID:            "task-1",
+				Title:         "Test Task",
+				Description:   "A test task description",
+				Files:         []string{"file1.go", "file2.go"},
+				DependsOn:     []string{"task-0"},
+				Priority:      1,
+				EstComplexity: "medium",
+			},
+		},
+		ExecutionOrder: [][]string{{"task-1"}},
+	}
+
+	result := builder.formatCandidatePlans([]CandidatePlanInfo{plan})
+
+	// Extract JSON from the result
+	jsonStart := strings.Index(result, "```json\n") + len("```json\n")
+	jsonEnd := strings.Index(result[jsonStart:], "\n```")
+	if jsonStart < len("```json\n") || jsonEnd < 0 {
+		t.Fatal("Could not find JSON block in output")
+	}
+
+	jsonStr := result[jsonStart : jsonStart+jsonEnd]
+
+	var tasks []TaskInfo
+	if err := json.Unmarshal([]byte(jsonStr), &tasks); err != nil {
+		t.Errorf("JSON in output is not valid: %v\nJSON:\n%s", err, jsonStr)
+	}
+
+	if len(tasks) != 1 {
+		t.Errorf("Expected 1 task in JSON, got %d", len(tasks))
+	}
+
+	if tasks[0].ID != "task-1" {
+		t.Errorf("Task ID = %q, want %q", tasks[0].ID, "task-1")
+	}
+}
+
+func TestPlanningBuilder_PromptTemplate(t *testing.T) {
+	builder := NewPlanningBuilder()
+
+	ctx := &Context{
+		Phase:     PhasePlanSelection,
+		SessionID: "test-session",
+		Objective: "Build a REST API",
+		CandidatePlans: []CandidatePlanInfo{
+			{
+				Strategy: "balanced",
+				Summary:  "Balanced approach",
+				Tasks:    []TaskInfo{{ID: "t1", Title: "Task 1"}},
+			},
+		},
+	}
+
+	result, err := builder.Build(ctx)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+
+	// Check that the prompt includes the expected structure
+	expectedSections := []string{
+		"## Objective",
+		"Build a REST API",
+		"## Candidate Plans",
+		"## Your Task",
+		"Parallelism potential",
+		"Task granularity",
+		"Dependency structure",
+		"File ownership",
+		"Completeness",
+		"Risk mitigation",
+		"## Decision",
+		"**Select** the best plan",
+		"**Merge** the best elements",
+		"## Output",
+		PlanFileName,
+		"<plan_decision>",
+		"</plan_decision>",
+	}
+
+	for _, section := range expectedSections {
+		if !strings.Contains(result, section) {
+			t.Errorf("Build() result missing section %q", section)
+		}
+	}
+}
+
+func TestNewPlanningBuilder(t *testing.T) {
+	builder := NewPlanningBuilder()
+	if builder == nil {
+		t.Error("NewPlanningBuilder() returned nil")
+	}
+}

--- a/internal/orchestrator/prompt/revision.go
+++ b/internal/orchestrator/prompt/revision.go
@@ -1,0 +1,146 @@
+// Package prompt provides interfaces and types for building prompts
+// in the ultra-plan orchestration system.
+package prompt
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RevisionCompletionFileName is the filename for revision phase completion.
+const RevisionCompletionFileName = ".claudio-revision-complete.json"
+
+// RevisionBuilder builds prompts for the revision phase.
+// It formats issues to address and provides instructions for fixing them.
+type RevisionBuilder struct{}
+
+// NewRevisionBuilder creates a new RevisionBuilder.
+func NewRevisionBuilder() *RevisionBuilder {
+	return &RevisionBuilder{}
+}
+
+// Build generates the revision prompt from the context.
+func (b *RevisionBuilder) Build(ctx *Context) (string, error) {
+	if err := b.validate(ctx); err != nil {
+		return "", err
+	}
+
+	issuesStr := b.formatIssues(ctx)
+	revisionRound := ctx.Revision.Round + 1
+
+	return fmt.Sprintf(revisionPromptTemplate,
+		ctx.Objective,
+		ctx.Task.ID,
+		ctx.Task.Title,
+		ctx.Task.Description,
+		revisionRound,
+		issuesStr,
+		ctx.Task.ID,
+		revisionRound,
+	), nil
+}
+
+// validate checks that the context has all required fields for revision prompts.
+func (b *RevisionBuilder) validate(ctx *Context) error {
+	if ctx == nil {
+		return ErrNilContext
+	}
+	if ctx.Phase != PhaseRevision {
+		return fmt.Errorf("%w: expected %s, got %s", ErrInvalidPhase, PhaseRevision, ctx.Phase)
+	}
+	if ctx.Plan == nil {
+		return ErrMissingPlan
+	}
+	if ctx.Task == nil {
+		return ErrMissingTask
+	}
+	if ctx.Revision == nil {
+		return ErrMissingRevision
+	}
+	if ctx.Objective == "" {
+		return ErrEmptyObjective
+	}
+	return nil
+}
+
+// formatIssues formats the revision issues for display.
+func (b *RevisionBuilder) formatIssues(ctx *Context) string {
+	var sb strings.Builder
+
+	// Filter issues for this specific task
+	var taskIssues []RevisionIssue
+	for _, issue := range ctx.Revision.Issues {
+		if issue.TaskID == ctx.Task.ID || issue.TaskID == "" {
+			taskIssues = append(taskIssues, issue)
+		}
+	}
+
+	for i, issue := range taskIssues {
+		sb.WriteString(fmt.Sprintf("%d. **%s**: %s\n", i+1, issue.Severity, issue.Description))
+		if len(issue.Files) > 0 {
+			sb.WriteString(fmt.Sprintf("   Files: %s\n", strings.Join(issue.Files, ", ")))
+		}
+		if issue.Suggestion != "" {
+			sb.WriteString(fmt.Sprintf("   Suggestion: %s\n", issue.Suggestion))
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+// revisionPromptTemplate is the prompt used for the revision phase.
+const revisionPromptTemplate = `You are addressing issues identified during review of completed work.
+
+## Original Objective
+%s
+
+## Task Being Revised
+- Task ID: %s
+- Task Title: %s
+- Original Description: %s
+- Revision Round: %d
+
+## Issues to Address
+%s
+
+## Worktree Information
+You are working in the same worktree that was used for the original task.
+All previous changes from this task are already present.
+
+## Instructions
+
+1. **Review** the issues identified above
+2. **Fix** each issue in the codebase
+3. **Test** that your fixes don't break existing functionality
+4. **Commit** your changes with a clear message describing the fixes
+
+Focus only on addressing the identified issues. Do not refactor or make other changes unless directly related to fixing the issues.
+
+## Completion Protocol
+
+When your revision is complete, you MUST write a completion file:
+
+1. Use Write tool to create ` + "`" + RevisionCompletionFileName + "`" + ` in your worktree root
+2. Include this JSON structure:
+` + "```json" + `
+{
+  "task_id": "%s",
+  "revision_round": %d,
+  "status": "complete",
+  "issues_addressed": [
+    {
+      "original_issue": "Issue description",
+      "fix_applied": "What you did to fix it",
+      "files_changed": ["file1.go"]
+    }
+  ],
+  "remaining_issues": [],
+  "notes": "Any additional context about the fixes"
+}
+` + "```" + `
+
+3. Use status "partial" if some issues couldn't be fully resolved
+4. Use status "blocked" if you need input or can't proceed
+
+This file signals that your revision work is complete.`

--- a/internal/orchestrator/prompt/revision_test.go
+++ b/internal/orchestrator/prompt/revision_test.go
@@ -1,0 +1,272 @@
+package prompt
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRevisionBuilder_Build(t *testing.T) {
+	tests := []struct {
+		name        string
+		ctx         *Context
+		wantErr     bool
+		errContains string
+		contains    []string
+	}{
+		{
+			name: "valid context with issues",
+			ctx: &Context{
+				Phase:     PhaseRevision,
+				SessionID: "test-session",
+				Objective: "Build authentication system",
+				Plan:      &PlanInfo{Summary: "Auth plan"},
+				Task: &TaskInfo{
+					ID:          "task-1",
+					Title:       "Implement login",
+					Description: "Create login functionality",
+				},
+				Revision: &RevisionInfo{
+					Round:     0,
+					MaxRounds: 3,
+					Issues: []RevisionIssue{
+						{
+							TaskID:      "task-1",
+							Description: "Missing input validation",
+							Severity:    "major",
+							Files:       []string{"auth.go"},
+							Suggestion:  "Add validation for email format",
+						},
+						{
+							TaskID:      "task-1",
+							Description: "No error handling",
+							Severity:    "critical",
+							Files:       []string{"handler.go", "service.go"},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			contains: []string{
+				"## Original Objective",
+				"Build authentication system",
+				"## Task Being Revised",
+				"Task ID: task-1",
+				"Task Title: Implement login",
+				"Create login functionality",
+				"Revision Round: 1",
+				"## Issues to Address",
+				"1. **major**: Missing input validation",
+				"Files: auth.go",
+				"Suggestion: Add validation for email format",
+				"2. **critical**: No error handling",
+				"Files: handler.go, service.go",
+				"## Instructions",
+				"## Completion Protocol",
+				RevisionCompletionFileName,
+			},
+		},
+		{
+			name: "filters issues for specific task",
+			ctx: &Context{
+				Phase:     PhaseRevision,
+				SessionID: "test-session",
+				Objective: "Test",
+				Plan:      &PlanInfo{},
+				Task: &TaskInfo{
+					ID:          "task-2",
+					Title:       "Task 2",
+					Description: "Description",
+				},
+				Revision: &RevisionInfo{
+					Issues: []RevisionIssue{
+						{TaskID: "task-1", Description: "Issue for task 1"},
+						{TaskID: "task-2", Description: "Issue for task 2"},
+						{TaskID: "", Description: "Global issue"},
+					},
+				},
+			},
+			wantErr: false,
+			contains: []string{
+				"Issue for task 2",
+				"Global issue",
+			},
+		},
+		{
+			name: "includes global issues (empty task ID)",
+			ctx: &Context{
+				Phase:     PhaseRevision,
+				SessionID: "test-session",
+				Objective: "Test",
+				Plan:      &PlanInfo{},
+				Task: &TaskInfo{
+					ID:          "task-1",
+					Title:       "Task 1",
+					Description: "Description",
+				},
+				Revision: &RevisionInfo{
+					Issues: []RevisionIssue{
+						{TaskID: "", Description: "Cross-cutting issue", Severity: "minor"},
+					},
+				},
+			},
+			wantErr: false,
+			contains: []string{
+				"Cross-cutting issue",
+			},
+		},
+		{
+			name:        "nil context",
+			ctx:         nil,
+			wantErr:     true,
+			errContains: "nil",
+		},
+		{
+			name: "missing plan",
+			ctx: &Context{
+				Phase:     PhaseRevision,
+				SessionID: "test-session",
+				Objective: "Test",
+				Task:      &TaskInfo{ID: "t1", Title: "T"},
+				Revision:  &RevisionInfo{},
+			},
+			wantErr:     true,
+			errContains: "plan",
+		},
+		{
+			name: "missing task",
+			ctx: &Context{
+				Phase:     PhaseRevision,
+				SessionID: "test-session",
+				Objective: "Test",
+				Plan:      &PlanInfo{},
+				Revision:  &RevisionInfo{},
+			},
+			wantErr:     true,
+			errContains: "task",
+		},
+		{
+			name: "missing revision info",
+			ctx: &Context{
+				Phase:     PhaseRevision,
+				SessionID: "test-session",
+				Objective: "Test",
+				Plan:      &PlanInfo{},
+				Task:      &TaskInfo{ID: "t1", Title: "T"},
+			},
+			wantErr:     true,
+			errContains: "revision",
+		},
+		{
+			name: "missing objective",
+			ctx: &Context{
+				Phase:     PhaseRevision,
+				SessionID: "test-session",
+				Plan:      &PlanInfo{},
+				Task:      &TaskInfo{ID: "t1", Title: "T"},
+				Revision:  &RevisionInfo{},
+			},
+			wantErr:     true,
+			errContains: "objective",
+		},
+		{
+			name: "wrong phase",
+			ctx: &Context{
+				Phase:     PhaseTask,
+				SessionID: "test-session",
+				Objective: "Test",
+				Plan:      &PlanInfo{},
+				Task:      &TaskInfo{ID: "t1", Title: "T"},
+				Revision:  &RevisionInfo{},
+			},
+			wantErr:     true,
+			errContains: "invalid",
+		},
+	}
+
+	builder := NewRevisionBuilder()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := builder.Build(tt.ctx)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Build() expected error, got nil")
+					return
+				}
+				if tt.errContains != "" && !strings.Contains(strings.ToLower(err.Error()), tt.errContains) {
+					t.Errorf("Build() error = %v, want error containing %q", err, tt.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Build() unexpected error: %v", err)
+				return
+			}
+
+			for _, want := range tt.contains {
+				if !strings.Contains(result, want) {
+					t.Errorf("Build() result missing %q\nGot:\n%s", want, result)
+				}
+			}
+		})
+	}
+}
+
+func TestRevisionBuilder_CompletionProtocol(t *testing.T) {
+	builder := NewRevisionBuilder()
+
+	ctx := &Context{
+		Phase:     PhaseRevision,
+		SessionID: "test-session",
+		Objective: "Test",
+		Plan:      &PlanInfo{},
+		Task: &TaskInfo{
+			ID:          "unique-task",
+			Title:       "Task",
+			Description: "Description",
+		},
+		Revision: &RevisionInfo{Round: 1},
+	}
+
+	result, err := builder.Build(ctx)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+
+	expectedParts := []string{
+		"## Completion Protocol",
+		RevisionCompletionFileName,
+		`"task_id": "unique-task"`,
+		`"revision_round": 2`,
+		`"status": "complete"`,
+		`"issues_addressed":`,
+		`"remaining_issues":`,
+		`"notes":`,
+		"partial",
+		"blocked",
+	}
+
+	for _, part := range expectedParts {
+		if !strings.Contains(result, part) {
+			t.Errorf("Completion protocol missing %q", part)
+		}
+	}
+}
+
+func TestNewRevisionBuilder(t *testing.T) {
+	builder := NewRevisionBuilder()
+	if builder == nil {
+		t.Error("NewRevisionBuilder() returned nil")
+	}
+}
+
+func TestRevisionCompletionFileName(t *testing.T) {
+	if RevisionCompletionFileName == "" {
+		t.Error("RevisionCompletionFileName should not be empty")
+	}
+	if !strings.HasSuffix(RevisionCompletionFileName, ".json") {
+		t.Errorf("RevisionCompletionFileName should end with .json, got %q", RevisionCompletionFileName)
+	}
+}

--- a/internal/orchestrator/prompt/synthesis.go
+++ b/internal/orchestrator/prompt/synthesis.go
@@ -1,0 +1,163 @@
+// Package prompt provides interfaces and types for building prompts
+// in the ultra-plan orchestration system.
+package prompt
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SynthesisCompletionFileName is the filename for synthesis phase completion.
+const SynthesisCompletionFileName = ".claudio-synthesis-complete.json"
+
+// SynthesisBuilder builds prompts for the synthesis phase.
+// It aggregates completed task results for review and identifies integration issues.
+type SynthesisBuilder struct{}
+
+// NewSynthesisBuilder creates a new SynthesisBuilder.
+func NewSynthesisBuilder() *SynthesisBuilder {
+	return &SynthesisBuilder{}
+}
+
+// Build generates the synthesis prompt from the context.
+func (b *SynthesisBuilder) Build(ctx *Context) (string, error) {
+	if err := b.validate(ctx); err != nil {
+		return "", err
+	}
+
+	taskList := b.buildTaskList(ctx)
+	resultsSummary := b.buildResultsSummary(ctx)
+	revisionRound := 0
+
+	return fmt.Sprintf(synthesisPromptTemplate, ctx.Objective, taskList, resultsSummary, revisionRound), nil
+}
+
+// validate checks that the context has all required fields for synthesis prompts.
+func (b *SynthesisBuilder) validate(ctx *Context) error {
+	if ctx == nil {
+		return ErrNilContext
+	}
+	if ctx.Phase != PhaseSynthesis {
+		return fmt.Errorf("%w: expected %s, got %s", ErrInvalidPhase, PhaseSynthesis, ctx.Phase)
+	}
+	if ctx.Plan == nil {
+		return ErrMissingPlan
+	}
+	if ctx.Objective == "" {
+		return ErrEmptyObjective
+	}
+	return nil
+}
+
+// buildTaskList creates a summary list of completed tasks.
+func (b *SynthesisBuilder) buildTaskList(ctx *Context) string {
+	var sb strings.Builder
+
+	for _, taskID := range ctx.CompletedTasks {
+		task := b.findTask(ctx.Plan.Tasks, taskID)
+		if task == nil {
+			// Task marked as completed but not found in plan - include warning
+			sb.WriteString(fmt.Sprintf("- [%s] [NOT FOUND] - WARNING: task data missing\n", taskID))
+			continue
+		}
+
+		if task.CommitCount > 0 {
+			sb.WriteString(fmt.Sprintf("- [%s] %s (%d commits)\n", task.ID, task.Title, task.CommitCount))
+		} else {
+			sb.WriteString(fmt.Sprintf("- [%s] %s (NO COMMITS - verify this task)\n", task.ID, task.Title))
+		}
+	}
+
+	return sb.String()
+}
+
+// buildResultsSummary creates a detailed summary of task results.
+func (b *SynthesisBuilder) buildResultsSummary(ctx *Context) string {
+	var sb strings.Builder
+
+	for _, taskID := range ctx.CompletedTasks {
+		task := b.findTask(ctx.Plan.Tasks, taskID)
+		if task == nil {
+			// Task marked as completed but not found in plan - include warning
+			sb.WriteString(fmt.Sprintf("### [NOT FOUND: %s]\n", taskID))
+			sb.WriteString("Status: **WARNING - task data missing**\n\n")
+			continue
+		}
+
+		sb.WriteString(fmt.Sprintf("### %s\n", task.Title))
+		sb.WriteString("Status: completed\n")
+
+		if task.CommitCount > 0 {
+			sb.WriteString(fmt.Sprintf("Commits: %d\n", task.CommitCount))
+		}
+
+		if len(task.Files) > 0 {
+			sb.WriteString(fmt.Sprintf("Files: %s\n", strings.Join(task.Files, ", ")))
+		}
+
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+// findTask finds a task by ID in the task list.
+func (b *SynthesisBuilder) findTask(tasks []TaskInfo, id string) *TaskInfo {
+	for i := range tasks {
+		if tasks[i].ID == id {
+			return &tasks[i]
+		}
+	}
+	return nil
+}
+
+// synthesisPromptTemplate is the prompt used for the synthesis phase.
+const synthesisPromptTemplate = `You are reviewing the results of a parallel execution plan.
+
+## Original Objective
+%s
+
+## Completed Tasks
+%s
+
+## Task Results Summary
+%s
+
+## Instructions
+
+1. **Review** all completed work to ensure it meets the original objective
+2. **Identify** any integration issues, bugs, or conflicts that need resolution
+3. **Verify** that all pieces work together correctly
+4. **Check** for any missing functionality or incomplete implementations
+
+## Completion Protocol
+
+When your review is complete, you MUST write a completion file to signal the orchestrator:
+
+1. Use Write tool to create ` + "`" + SynthesisCompletionFileName + "`" + ` in your worktree root
+2. Include this JSON structure:
+` + "```json" + `
+{
+  "status": "complete",
+  "revision_round": %d,
+  "issues_found": [
+    {
+      "task_id": "task-id-here",
+      "description": "Clear description of the issue",
+      "files": ["file1.go", "file2.go"],
+      "severity": "critical|major|minor",
+      "suggestion": "How to fix this issue"
+    }
+  ],
+  "tasks_affected": ["task-1", "task-2"],
+  "integration_notes": "Observations about how the pieces integrate",
+  "recommendations": ["Suggestions for the consolidation phase"]
+}
+` + "```" + `
+
+3. Set status to "needs_revision" if critical/major issues require fixing, "complete" otherwise
+4. Leave issues_found as empty array [] if no issues found
+5. Include integration_notes with observations about cross-task integration
+6. Add recommendations for the consolidation phase (merge order, potential conflicts, etc.)
+
+This file signals that your review is done and provides context for subsequent phases.`

--- a/internal/orchestrator/prompt/synthesis_test.go
+++ b/internal/orchestrator/prompt/synthesis_test.go
@@ -1,0 +1,213 @@
+package prompt
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSynthesisBuilder_Build(t *testing.T) {
+	tests := []struct {
+		name        string
+		ctx         *Context
+		wantErr     bool
+		errContains string
+		contains    []string
+	}{
+		{
+			name: "valid context with completed tasks",
+			ctx: &Context{
+				Phase:     PhaseSynthesis,
+				SessionID: "test-session",
+				Objective: "Build authentication system",
+				Plan: &PlanInfo{
+					Summary: "Auth implementation",
+					Tasks: []TaskInfo{
+						{ID: "task-1", Title: "Create user model", CommitCount: 2},
+						{ID: "task-2", Title: "Add login endpoint", CommitCount: 3},
+					},
+				},
+				CompletedTasks: []string{"task-1", "task-2"},
+			},
+			wantErr: false,
+			contains: []string{
+				"## Original Objective",
+				"Build authentication system",
+				"## Completed Tasks",
+				"[task-1] Create user model (2 commits)",
+				"[task-2] Add login endpoint (3 commits)",
+				"## Task Results Summary",
+				"### Create user model",
+				"### Add login endpoint",
+				"## Instructions",
+				"Review",
+				"Identify",
+				"## Completion Protocol",
+				SynthesisCompletionFileName,
+			},
+		},
+		{
+			name: "task with no commits shows warning",
+			ctx: &Context{
+				Phase:     PhaseSynthesis,
+				SessionID: "test-session",
+				Objective: "Test objective",
+				Plan: &PlanInfo{
+					Tasks: []TaskInfo{
+						{ID: "task-1", Title: "Task with no commits", CommitCount: 0},
+					},
+				},
+				CompletedTasks: []string{"task-1"},
+			},
+			wantErr: false,
+			contains: []string{
+				"NO COMMITS - verify this task",
+			},
+		},
+		{
+			name: "task with files shows them",
+			ctx: &Context{
+				Phase:     PhaseSynthesis,
+				SessionID: "test-session",
+				Objective: "Test",
+				Plan: &PlanInfo{
+					Tasks: []TaskInfo{
+						{
+							ID:          "task-1",
+							Title:       "File task",
+							CommitCount: 1,
+							Files:       []string{"file1.go", "file2.go"},
+						},
+					},
+				},
+				CompletedTasks: []string{"task-1"},
+			},
+			wantErr: false,
+			contains: []string{
+				"Files: file1.go, file2.go",
+			},
+		},
+		{
+			name:        "nil context",
+			ctx:         nil,
+			wantErr:     true,
+			errContains: "nil",
+		},
+		{
+			name: "missing plan",
+			ctx: &Context{
+				Phase:     PhaseSynthesis,
+				SessionID: "test-session",
+				Objective: "Test",
+			},
+			wantErr:     true,
+			errContains: "plan",
+		},
+		{
+			name: "missing objective",
+			ctx: &Context{
+				Phase:     PhaseSynthesis,
+				SessionID: "test-session",
+				Plan:      &PlanInfo{},
+			},
+			wantErr:     true,
+			errContains: "objective",
+		},
+		{
+			name: "wrong phase",
+			ctx: &Context{
+				Phase:     PhaseTask,
+				SessionID: "test-session",
+				Objective: "Test",
+				Plan:      &PlanInfo{},
+			},
+			wantErr:     true,
+			errContains: "invalid",
+		},
+	}
+
+	builder := NewSynthesisBuilder()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := builder.Build(tt.ctx)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Build() expected error, got nil")
+					return
+				}
+				if tt.errContains != "" && !strings.Contains(strings.ToLower(err.Error()), tt.errContains) {
+					t.Errorf("Build() error = %v, want error containing %q", err, tt.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Build() unexpected error: %v", err)
+				return
+			}
+
+			for _, want := range tt.contains {
+				if !strings.Contains(result, want) {
+					t.Errorf("Build() result missing %q\nGot:\n%s", want, result)
+				}
+			}
+		})
+	}
+}
+
+func TestSynthesisBuilder_CompletionProtocol(t *testing.T) {
+	builder := NewSynthesisBuilder()
+
+	ctx := &Context{
+		Phase:     PhaseSynthesis,
+		SessionID: "test-session",
+		Objective: "Test",
+		Plan: &PlanInfo{
+			Tasks: []TaskInfo{{ID: "t1", Title: "Task 1"}},
+		},
+		CompletedTasks: []string{"t1"},
+	}
+
+	result, err := builder.Build(ctx)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+
+	expectedParts := []string{
+		"## Completion Protocol",
+		SynthesisCompletionFileName,
+		`"status": "complete"`,
+		`"revision_round":`,
+		`"issues_found":`,
+		`"task_id":`,
+		`"description":`,
+		`"severity":`,
+		`"tasks_affected":`,
+		`"integration_notes":`,
+		`"recommendations":`,
+		"needs_revision",
+	}
+
+	for _, part := range expectedParts {
+		if !strings.Contains(result, part) {
+			t.Errorf("Completion protocol missing %q", part)
+		}
+	}
+}
+
+func TestNewSynthesisBuilder(t *testing.T) {
+	builder := NewSynthesisBuilder()
+	if builder == nil {
+		t.Error("NewSynthesisBuilder() returned nil")
+	}
+}
+
+func TestSynthesisCompletionFileName(t *testing.T) {
+	if SynthesisCompletionFileName == "" {
+		t.Error("SynthesisCompletionFileName should not be empty")
+	}
+	if !strings.HasSuffix(SynthesisCompletionFileName, ".json") {
+		t.Errorf("SynthesisCompletionFileName should end with .json, got %q", SynthesisCompletionFileName)
+	}
+}

--- a/internal/orchestrator/prompt/task.go
+++ b/internal/orchestrator/prompt/task.go
@@ -1,0 +1,134 @@
+// Package prompt provides interfaces and types for building prompts
+// in the ultra-plan orchestration system.
+package prompt
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TaskCompletionFileName is the filename for task completion signaling.
+const TaskCompletionFileName = ".claudio-task-complete.json"
+
+// TaskBuilder builds prompts for individual task execution.
+// It formats task details, expected files, previous group context,
+// and completion protocol instructions.
+type TaskBuilder struct{}
+
+// NewTaskBuilder creates a new TaskBuilder.
+func NewTaskBuilder() *TaskBuilder {
+	return &TaskBuilder{}
+}
+
+// Build generates the task prompt from the context.
+func (b *TaskBuilder) Build(ctx *Context) (string, error) {
+	if err := b.validate(ctx); err != nil {
+		return "", err
+	}
+
+	var sb strings.Builder
+
+	// Task header
+	fmt.Fprintf(&sb, "# Task: %s\n\n", ctx.Task.Title)
+	fmt.Fprintf(&sb, "## Part of Ultra-Plan: %s\n\n", ctx.Plan.Summary)
+
+	// Task description
+	sb.WriteString("## Your Task\n\n")
+	sb.WriteString(ctx.Task.Description)
+	sb.WriteString("\n\n")
+
+	// Expected files section
+	if len(ctx.Task.Files) > 0 {
+		sb.WriteString("## Expected Files\n\n")
+		sb.WriteString("You are expected to work with these files:\n")
+		for _, f := range ctx.Task.Files {
+			fmt.Fprintf(&sb, "- %s\n", f)
+		}
+		sb.WriteString("\n")
+	}
+
+	// Previous group context (for tasks not in group 0)
+	if ctx.PreviousGroup != nil && ctx.GroupIndex > 0 {
+		b.writePreviousGroupContext(&sb, ctx.PreviousGroup)
+	}
+
+	// Guidelines
+	sb.WriteString("## Guidelines\n\n")
+	sb.WriteString("- Focus only on this specific task\n")
+	sb.WriteString("- Do not modify files outside of your assigned scope unless necessary\n")
+	sb.WriteString("- Commit your changes before writing the completion file\n\n")
+
+	// Completion protocol
+	b.writeCompletionProtocol(&sb, ctx.Task.ID)
+
+	return sb.String(), nil
+}
+
+// validate checks that the context has all required fields for task prompts.
+func (b *TaskBuilder) validate(ctx *Context) error {
+	if ctx == nil {
+		return ErrNilContext
+	}
+	if ctx.Phase != PhaseTask {
+		return fmt.Errorf("%w: expected %s, got %s", ErrInvalidPhase, PhaseTask, ctx.Phase)
+	}
+	if ctx.Plan == nil {
+		return ErrMissingPlan
+	}
+	if ctx.Task == nil {
+		return ErrMissingTask
+	}
+	if ctx.Task.ID == "" {
+		return fmt.Errorf("%w: task ID is required", ErrMissingTask)
+	}
+	if ctx.Task.Title == "" {
+		return fmt.Errorf("%w: task title is required", ErrMissingTask)
+	}
+	return nil
+}
+
+// writePreviousGroupContext writes the context from the previous group's consolidation.
+func (b *TaskBuilder) writePreviousGroupContext(sb *strings.Builder, prev *GroupContext) {
+	sb.WriteString("## Context from Previous Group\n\n")
+	fmt.Fprintf(sb, "This task builds on work consolidated from Group %d.\n\n", prev.GroupIndex+1)
+
+	if prev.Notes != "" {
+		fmt.Fprintf(sb, "**Consolidator Notes**: %s\n\n", prev.Notes)
+	}
+
+	if len(prev.IssuesForNextGroup) > 0 {
+		sb.WriteString("**Important**: The previous group's consolidator flagged these issues:\n")
+		for _, issue := range prev.IssuesForNextGroup {
+			fmt.Fprintf(sb, "- %s\n", issue)
+		}
+		sb.WriteString("\n")
+	}
+
+	if prev.VerificationPassed {
+		sb.WriteString("The consolidated code from the previous group has been verified (build/lint/tests passed).\n\n")
+	} else {
+		sb.WriteString("**Warning**: The previous group's code verification may have issues. Check carefully.\n\n")
+	}
+}
+
+// writeCompletionProtocol writes the completion protocol instructions.
+func (b *TaskBuilder) writeCompletionProtocol(sb *strings.Builder, taskID string) {
+	sb.WriteString("## Completion Protocol\n\n")
+	sb.WriteString("When your task is complete, you MUST write a completion file to signal the orchestrator:\n\n")
+	fmt.Fprintf(sb, "1. Use Write tool to create `%s` in your worktree root\n", TaskCompletionFileName)
+	sb.WriteString("2. Include this JSON structure:\n")
+	sb.WriteString("```json\n")
+	sb.WriteString("{\n")
+	fmt.Fprintf(sb, "  \"task_id\": \"%s\",\n", taskID)
+	sb.WriteString("  \"status\": \"complete\",\n")
+	sb.WriteString("  \"summary\": \"Brief description of what you accomplished\",\n")
+	sb.WriteString("  \"files_modified\": [\"list\", \"of\", \"files\", \"you\", \"changed\"],\n")
+	sb.WriteString("  \"notes\": \"Any implementation notes for the consolidation phase\",\n")
+	sb.WriteString("  \"issues\": [\"Any concerns or blocking issues found\"],\n")
+	sb.WriteString("  \"suggestions\": [\"Suggestions for integration with other tasks\"],\n")
+	sb.WriteString("  \"dependencies\": [\"Any new runtime dependencies added\"]\n")
+	sb.WriteString("}\n")
+	sb.WriteString("```\n\n")
+	sb.WriteString("3. Use status \"blocked\" if you cannot complete (explain in issues), or \"failed\" if something broke\n")
+	sb.WriteString("4. This file signals that your work is done and provides context for consolidation\n")
+}

--- a/internal/orchestrator/prompt/task_test.go
+++ b/internal/orchestrator/prompt/task_test.go
@@ -1,0 +1,311 @@
+package prompt
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTaskBuilder_Build(t *testing.T) {
+	tests := []struct {
+		name        string
+		ctx         *Context
+		wantErr     bool
+		errContains string
+		contains    []string
+		notContains []string
+	}{
+		{
+			name: "valid context with minimal task",
+			ctx: &Context{
+				Phase:     PhaseTask,
+				SessionID: "test-session",
+				Objective: "Build feature",
+				Plan: &PlanInfo{
+					Summary: "Feature implementation plan",
+				},
+				Task: &TaskInfo{
+					ID:          "task-1",
+					Title:       "Setup database",
+					Description: "Create the database schema and models",
+				},
+			},
+			wantErr: false,
+			contains: []string{
+				"# Task: Setup database",
+				"## Part of Ultra-Plan: Feature implementation plan",
+				"## Your Task",
+				"Create the database schema and models",
+				"## Guidelines",
+				"Focus only on this specific task",
+				"## Completion Protocol",
+				TaskCompletionFileName,
+				`"task_id": "task-1"`,
+			},
+			notContains: []string{
+				"## Expected Files",
+				"## Context from Previous Group",
+			},
+		},
+		{
+			name: "valid context with files",
+			ctx: &Context{
+				Phase:     PhaseTask,
+				SessionID: "test-session",
+				Objective: "Build feature",
+				Plan:      &PlanInfo{Summary: "Plan"},
+				Task: &TaskInfo{
+					ID:          "task-2",
+					Title:       "Implement handler",
+					Description: "Create HTTP handlers",
+					Files:       []string{"internal/handler.go", "internal/handler_test.go"},
+				},
+			},
+			wantErr: false,
+			contains: []string{
+				"## Expected Files",
+				"internal/handler.go",
+				"internal/handler_test.go",
+			},
+		},
+		{
+			name: "valid context with previous group context",
+			ctx: &Context{
+				Phase:      PhaseTask,
+				SessionID:  "test-session",
+				Objective:  "Build feature",
+				GroupIndex: 1,
+				Plan:       &PlanInfo{Summary: "Plan"},
+				Task: &TaskInfo{
+					ID:          "task-3",
+					Title:       "Add tests",
+					Description: "Add integration tests",
+				},
+				PreviousGroup: &GroupContext{
+					GroupIndex:         0,
+					Notes:              "Database schema ready",
+					IssuesForNextGroup: []string{"Watch for connection pooling", "Consider caching"},
+					VerificationPassed: true,
+				},
+			},
+			wantErr: false,
+			contains: []string{
+				"## Context from Previous Group",
+				"builds on work consolidated from Group 1",
+				"**Consolidator Notes**: Database schema ready",
+				"**Important**:",
+				"Watch for connection pooling",
+				"Consider caching",
+				"has been verified (build/lint/tests passed)",
+			},
+		},
+		{
+			name: "previous group context with failed verification",
+			ctx: &Context{
+				Phase:      PhaseTask,
+				SessionID:  "test-session",
+				Objective:  "Build feature",
+				GroupIndex: 1,
+				Plan:       &PlanInfo{Summary: "Plan"},
+				Task: &TaskInfo{
+					ID:          "task-4",
+					Title:       "Task after failed verification",
+					Description: "Description",
+				},
+				PreviousGroup: &GroupContext{
+					GroupIndex:         0,
+					VerificationPassed: false,
+				},
+			},
+			wantErr: false,
+			contains: []string{
+				"**Warning**: The previous group's code verification may have issues",
+			},
+			notContains: []string{
+				"has been verified",
+			},
+		},
+		{
+			name: "group 0 task ignores previous group context",
+			ctx: &Context{
+				Phase:      PhaseTask,
+				SessionID:  "test-session",
+				Objective:  "Build feature",
+				GroupIndex: 0,
+				Plan:       &PlanInfo{Summary: "Plan"},
+				Task: &TaskInfo{
+					ID:          "task-1",
+					Title:       "First task",
+					Description: "First group task",
+				},
+				PreviousGroup: &GroupContext{
+					Notes: "Should not appear",
+				},
+			},
+			wantErr: false,
+			notContains: []string{
+				"## Context from Previous Group",
+				"Should not appear",
+			},
+		},
+		{
+			name:        "nil context",
+			ctx:         nil,
+			wantErr:     true,
+			errContains: "nil",
+		},
+		{
+			name: "missing plan",
+			ctx: &Context{
+				Phase:     PhaseTask,
+				SessionID: "test-session",
+				Objective: "Test",
+				Task:      &TaskInfo{ID: "t1", Title: "Task"},
+			},
+			wantErr:     true,
+			errContains: "plan",
+		},
+		{
+			name: "missing task",
+			ctx: &Context{
+				Phase:     PhaseTask,
+				SessionID: "test-session",
+				Objective: "Test",
+				Plan:      &PlanInfo{Summary: "Plan"},
+			},
+			wantErr:     true,
+			errContains: "task",
+		},
+		{
+			name: "missing task ID",
+			ctx: &Context{
+				Phase:     PhaseTask,
+				SessionID: "test-session",
+				Objective: "Test",
+				Plan:      &PlanInfo{Summary: "Plan"},
+				Task:      &TaskInfo{Title: "Task"},
+			},
+			wantErr:     true,
+			errContains: "task id",
+		},
+		{
+			name: "missing task title",
+			ctx: &Context{
+				Phase:     PhaseTask,
+				SessionID: "test-session",
+				Objective: "Test",
+				Plan:      &PlanInfo{Summary: "Plan"},
+				Task:      &TaskInfo{ID: "t1"},
+			},
+			wantErr:     true,
+			errContains: "task title",
+		},
+		{
+			name: "wrong phase",
+			ctx: &Context{
+				Phase:     PhasePlanning,
+				SessionID: "test-session",
+				Objective: "Test",
+				Plan:      &PlanInfo{Summary: "Plan"},
+				Task:      &TaskInfo{ID: "t1", Title: "Task"},
+			},
+			wantErr:     true,
+			errContains: "invalid",
+		},
+	}
+
+	builder := NewTaskBuilder()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := builder.Build(tt.ctx)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Build() expected error, got nil")
+					return
+				}
+				if tt.errContains != "" && !strings.Contains(strings.ToLower(err.Error()), tt.errContains) {
+					t.Errorf("Build() error = %v, want error containing %q", err, tt.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Build() unexpected error: %v", err)
+				return
+			}
+
+			for _, want := range tt.contains {
+				if !strings.Contains(result, want) {
+					t.Errorf("Build() result missing %q\nGot:\n%s", want, result)
+				}
+			}
+
+			for _, notWant := range tt.notContains {
+				if strings.Contains(result, notWant) {
+					t.Errorf("Build() result should not contain %q\nGot:\n%s", notWant, result)
+				}
+			}
+		})
+	}
+}
+
+func TestTaskBuilder_CompletionProtocol(t *testing.T) {
+	builder := NewTaskBuilder()
+
+	ctx := &Context{
+		Phase:     PhaseTask,
+		SessionID: "test-session",
+		Objective: "Test",
+		Plan:      &PlanInfo{Summary: "Plan"},
+		Task: &TaskInfo{
+			ID:          "unique-task-id",
+			Title:       "Test Task",
+			Description: "Test description",
+		},
+	}
+
+	result, err := builder.Build(ctx)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+
+	// Verify completion protocol structure
+	expectedParts := []string{
+		"## Completion Protocol",
+		"MUST write a completion file",
+		TaskCompletionFileName,
+		`"task_id": "unique-task-id"`,
+		`"status": "complete"`,
+		`"summary":`,
+		`"files_modified":`,
+		`"notes":`,
+		`"issues":`,
+		`"suggestions":`,
+		`"dependencies":`,
+		"status \"blocked\"",
+		"\"failed\"",
+	}
+
+	for _, part := range expectedParts {
+		if !strings.Contains(result, part) {
+			t.Errorf("Completion protocol missing %q", part)
+		}
+	}
+}
+
+func TestNewTaskBuilder(t *testing.T) {
+	builder := NewTaskBuilder()
+	if builder == nil {
+		t.Error("NewTaskBuilder() returned nil")
+	}
+}
+
+func TestTaskCompletionFileName(t *testing.T) {
+	if TaskCompletionFileName == "" {
+		t.Error("TaskCompletionFileName should not be empty")
+	}
+	if !strings.HasSuffix(TaskCompletionFileName, ".json") {
+		t.Errorf("TaskCompletionFileName should end with .json, got %q", TaskCompletionFileName)
+	}
+}

--- a/internal/tui/panel/conflict.go
+++ b/internal/tui/panel/conflict.go
@@ -1,0 +1,64 @@
+// Package panel provides interfaces and types for TUI panel rendering.
+package panel
+
+import (
+	"github.com/Iron-Ham/claudio/internal/tui/view"
+)
+
+// ConflictPanel renders file conflict information between instances.
+// It adapts the view.ConflictsView to the PanelRenderer interface.
+type ConflictPanel struct {
+	height int
+}
+
+// NewConflictPanel creates a new ConflictPanel.
+func NewConflictPanel() *ConflictPanel {
+	return &ConflictPanel{}
+}
+
+// Render produces the conflict panel output.
+func (p *ConflictPanel) Render(state *RenderState) string {
+	if err := state.ValidateBasic(); err != nil {
+		return "[conflict panel: render error]"
+	}
+
+	// No conflicts, return empty
+	if len(state.Conflicts) == 0 {
+		p.height = 0
+		return ""
+	}
+
+	// Build instance info list from state instances
+	instanceInfos := make([]view.InstanceInfo, len(state.Instances))
+	for i, inst := range state.Instances {
+		instanceInfos[i] = view.InstanceInfo{
+			ID:   inst.ID,
+			Task: inst.Task,
+		}
+	}
+
+	// Use the existing ConflictsView for rendering
+	conflictsView := view.NewConflictsView(state.Conflicts, instanceInfos)
+	result := conflictsView.Render(state.Width)
+
+	// Estimate height from result
+	p.height = countNewlines(result) + 1
+
+	return result
+}
+
+// Height returns the rendered height of the panel.
+func (p *ConflictPanel) Height() int {
+	return p.height
+}
+
+// countNewlines counts the number of newlines in a string.
+func countNewlines(s string) int {
+	count := 0
+	for _, c := range s {
+		if c == '\n' {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/tui/panel/conflict_test.go
+++ b/internal/tui/panel/conflict_test.go
@@ -1,0 +1,196 @@
+package panel
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/conflict"
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+)
+
+func TestConflictPanel_Render(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    *RenderState
+		contains []string
+		isEmpty  bool
+	}{
+		{
+			name: "renders conflicts with instance info",
+			state: &RenderState{
+				Width:  80,
+				Height: 50,
+				Instances: []*orchestrator.Instance{
+					{ID: "inst-1", Task: "Feature A"},
+					{ID: "inst-2", Task: "Feature B"},
+				},
+				Conflicts: []conflict.FileConflict{
+					{
+						RelativePath: "src/main.go",
+						Instances:    []string{"inst-1", "inst-2"},
+						LastModified: time.Now(),
+					},
+				},
+			},
+			contains: []string{
+				"src/main.go",
+			},
+			isEmpty: false,
+		},
+		{
+			name: "returns empty when no conflicts",
+			state: &RenderState{
+				Width:     80,
+				Height:    50,
+				Conflicts: nil,
+			},
+			isEmpty: true,
+		},
+		{
+			name: "returns empty when empty conflicts slice",
+			state: &RenderState{
+				Width:     80,
+				Height:    50,
+				Conflicts: []conflict.FileConflict{},
+			},
+			isEmpty: true,
+		},
+		{
+			name: "invalid state returns error indicator",
+			state: &RenderState{
+				Width:  0,
+				Height: 0,
+			},
+			contains: []string{"render error"},
+			isEmpty:  false,
+		},
+	}
+
+	panel := NewConflictPanel()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := panel.Render(tt.state)
+
+			if tt.isEmpty && result != "" {
+				t.Errorf("expected empty result, got: %s", result)
+			}
+			if !tt.isEmpty && result == "" {
+				t.Error("expected non-empty result, got empty")
+			}
+
+			for _, want := range tt.contains {
+				if !strings.Contains(result, want) {
+					t.Errorf("result missing %q\nGot:\n%s", want, result)
+				}
+			}
+		})
+	}
+}
+
+func TestConflictPanel_Height(t *testing.T) {
+	panel := NewConflictPanel()
+
+	// Test with conflicts
+	state := &RenderState{
+		Width:  80,
+		Height: 50,
+		Instances: []*orchestrator.Instance{
+			{ID: "inst-1", Task: "Task 1"},
+		},
+		Conflicts: []conflict.FileConflict{
+			{
+				RelativePath: "file.go",
+				Instances:    []string{"inst-1"},
+			},
+		},
+	}
+
+	panel.Render(state)
+
+	if panel.Height() <= 0 {
+		t.Errorf("Height() = %d, want positive value", panel.Height())
+	}
+}
+
+func TestConflictPanel_HeightWithNoConflicts(t *testing.T) {
+	panel := NewConflictPanel()
+
+	state := &RenderState{
+		Width:     80,
+		Height:    50,
+		Conflicts: nil,
+	}
+
+	panel.Render(state)
+
+	if panel.Height() != 0 {
+		t.Errorf("Height() = %d, want 0 with no conflicts", panel.Height())
+	}
+}
+
+func TestNewConflictPanel(t *testing.T) {
+	panel := NewConflictPanel()
+	if panel == nil {
+		t.Error("NewConflictPanel() returned nil")
+	}
+}
+
+func TestCountNewlines(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"", 0},
+		{"no newlines", 0},
+		{"one\n", 1},
+		{"two\nlines\n", 2},
+		{"\n\n\n", 3},
+		{"line1\nline2\nline3", 2},
+	}
+
+	for _, tt := range tests {
+		got := countNewlines(tt.input)
+		if got != tt.want {
+			t.Errorf("countNewlines(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestConflictPanel_MultipleConflicts(t *testing.T) {
+	panel := NewConflictPanel()
+
+	state := &RenderState{
+		Width:  80,
+		Height: 50,
+		Instances: []*orchestrator.Instance{
+			{ID: "inst-1", Task: "Feature A"},
+			{ID: "inst-2", Task: "Feature B"},
+			{ID: "inst-3", Task: "Feature C"},
+		},
+		Conflicts: []conflict.FileConflict{
+			{
+				RelativePath: "src/main.go",
+				Instances:    []string{"inst-1", "inst-2"},
+			},
+			{
+				RelativePath: "src/utils.go",
+				Instances:    []string{"inst-2", "inst-3"},
+			},
+			{
+				RelativePath: "src/config.go",
+				Instances:    []string{"inst-1", "inst-3"},
+			},
+		},
+	}
+
+	result := panel.Render(state)
+
+	expectedFiles := []string{"src/main.go", "src/utils.go", "src/config.go"}
+	for _, file := range expectedFiles {
+		if !strings.Contains(result, file) {
+			t.Errorf("result missing conflict file %q", file)
+		}
+	}
+}

--- a/internal/tui/panel/diff.go
+++ b/internal/tui/panel/diff.go
@@ -1,0 +1,191 @@
+// Package panel provides interfaces and types for TUI panel rendering.
+package panel
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// DiffPanel renders a git diff with syntax highlighting and scrolling support.
+type DiffPanel struct {
+	height int
+}
+
+// NewDiffPanel creates a new DiffPanel.
+func NewDiffPanel() *DiffPanel {
+	return &DiffPanel{}
+}
+
+// Render produces the diff panel output.
+func (p *DiffPanel) Render(state *RenderState) string {
+	if err := state.ValidateBasic(); err != nil {
+		return "[diff panel: render error]"
+	}
+
+	var b strings.Builder
+
+	// Header with branch name if available
+	title := "Diff Preview"
+	if state.ActiveInstance != nil && state.ActiveInstance.Branch != "" {
+		title = fmt.Sprintf("Diff Preview: %s", state.ActiveInstance.Branch)
+	}
+	if state.Theme != nil {
+		title = state.Theme.Primary().Render(title)
+	}
+	b.WriteString(title)
+	b.WriteString("\n")
+
+	// Handle empty diff
+	if state.DiffContent == "" {
+		noChanges := "No changes to display"
+		if state.Theme != nil {
+			noChanges = state.Theme.Muted().Render(noChanges)
+		}
+		b.WriteString(noChanges)
+		p.height = 3
+		return b.String()
+	}
+
+	// Calculate available height for diff content
+	maxLines := state.Height - 10
+	if maxLines < 5 {
+		maxLines = 5
+	}
+
+	// Split diff into lines
+	lines := strings.Split(state.DiffContent, "\n")
+	totalLines := len(lines)
+
+	// Clamp scroll position
+	maxScroll := totalLines - maxLines
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	scroll := state.ScrollOffset
+	if scroll > maxScroll {
+		scroll = maxScroll
+	}
+	if scroll < 0 {
+		scroll = 0
+	}
+
+	// Get visible lines
+	startLine := scroll
+	endLine := startLine + maxLines
+	if endLine > totalLines {
+		endLine = totalLines
+	}
+
+	visibleLines := lines[startLine:endLine]
+
+	// Apply syntax highlighting to each visible line
+	var highlighted []string
+	for _, line := range visibleLines {
+		highlighted = append(highlighted, p.highlightDiffLine(line, state.Theme))
+	}
+
+	// Show scroll indicator
+	scrollInfo := fmt.Sprintf("Lines %d-%d of %d", startLine+1, endLine, totalLines)
+	helpHint := "[j/k scroll, g/G top/bottom, d/Esc close]"
+	if totalLines <= maxLines {
+		helpHint = "[d/Esc close]"
+	}
+	if state.Theme != nil {
+		scrollInfo = state.Theme.Muted().Render(scrollInfo)
+		helpHint = state.Theme.Muted().Render(helpHint)
+	}
+	b.WriteString(scrollInfo + "  " + helpHint)
+	b.WriteString("\n\n")
+
+	// Add the diff content
+	b.WriteString(strings.Join(highlighted, "\n"))
+
+	p.height = len(visibleLines) + 4 // +4 for header and scroll info
+
+	return b.String()
+}
+
+// highlightDiffLine applies syntax highlighting to a single diff line.
+func (p *DiffPanel) highlightDiffLine(line string, theme Theme) string {
+	if len(line) == 0 {
+		return line
+	}
+
+	// Determine style based on line prefix
+	var style lipgloss.Style
+	var useDefault bool
+
+	switch {
+	case strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---"):
+		if theme != nil {
+			style = theme.DiffHeader()
+		} else {
+			useDefault = true
+		}
+	case strings.HasPrefix(line, "@@"):
+		if theme != nil {
+			style = theme.DiffHunk()
+		} else {
+			useDefault = true
+		}
+	case strings.HasPrefix(line, "+"):
+		if theme != nil {
+			style = theme.DiffAdd()
+		} else {
+			useDefault = true
+		}
+	case strings.HasPrefix(line, "-"):
+		if theme != nil {
+			style = theme.DiffRemove()
+		} else {
+			useDefault = true
+		}
+	case strings.HasPrefix(line, "diff "):
+		if theme != nil {
+			style = theme.DiffHeader()
+		} else {
+			useDefault = true
+		}
+	case strings.HasPrefix(line, "index "):
+		if theme != nil {
+			style = theme.DiffHeader()
+		} else {
+			useDefault = true
+		}
+	default:
+		if theme != nil {
+			style = theme.DiffContext()
+		} else {
+			useDefault = true
+		}
+	}
+
+	if useDefault {
+		return p.defaultHighlight(line)
+	}
+	return style.Render(line)
+}
+
+// defaultHighlight provides basic highlighting without a theme.
+func (p *DiffPanel) defaultHighlight(line string) string {
+	switch {
+	case strings.HasPrefix(line, "+++"), strings.HasPrefix(line, "---"),
+		strings.HasPrefix(line, "diff "), strings.HasPrefix(line, "index "):
+		return lipgloss.NewStyle().Bold(true).Render(line)
+	case strings.HasPrefix(line, "@@"):
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Render(line)
+	case strings.HasPrefix(line, "+"):
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Render(line)
+	case strings.HasPrefix(line, "-"):
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Render(line)
+	default:
+		return line
+	}
+}
+
+// Height returns the rendered height of the panel.
+func (p *DiffPanel) Height() int {
+	return p.height
+}

--- a/internal/tui/panel/diff_test.go
+++ b/internal/tui/panel/diff_test.go
@@ -1,0 +1,301 @@
+package panel
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+)
+
+func TestDiffPanel_Render(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    *RenderState
+		contains []string
+		notEmpty bool
+	}{
+		{
+			name: "renders diff with content",
+			state: &RenderState{
+				Width:  80,
+				Height: 50,
+				ActiveInstance: &orchestrator.Instance{
+					Branch: "feature/test-branch",
+				},
+				DiffContent: `diff --git a/file.go b/file.go
+index abc123..def456 100644
+--- a/file.go
++++ b/file.go
+@@ -1,5 +1,6 @@
+ package main
+
++import "fmt"
+
+ func main() {
+-    println("hello")
++    fmt.Println("hello")
+ }`,
+			},
+			contains: []string{
+				"Diff Preview",
+				"feature/test-branch",
+				"diff --git",
+				"+import",
+				"-    println",
+				"+    fmt.Println",
+				"@@",
+			},
+			notEmpty: true,
+		},
+		{
+			name: "shows no changes message when empty",
+			state: &RenderState{
+				Width:       80,
+				Height:      50,
+				DiffContent: "",
+			},
+			contains: []string{
+				"Diff Preview",
+				"No changes to display",
+			},
+			notEmpty: true,
+		},
+		{
+			name: "shows branch name when available",
+			state: &RenderState{
+				Width:  80,
+				Height: 50,
+				ActiveInstance: &orchestrator.Instance{
+					Branch: "my-feature",
+				},
+				DiffContent: "+line added",
+			},
+			contains: []string{
+				"Diff Preview: my-feature",
+			},
+			notEmpty: true,
+		},
+		{
+			name: "shows generic title without active instance",
+			state: &RenderState{
+				Width:       80,
+				Height:      50,
+				DiffContent: "+line added",
+			},
+			contains: []string{
+				"Diff Preview",
+			},
+			notEmpty: true,
+		},
+		{
+			name: "handles scrolling",
+			state: &RenderState{
+				Width:        80,
+				Height:       20,
+				ScrollOffset: 2,
+				DiffContent:  "+line1\n+line2\n+line3\n+line4\n+line5\n+line6\n+line7\n+line8\n+line9\n+line10",
+			},
+			contains: []string{
+				"Lines", // Scroll indicator
+			},
+			notEmpty: true,
+		},
+		{
+			name: "invalid state returns error indicator",
+			state: &RenderState{
+				Width:  0,
+				Height: 0,
+			},
+			contains: []string{"render error"},
+			notEmpty: true,
+		},
+	}
+
+	panel := NewDiffPanel()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := panel.Render(tt.state)
+
+			if tt.notEmpty && result == "" {
+				t.Error("expected non-empty result, got empty")
+			}
+			if !tt.notEmpty && result != "" {
+				t.Errorf("expected empty result, got: %s", result)
+			}
+
+			for _, want := range tt.contains {
+				if !strings.Contains(result, want) {
+					t.Errorf("result missing %q\nGot:\n%s", want, result)
+				}
+			}
+		})
+	}
+}
+
+func TestDiffPanel_Height(t *testing.T) {
+	panel := NewDiffPanel()
+
+	state := &RenderState{
+		Width:  80,
+		Height: 50,
+		DiffContent: `+line1
++line2
++line3`,
+	}
+
+	panel.Render(state)
+
+	if panel.Height() <= 0 {
+		t.Errorf("Height() = %d, want positive value", panel.Height())
+	}
+}
+
+func TestDiffPanel_SyntaxHighlighting(t *testing.T) {
+	panel := NewDiffPanel()
+
+	// Test that different line types are rendered differently
+	// We can't easily check ANSI codes, but we can verify the lines are present
+	state := &RenderState{
+		Width:  80,
+		Height: 50,
+		DiffContent: `diff --git a/file.go b/file.go
+--- a/file.go
++++ b/file.go
+@@ -1,3 +1,3 @@
+ context line
+-removed line
++added line`,
+	}
+
+	result := panel.Render(state)
+
+	expectedLines := []string{
+		"diff --git",
+		"---",
+		"+++",
+		"@@",
+		"context line",
+		"-removed line",
+		"+added line",
+	}
+
+	for _, line := range expectedLines {
+		if !strings.Contains(result, line) {
+			t.Errorf("result missing line %q", line)
+		}
+	}
+}
+
+func TestDiffPanel_ScrollClamping(t *testing.T) {
+	panel := NewDiffPanel()
+
+	// Test negative scroll is clamped
+	state := &RenderState{
+		Width:        80,
+		Height:       50,
+		ScrollOffset: -10,
+		DiffContent:  "+line1\n+line2\n+line3",
+	}
+
+	result := panel.Render(state)
+	if result == "" {
+		t.Error("expected non-empty result with negative scroll")
+	}
+}
+
+func TestDiffPanel_ExcessiveScroll(t *testing.T) {
+	panel := NewDiffPanel()
+
+	// Test excessive scroll is clamped
+	state := &RenderState{
+		Width:        80,
+		Height:       50,
+		ScrollOffset: 10000,
+		DiffContent:  "+line1\n+line2\n+line3",
+	}
+
+	result := panel.Render(state)
+	if result == "" {
+		t.Error("expected non-empty result with excessive scroll")
+	}
+}
+
+func TestDiffPanel_WithTheme(t *testing.T) {
+	panel := NewDiffPanel()
+
+	state := &RenderState{
+		Width:  80,
+		Height: 50,
+		Theme:  &mockTheme{},
+		DiffContent: `+added line
+-removed line`,
+	}
+
+	result := panel.Render(state)
+	if result == "" {
+		t.Error("expected non-empty result with theme")
+	}
+
+	if !strings.Contains(result, "added line") {
+		t.Error("result missing added line")
+	}
+	if !strings.Contains(result, "removed line") {
+		t.Error("result missing removed line")
+	}
+}
+
+func TestDiffPanel_EmptyLines(t *testing.T) {
+	panel := NewDiffPanel()
+
+	state := &RenderState{
+		Width:  80,
+		Height: 50,
+		DiffContent: `+line1
+
++line2`,
+	}
+
+	result := panel.Render(state)
+	if result == "" {
+		t.Error("expected non-empty result with empty lines in diff")
+	}
+}
+
+func TestNewDiffPanel(t *testing.T) {
+	panel := NewDiffPanel()
+	if panel == nil {
+		t.Error("NewDiffPanel() returned nil")
+	}
+}
+
+func TestDiffPanel_HighlightDiffLine(t *testing.T) {
+	panel := NewDiffPanel()
+
+	// Test without theme (uses default highlighting)
+	lines := []struct {
+		input   string
+		hasAnsi bool // If default styling is applied, will have ANSI codes
+	}{
+		{"+added", true},
+		{"-removed", true},
+		{"@@hunk@@", true},
+		{"+++header", true},
+		{"---header", true},
+		{"diff file", true},
+		{"index 123", true},
+		{"context", false}, // Context lines have no special default styling
+		{"", false},        // Empty lines
+	}
+
+	for _, tc := range lines {
+		result := panel.highlightDiffLine(tc.input, nil)
+		// Just verify we get the original content (possibly styled)
+		if !strings.Contains(result, strings.TrimPrefix(strings.TrimPrefix(tc.input, "+"), "-")) {
+			// For empty lines, the original content is empty
+			if tc.input != "" {
+				t.Errorf("highlightDiffLine(%q) didn't contain original content", tc.input)
+			}
+		}
+	}
+}

--- a/internal/tui/panel/help.go
+++ b/internal/tui/panel/help.go
@@ -1,0 +1,206 @@
+// Package panel provides interfaces and types for TUI panel rendering.
+package panel
+
+import (
+	"fmt"
+	"strings"
+)
+
+// HelpPanel renders the help overlay with keybindings and scrolling support.
+type HelpPanel struct {
+	height int
+}
+
+// NewHelpPanel creates a new HelpPanel.
+func NewHelpPanel() *HelpPanel {
+	return &HelpPanel{}
+}
+
+// Render produces the help panel output.
+func (p *HelpPanel) Render(state *RenderState) string {
+	if err := state.ValidateBasic(); err != nil {
+		return "[help panel: render error]"
+	}
+
+	// Use provided sections or fall back to defaults
+	sections := state.HelpSections
+	if len(sections) == 0 {
+		sections = DefaultHelpSections()
+	}
+
+	var lines []string
+
+	// Title
+	title := "Claudio Help"
+	subtitle := "Press : to enter command mode. Use j/k to scroll, ? or :h to close."
+	if state.Theme != nil {
+		title = state.Theme.Primary().Render(title)
+		subtitle = state.Theme.Muted().Render(subtitle)
+	}
+	lines = append(lines, title)
+	lines = append(lines, subtitle)
+	lines = append(lines, "")
+
+	// Build sections
+	for _, section := range sections {
+		sectionTitle := "▸ " + section.Title
+		if state.Theme != nil {
+			sectionTitle = state.Theme.Primary().Bold(true).Render(sectionTitle)
+		}
+		lines = append(lines, sectionTitle)
+
+		for _, item := range section.Items {
+			keyStr := item.Key
+			descStr := item.Description
+			if state.Theme != nil {
+				keyStr = state.Theme.Secondary().Render(keyStr)
+				descStr = state.Theme.Muted().Render(descStr)
+			}
+			lines = append(lines, fmt.Sprintf("    %s  %s", keyStr, descStr))
+		}
+		lines = append(lines, "")
+		lines = append(lines, "")
+	}
+
+	// Calculate visible lines based on available height
+	maxLines := state.Height - 6 // Leave room for borders and scroll indicator
+	if maxLines < 10 {
+		maxLines = 10
+	}
+
+	// Clamp scroll to valid range
+	maxScroll := len(lines) - maxLines
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	scroll := state.ScrollOffset
+	if scroll > maxScroll {
+		scroll = maxScroll
+	}
+	if scroll < 0 {
+		scroll = 0
+	}
+
+	// Slice visible lines
+	endLine := scroll + maxLines
+	if endLine > len(lines) {
+		endLine = len(lines)
+	}
+	visibleLines := lines[scroll:endLine]
+
+	// Build content
+	var content string
+	if maxScroll > 0 {
+		// Add scroll indicator
+		scrollInfo := fmt.Sprintf(" [%d/%d] ", scroll+1, maxScroll+1)
+		if state.Theme != nil {
+			scrollInfo = state.Theme.Muted().Render(scrollInfo)
+		}
+		if scroll > 0 {
+			upArrow := "▲ "
+			if state.Theme != nil {
+				upArrow = state.Theme.Warning().Render(upArrow)
+			}
+			scrollInfo = upArrow + scrollInfo
+		}
+		if scroll < maxScroll {
+			downArrow := " ▼"
+			if state.Theme != nil {
+				downArrow = state.Theme.Warning().Render(downArrow)
+			}
+			scrollInfo = scrollInfo + downArrow
+		}
+		content = strings.Join(visibleLines, "\n") + "\n" + scrollInfo
+	} else {
+		content = strings.Join(visibleLines, "\n")
+	}
+
+	p.height = len(visibleLines) + 2 // +2 for scroll indicator line
+
+	return content
+}
+
+// Height returns the rendered height of the panel.
+func (p *HelpPanel) Height() int {
+	return p.height
+}
+
+// DefaultHelpSections returns the default Claudio help sections.
+func DefaultHelpSections() []HelpSection {
+	return []HelpSection{
+		{
+			Title: "Navigation",
+			Items: []HelpItem{
+				{Key: "Tab/l  Shift+Tab/h", Description: "Next / Previous instance"},
+				{Key: "j/↓  k/↑", Description: "Scroll down / up one line"},
+				{Key: "Ctrl+D/U  Ctrl+F/B", Description: "Scroll half / full page"},
+				{Key: "g  G", Description: "Jump to top / bottom"},
+			},
+		},
+		{
+			Title: "Instance Control",
+			Items: []HelpItem{
+				{Key: ":s  :start", Description: "Start a stopped/new instance"},
+				{Key: ":x  :stop", Description: "Stop instance + auto-PR workflow"},
+				{Key: ":e  :exit", Description: "Stop instance (no auto-PR)"},
+				{Key: ":p  :pause", Description: "Pause/resume instance"},
+				{Key: ":R  :reconnect", Description: "Reattach to stopped tmux session"},
+				{Key: ":restart", Description: "Restart stuck/timeout instance"},
+			},
+		},
+		{
+			Title: "Instance Management",
+			Items: []HelpItem{
+				{Key: ":a  :add", Description: "Create and add new instance"},
+				{Key: ":chain  :dep  :depends", Description: "Add dependent task"},
+				{Key: ":D  :remove", Description: "Remove instance (keeps branch)"},
+				{Key: ":kill", Description: "Force kill and remove instance"},
+				{Key: ":C  :clear", Description: "Remove all completed instances"},
+			},
+		},
+		{
+			Title: "View Commands",
+			Items: []HelpItem{
+				{Key: ":d  :diff", Description: "Toggle diff preview panel"},
+				{Key: ":m  :stats", Description: "Toggle metrics panel"},
+				{Key: ":c  :conflicts", Description: "Toggle conflict view"},
+				{Key: ":f  :filter", Description: "Open filter panel"},
+				{Key: ":tmux", Description: "Show tmux attach command"},
+				{Key: ":r  :pr", Description: "Show PR creation command"},
+			},
+		},
+		{
+			Title: "Terminal Pane",
+			Items: []HelpItem{
+				{Key: "`  :term", Description: "Toggle terminal pane"},
+				{Key: ":t", Description: "Focus terminal for typing"},
+				{Key: "Ctrl+]", Description: "Exit terminal mode"},
+				{Key: "Ctrl+Shift+T", Description: "Switch terminal directory"},
+			},
+		},
+		{
+			Title: "Input Mode",
+			Items: []HelpItem{
+				{Key: "i  Enter", Description: "Enter input mode (talk to Claude)"},
+				{Key: "Ctrl+]", Description: "Exit input mode"},
+			},
+		},
+		{
+			Title: "Search",
+			Items: []HelpItem{
+				{Key: "/", Description: "Start search"},
+				{Key: "n  N", Description: "Next / previous match"},
+				{Key: "Ctrl+/", Description: "Clear search"},
+				{Key: "r:pattern", Description: "Use regex search"},
+			},
+		},
+		{
+			Title: "Session",
+			Items: []HelpItem{
+				{Key: ":h  :help", Description: "Toggle this help panel"},
+				{Key: ":q  :quit", Description: "Quit (instances continue in tmux)"},
+				{Key: "?", Description: "Quick toggle help"},
+			},
+		},
+	}
+}

--- a/internal/tui/panel/help_test.go
+++ b/internal/tui/panel/help_test.go
@@ -1,0 +1,279 @@
+package panel
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHelpPanel_Render(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    *RenderState
+		contains []string
+		notEmpty bool
+	}{
+		{
+			name: "renders with default sections",
+			state: &RenderState{
+				Width:  80,
+				Height: 100, // Large enough to show all sections
+			},
+			contains: []string{
+				"Claudio Help",
+				"command mode",
+				"Navigation",
+				"Instance Control",
+				"Instance Management",
+				"View Commands",
+				"Terminal Pane",
+				"Input Mode",
+				"Search",
+				"Session",
+			},
+			notEmpty: true,
+		},
+		{
+			name: "renders with custom sections",
+			state: &RenderState{
+				Width:  80,
+				Height: 30,
+				HelpSections: []HelpSection{
+					{
+						Title: "Custom Section",
+						Items: []HelpItem{
+							{Key: "Ctrl+A", Description: "Do something"},
+							{Key: "Ctrl+B", Description: "Do another thing"},
+						},
+					},
+				},
+			},
+			contains: []string{
+				"Custom Section",
+				"Ctrl+A",
+				"Do something",
+				"Ctrl+B",
+				"Do another thing",
+			},
+			notEmpty: true,
+		},
+		{
+			name: "shows scroll indicator when content exceeds height",
+			state: &RenderState{
+				Width:        80,
+				Height:       15, // Small height to trigger scrolling
+				ScrollOffset: 0,
+			},
+			contains: []string{
+				"▼", // Down arrow when scrollable
+			},
+			notEmpty: true,
+		},
+		{
+			name: "shows up arrow when scrolled",
+			state: &RenderState{
+				Width:        80,
+				Height:       15,
+				ScrollOffset: 5,
+			},
+			contains: []string{
+				"▲", // Up arrow when scrolled down
+			},
+			notEmpty: true,
+		},
+		{
+			name: "invalid state returns error indicator",
+			state: &RenderState{
+				Width:  0,
+				Height: 0,
+			},
+			contains: []string{"render error"},
+			notEmpty: true,
+		},
+	}
+
+	panel := NewHelpPanel()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := panel.Render(tt.state)
+
+			if tt.notEmpty && result == "" {
+				t.Error("expected non-empty result, got empty")
+			}
+			if !tt.notEmpty && result != "" {
+				t.Errorf("expected empty result, got: %s", result)
+			}
+
+			for _, want := range tt.contains {
+				if !strings.Contains(result, want) {
+					t.Errorf("result missing %q\nGot:\n%s", want, result)
+				}
+			}
+		})
+	}
+}
+
+func TestHelpPanel_Height(t *testing.T) {
+	panel := NewHelpPanel()
+
+	state := &RenderState{
+		Width:  80,
+		Height: 50,
+	}
+
+	panel.Render(state)
+
+	if panel.Height() <= 0 {
+		t.Errorf("Height() = %d, want positive value", panel.Height())
+	}
+}
+
+func TestHelpPanel_ScrollClamping(t *testing.T) {
+	panel := NewHelpPanel()
+
+	// Test negative scroll is clamped to 0
+	state := &RenderState{
+		Width:        80,
+		Height:       50,
+		ScrollOffset: -10,
+	}
+
+	result := panel.Render(state)
+	if result == "" {
+		t.Error("expected non-empty result with negative scroll")
+	}
+
+	// Should still show the title at the top
+	if !strings.Contains(result, "Claudio Help") {
+		t.Error("expected to see title with negative scroll clamped to 0")
+	}
+}
+
+func TestHelpPanel_ExcessiveScroll(t *testing.T) {
+	panel := NewHelpPanel()
+
+	// Test excessive scroll is clamped
+	state := &RenderState{
+		Width:        80,
+		Height:       50,
+		ScrollOffset: 10000, // Way more than content lines
+	}
+
+	result := panel.Render(state)
+	if result == "" {
+		t.Error("expected non-empty result with excessive scroll")
+	}
+}
+
+func TestNewHelpPanel(t *testing.T) {
+	panel := NewHelpPanel()
+	if panel == nil {
+		t.Error("NewHelpPanel() returned nil")
+	}
+}
+
+func TestDefaultHelpSections(t *testing.T) {
+	sections := DefaultHelpSections()
+
+	if len(sections) == 0 {
+		t.Error("DefaultHelpSections() returned empty slice")
+	}
+
+	// Check that expected sections exist
+	expectedSections := []string{
+		"Navigation",
+		"Instance Control",
+		"Instance Management",
+		"View Commands",
+		"Terminal Pane",
+		"Input Mode",
+		"Search",
+		"Session",
+	}
+
+	for _, expected := range expectedSections {
+		found := false
+		for _, section := range sections {
+			if section.Title == expected {
+				found = true
+				if len(section.Items) == 0 {
+					t.Errorf("section %q has no items", expected)
+				}
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected section %q not found", expected)
+		}
+	}
+}
+
+func TestHelpSection_Items(t *testing.T) {
+	sections := DefaultHelpSections()
+
+	for _, section := range sections {
+		for _, item := range section.Items {
+			if item.Key == "" {
+				t.Errorf("section %q has item with empty key", section.Title)
+			}
+			if item.Description == "" {
+				t.Errorf("section %q has item with empty description for key %q", section.Title, item.Key)
+			}
+		}
+	}
+}
+
+func TestHelpPanel_SmallHeight(t *testing.T) {
+	panel := NewHelpPanel()
+
+	// Test with very small height
+	state := &RenderState{
+		Width:  80,
+		Height: 5, // Very small
+	}
+
+	result := panel.Render(state)
+	if result == "" {
+		t.Error("expected non-empty result with small height")
+	}
+}
+
+func TestHelpPanel_MultipleSectionsWithScrolling(t *testing.T) {
+	panel := NewHelpPanel()
+
+	// Create custom sections that will definitely exceed the height
+	sections := make([]HelpSection, 10)
+	for i := range sections {
+		items := make([]HelpItem, 5)
+		for j := range items {
+			items[j] = HelpItem{
+				Key:         "key" + string(rune('A'+j)),
+				Description: "desc" + string(rune('0'+j)),
+			}
+		}
+		sections[i] = HelpSection{
+			Title: "Section " + string(rune('A'+i)),
+			Items: items,
+		}
+	}
+
+	state := &RenderState{
+		Width:        80,
+		Height:       20,
+		HelpSections: sections,
+	}
+
+	// Render without scroll
+	result := panel.Render(state)
+	if !strings.Contains(result, "Section A") {
+		t.Error("expected first section visible without scroll")
+	}
+
+	// Render with scroll
+	state.ScrollOffset = 30
+	result = panel.Render(state)
+	// Should show different content due to scroll
+	if strings.HasPrefix(result, "Section A") {
+		t.Error("expected different content after scrolling")
+	}
+}

--- a/internal/tui/panel/instance.go
+++ b/internal/tui/panel/instance.go
@@ -1,0 +1,98 @@
+// Package panel provides interfaces and types for TUI panel rendering.
+package panel
+
+import (
+	"github.com/Iron-Ham/claudio/internal/conflict"
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/tui/view"
+)
+
+// InstancePanel renders the instance sidebar showing all instances and their status.
+// It adapts the view.DashboardView to the PanelRenderer interface.
+type InstancePanel struct {
+	height int
+	view   *view.DashboardView
+}
+
+// NewInstancePanel creates a new InstancePanel.
+func NewInstancePanel() *InstancePanel {
+	return &InstancePanel{
+		view: view.NewDashboardView(),
+	}
+}
+
+// Render produces the instance panel output.
+func (p *InstancePanel) Render(state *RenderState) string {
+	if err := state.ValidateBasic(); err != nil {
+		return "[instance panel: render error]"
+	}
+
+	// Create adapter state from RenderState
+	adapterState := &instancePanelState{
+		session:             state.Session,
+		activeTab:           state.ActiveIndex,
+		sidebarScrollOffset: state.ScrollOffset,
+		conflicts:           state.Conflicts,
+		terminalWidth:       state.Width,
+		terminalHeight:      state.Height,
+		isAddingTask:        state.IsAddingTask,
+	}
+
+	result := p.view.RenderSidebar(adapterState, state.Width, state.Height)
+
+	// Estimate height from result
+	p.height = countNewlines(result) + 1
+
+	return result
+}
+
+// Height returns the rendered height of the panel.
+func (p *InstancePanel) Height() int {
+	return p.height
+}
+
+// instancePanelState adapts RenderState to the view.DashboardState interface.
+type instancePanelState struct {
+	session             *orchestrator.Session
+	activeTab           int
+	sidebarScrollOffset int
+	conflicts           []conflict.FileConflict
+	terminalWidth       int
+	terminalHeight      int
+	isAddingTask        bool
+}
+
+// Session implements view.DashboardState.
+func (s *instancePanelState) Session() *orchestrator.Session {
+	return s.session
+}
+
+// ActiveTab implements view.DashboardState.
+func (s *instancePanelState) ActiveTab() int {
+	return s.activeTab
+}
+
+// SidebarScrollOffset implements view.DashboardState.
+func (s *instancePanelState) SidebarScrollOffset() int {
+	return s.sidebarScrollOffset
+}
+
+// Conflicts implements view.DashboardState.
+func (s *instancePanelState) Conflicts() []conflict.FileConflict {
+	return s.conflicts
+}
+
+// TerminalWidth implements view.DashboardState.
+func (s *instancePanelState) TerminalWidth() int {
+	return s.terminalWidth
+}
+
+// TerminalHeight implements view.DashboardState.
+func (s *instancePanelState) TerminalHeight() int {
+	return s.terminalHeight
+}
+
+// IsAddingTask implements view.DashboardState.
+func (s *instancePanelState) IsAddingTask() bool {
+	return s.isAddingTask
+}

--- a/internal/tui/panel/instance_test.go
+++ b/internal/tui/panel/instance_test.go
@@ -1,0 +1,218 @@
+package panel
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+)
+
+func TestInstancePanel_Render(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    *RenderState
+		contains []string
+		notEmpty bool
+	}{
+		{
+			name: "renders instances with session",
+			state: &RenderState{
+				Width:       80,
+				Height:      50,
+				ActiveIndex: 0,
+				Session: &orchestrator.Session{
+					ID: "test-session",
+					Instances: []*orchestrator.Instance{
+						{
+							ID:     "inst-1",
+							Task:   "Build feature",
+							Status: orchestrator.StatusWorking,
+						},
+						{
+							ID:     "inst-2",
+							Task:   "Fix bug",
+							Status: orchestrator.StatusCompleted,
+						},
+					},
+				},
+			},
+			contains: []string{
+				"Instances",
+				"Build feature",
+				"Fix bug",
+			},
+			notEmpty: true,
+		},
+		{
+			name: "shows no instances message",
+			state: &RenderState{
+				Width:   80,
+				Height:  50,
+				Session: &orchestrator.Session{},
+			},
+			contains: []string{
+				"No instances",
+			},
+			notEmpty: true,
+		},
+		{
+			name: "shows title without session",
+			state: &RenderState{
+				Width:   80,
+				Height:  50,
+				Session: nil,
+			},
+			contains: []string{
+				"Instances",
+			},
+			notEmpty: true,
+		},
+		{
+			name: "invalid state returns error indicator",
+			state: &RenderState{
+				Width:  0,
+				Height: 0,
+			},
+			contains: []string{"render error"},
+			notEmpty: true,
+		},
+	}
+
+	panel := NewInstancePanel()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := panel.Render(tt.state)
+
+			if tt.notEmpty && result == "" {
+				t.Error("expected non-empty result, got empty")
+			}
+			if !tt.notEmpty && result != "" {
+				t.Errorf("expected empty result, got: %s", result)
+			}
+
+			for _, want := range tt.contains {
+				if !strings.Contains(result, want) {
+					t.Errorf("result missing %q\nGot:\n%s", want, result)
+				}
+			}
+		})
+	}
+}
+
+func TestInstancePanel_Height(t *testing.T) {
+	panel := NewInstancePanel()
+
+	state := &RenderState{
+		Width:  80,
+		Height: 50,
+		Session: &orchestrator.Session{
+			Instances: []*orchestrator.Instance{
+				{ID: "inst-1", Task: "Task 1"},
+				{ID: "inst-2", Task: "Task 2"},
+			},
+		},
+	}
+
+	panel.Render(state)
+
+	if panel.Height() <= 0 {
+		t.Errorf("Height() = %d, want positive value", panel.Height())
+	}
+}
+
+func TestInstancePanel_ScrollOffset(t *testing.T) {
+	panel := NewInstancePanel()
+
+	// Create many instances to test scrolling
+	instances := make([]*orchestrator.Instance, 20)
+	for i := range instances {
+		instances[i] = &orchestrator.Instance{
+			ID:      "inst-" + string(rune('a'+i)),
+			Task:    "Task " + string(rune('A'+i)),
+			Created: time.Now(),
+		}
+	}
+
+	state := &RenderState{
+		Width:        40,
+		Height:       20,
+		ScrollOffset: 5,
+		Session: &orchestrator.Session{
+			Instances: instances,
+		},
+	}
+
+	result := panel.Render(state)
+	if result == "" {
+		t.Error("expected non-empty result with scroll offset")
+	}
+}
+
+func TestInstancePanel_IsAddingTask(t *testing.T) {
+	panel := NewInstancePanel()
+
+	state := &RenderState{
+		Width:        80,
+		Height:       50,
+		IsAddingTask: true,
+		Session: &orchestrator.Session{
+			Instances: []*orchestrator.Instance{
+				{ID: "inst-1", Task: "Task 1"},
+			},
+		},
+	}
+
+	result := panel.Render(state)
+	if result == "" {
+		t.Error("expected non-empty result when adding task")
+	}
+}
+
+func TestNewInstancePanel(t *testing.T) {
+	panel := NewInstancePanel()
+	if panel == nil {
+		t.Fatal("NewInstancePanel() returned nil")
+	}
+	if panel.view == nil {
+		t.Error("NewInstancePanel() should initialize view")
+	}
+}
+
+func TestInstancePanelState_Interface(t *testing.T) {
+	session := &orchestrator.Session{ID: "test"}
+
+	state := &instancePanelState{
+		session:             session,
+		activeTab:           2,
+		sidebarScrollOffset: 5,
+		conflicts:           nil,
+		terminalWidth:       80,
+		terminalHeight:      24,
+		isAddingTask:        true,
+	}
+
+	// Verify interface methods return expected values
+	if state.Session() != session {
+		t.Error("Session() returned wrong value")
+	}
+	if state.ActiveTab() != 2 {
+		t.Errorf("ActiveTab() = %d, want 2", state.ActiveTab())
+	}
+	if state.SidebarScrollOffset() != 5 {
+		t.Errorf("SidebarScrollOffset() = %d, want 5", state.SidebarScrollOffset())
+	}
+	if state.Conflicts() != nil {
+		t.Error("Conflicts() should be nil")
+	}
+	if state.TerminalWidth() != 80 {
+		t.Errorf("TerminalWidth() = %d, want 80", state.TerminalWidth())
+	}
+	if state.TerminalHeight() != 24 {
+		t.Errorf("TerminalHeight() = %d, want 24", state.TerminalHeight())
+	}
+	if !state.IsAddingTask() {
+		t.Error("IsAddingTask() = false, want true")
+	}
+}

--- a/internal/tui/panel/renderer.go
+++ b/internal/tui/panel/renderer.go
@@ -5,7 +5,9 @@ package panel
 
 import (
 	"errors"
+	"time"
 
+	"github.com/Iron-Ham/claudio/internal/conflict"
 	"github.com/Iron-Ham/claudio/internal/orchestrator"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -50,6 +52,33 @@ type Theme interface {
 	Surface() lipgloss.Style
 	// Border returns the style for borders.
 	Border() lipgloss.Style
+
+	// DiffAdd returns the style for added lines in diffs.
+	DiffAdd() lipgloss.Style
+	// DiffRemove returns the style for removed lines in diffs.
+	DiffRemove() lipgloss.Style
+	// DiffHeader returns the style for diff headers.
+	DiffHeader() lipgloss.Style
+	// DiffHunk returns the style for diff hunk markers.
+	DiffHunk() lipgloss.Style
+	// DiffContext returns the style for context lines in diffs.
+	DiffContext() lipgloss.Style
+}
+
+// HelpSection represents a section of help content with keybindings.
+type HelpSection struct {
+	// Title is the section name (e.g., "Navigation", "Instance Control").
+	Title string
+	// Items contains the keybindings in this section.
+	Items []HelpItem
+}
+
+// HelpItem represents a single keybinding in the help panel.
+type HelpItem struct {
+	// Key is the keybinding (e.g., "j/k", "Enter").
+	Key string
+	// Description explains what the keybinding does.
+	Description string
 }
 
 // RenderState holds the complete state needed for rendering a panel.
@@ -85,6 +114,42 @@ type RenderState struct {
 	// Focused indicates whether this panel currently has focus.
 	// Used to adjust border styling and visual emphasis.
 	Focused bool
+
+	// SessionCreated is when the current session started.
+	// Used by stats panel to display session duration.
+	SessionCreated time.Time
+
+	// SessionMetrics contains aggregated metrics for the session.
+	// Used by stats panel for token usage and cost display.
+	SessionMetrics *orchestrator.SessionMetrics
+
+	// CostWarningThreshold is the configured cost warning level.
+	// Used to highlight when costs exceed expected levels.
+	CostWarningThreshold float64
+
+	// CostLimit is the configured maximum cost limit.
+	// Used to display remaining budget.
+	CostLimit float64
+
+	// DiffContent holds the git diff content for the diff panel.
+	// Contains the raw diff output to be syntax highlighted.
+	DiffContent string
+
+	// HelpSections contains help text organized by section.
+	// Used by the help panel to display categorized keybindings.
+	HelpSections []HelpSection
+
+	// Conflicts contains detected file conflicts between instances.
+	// Used by the conflict panel to display conflict information.
+	Conflicts []conflict.FileConflict
+
+	// Session is the current orchestrator session.
+	// Used by the instance panel to render the full sidebar.
+	Session *orchestrator.Session
+
+	// IsAddingTask indicates if the user is currently adding a new task.
+	// Used by the instance panel to show input mode state.
+	IsAddingTask bool
 }
 
 // Validate checks that the RenderState has valid values for rendering.

--- a/internal/tui/panel/renderer_test.go
+++ b/internal/tui/panel/renderer_test.go
@@ -10,13 +10,18 @@ import (
 // mockTheme implements Theme for testing purposes.
 type mockTheme struct{}
 
-func (m *mockTheme) Primary() lipgloss.Style   { return lipgloss.NewStyle() }
-func (m *mockTheme) Secondary() lipgloss.Style { return lipgloss.NewStyle() }
-func (m *mockTheme) Muted() lipgloss.Style     { return lipgloss.NewStyle() }
-func (m *mockTheme) Error() lipgloss.Style     { return lipgloss.NewStyle() }
-func (m *mockTheme) Warning() lipgloss.Style   { return lipgloss.NewStyle() }
-func (m *mockTheme) Surface() lipgloss.Style   { return lipgloss.NewStyle() }
-func (m *mockTheme) Border() lipgloss.Style    { return lipgloss.NewStyle() }
+func (m *mockTheme) Primary() lipgloss.Style     { return lipgloss.NewStyle() }
+func (m *mockTheme) Secondary() lipgloss.Style   { return lipgloss.NewStyle() }
+func (m *mockTheme) Muted() lipgloss.Style       { return lipgloss.NewStyle() }
+func (m *mockTheme) Error() lipgloss.Style       { return lipgloss.NewStyle() }
+func (m *mockTheme) Warning() lipgloss.Style     { return lipgloss.NewStyle() }
+func (m *mockTheme) Surface() lipgloss.Style     { return lipgloss.NewStyle() }
+func (m *mockTheme) Border() lipgloss.Style      { return lipgloss.NewStyle() }
+func (m *mockTheme) DiffAdd() lipgloss.Style     { return lipgloss.NewStyle() }
+func (m *mockTheme) DiffRemove() lipgloss.Style  { return lipgloss.NewStyle() }
+func (m *mockTheme) DiffHeader() lipgloss.Style  { return lipgloss.NewStyle() }
+func (m *mockTheme) DiffHunk() lipgloss.Style    { return lipgloss.NewStyle() }
+func (m *mockTheme) DiffContext() lipgloss.Style { return lipgloss.NewStyle() }
 
 // mockPanelRenderer implements PanelRenderer for testing.
 type mockPanelRenderer struct {
@@ -60,6 +65,11 @@ func TestThemeInterface(t *testing.T) {
 	_ = theme.Warning()
 	_ = theme.Surface()
 	_ = theme.Border()
+	_ = theme.DiffAdd()
+	_ = theme.DiffRemove()
+	_ = theme.DiffHeader()
+	_ = theme.DiffHunk()
+	_ = theme.DiffContext()
 }
 
 func TestRenderState_Validate(t *testing.T) {

--- a/internal/tui/panel/stats.go
+++ b/internal/tui/panel/stats.go
@@ -1,0 +1,196 @@
+// Package panel provides interfaces and types for TUI panel rendering.
+package panel
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	instmetrics "github.com/Iron-Ham/claudio/internal/instance/metrics"
+)
+
+// StatsPanel renders session statistics and metrics.
+// It displays token usage, cost information, and per-instance breakdowns.
+type StatsPanel struct {
+	height int
+}
+
+// NewStatsPanel creates a new StatsPanel.
+func NewStatsPanel() *StatsPanel {
+	return &StatsPanel{}
+}
+
+// Render produces the stats panel output.
+func (p *StatsPanel) Render(state *RenderState) string {
+	if err := state.ValidateBasic(); err != nil {
+		return "[stats panel: render error]"
+	}
+
+	var b strings.Builder
+
+	// Title
+	title := "📊 Session Statistics"
+	if state.Theme != nil {
+		title = state.Theme.Primary().Render(title)
+	}
+	b.WriteString(title)
+	b.WriteString("\n\n")
+
+	// Check for no session
+	if state.SessionMetrics == nil {
+		noSession := "No active session"
+		if state.Theme != nil {
+			noSession = state.Theme.Muted().Render(noSession)
+		}
+		b.WriteString(noSession)
+		p.height = 4
+		return b.String()
+	}
+
+	metrics := state.SessionMetrics
+
+	// Session summary
+	subtitle := "Session Summary"
+	if state.Theme != nil {
+		subtitle = state.Theme.Secondary().Render(subtitle)
+	}
+	b.WriteString(subtitle)
+	b.WriteString("\n")
+	b.WriteString(fmt.Sprintf("  Total Instances: %d (%d active)\n",
+		metrics.InstanceCount, metrics.ActiveCount))
+	if !state.SessionCreated.IsZero() {
+		b.WriteString(fmt.Sprintf("  Session Started: %s\n",
+			state.SessionCreated.Format("2006-01-02 15:04:05")))
+	}
+	b.WriteString("\n")
+
+	// Token usage
+	tokenTitle := "Token Usage"
+	if state.Theme != nil {
+		tokenTitle = state.Theme.Secondary().Render(tokenTitle)
+	}
+	b.WriteString(tokenTitle)
+	b.WriteString("\n")
+	b.WriteString(fmt.Sprintf("  Input:  %s\n", instmetrics.FormatTokens(metrics.TotalInputTokens)))
+	b.WriteString(fmt.Sprintf("  Output: %s\n", instmetrics.FormatTokens(metrics.TotalOutputTokens)))
+	totalTokens := metrics.TotalInputTokens + metrics.TotalOutputTokens
+	b.WriteString(fmt.Sprintf("  Total:  %s\n", instmetrics.FormatTokens(totalTokens)))
+	if metrics.TotalCacheRead > 0 || metrics.TotalCacheWrite > 0 {
+		b.WriteString(fmt.Sprintf("  Cache:  %s read / %s write\n",
+			instmetrics.FormatTokens(metrics.TotalCacheRead),
+			instmetrics.FormatTokens(metrics.TotalCacheWrite)))
+	}
+	b.WriteString("\n")
+
+	// Cost summary
+	costTitle := "Estimated Cost"
+	if state.Theme != nil {
+		costTitle = state.Theme.Secondary().Render(costTitle)
+	}
+	b.WriteString(costTitle)
+	b.WriteString("\n")
+	costStr := instmetrics.FormatCost(metrics.TotalCost)
+	if state.CostWarningThreshold > 0 && metrics.TotalCost >= state.CostWarningThreshold {
+		warningText := fmt.Sprintf("  Total: %s (⚠ exceeds warning threshold)", costStr)
+		if state.Theme != nil {
+			warningText = state.Theme.Warning().Render(warningText)
+		}
+		b.WriteString(warningText)
+		b.WriteString("\n")
+	} else {
+		b.WriteString(fmt.Sprintf("  Total: %s\n", costStr))
+	}
+	if state.CostLimit > 0 {
+		b.WriteString(fmt.Sprintf("  Limit: %s\n", instmetrics.FormatCost(state.CostLimit)))
+	}
+	b.WriteString("\n")
+
+	// Per-instance breakdown
+	instanceTitle := "Top Instances by Cost"
+	if state.Theme != nil {
+		instanceTitle = state.Theme.Secondary().Render(instanceTitle)
+	}
+	b.WriteString(instanceTitle)
+	b.WriteString("\n")
+
+	p.renderTopInstances(&b, state)
+
+	b.WriteString("\n")
+	hint := "Press [m] to close this view"
+	if state.Theme != nil {
+		hint = state.Theme.Muted().Render(hint)
+	}
+	b.WriteString(hint)
+
+	// Calculate height
+	p.height = strings.Count(b.String(), "\n") + 1
+
+	return b.String()
+}
+
+// renderTopInstances renders the top instances by cost.
+func (p *StatsPanel) renderTopInstances(b *strings.Builder, state *RenderState) {
+	type instCost struct {
+		id   string
+		num  int
+		task string
+		cost float64
+	}
+
+	var costList []instCost
+	for i, inst := range state.Instances {
+		cost := 0.0
+		if inst.Metrics != nil {
+			cost = inst.Metrics.Cost
+		}
+		costList = append(costList, instCost{
+			id:   inst.ID,
+			num:  i + 1,
+			task: inst.Task,
+			cost: cost,
+		})
+	}
+
+	// Sort descending by cost
+	sort.Slice(costList, func(i, j int) bool {
+		return costList[i].cost > costList[j].cost
+	})
+
+	// Show top 5
+	shown := 0
+	for _, ic := range costList {
+		if shown >= 5 {
+			break
+		}
+		if ic.cost > 0 {
+			taskTrunc := truncateString(ic.task, state.Width-25)
+			fmt.Fprintf(b, "  %d. [%d] %s: %s\n",
+				shown+1, ic.num, taskTrunc, instmetrics.FormatCost(ic.cost))
+			shown++
+		}
+	}
+	if shown == 0 {
+		noData := "  No cost data available yet"
+		if state.Theme != nil {
+			noData = state.Theme.Muted().Render(noData)
+		}
+		b.WriteString(noData)
+		b.WriteString("\n")
+	}
+}
+
+// Height returns the rendered height of the panel.
+func (p *StatsPanel) Height() int {
+	return p.height
+}
+
+// truncateString truncates a string to maxLen characters, adding "..." if truncated.
+func truncateString(s string, maxLen int) string {
+	if maxLen <= 3 {
+		return "..."
+	}
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/internal/tui/panel/stats_test.go
+++ b/internal/tui/panel/stats_test.go
@@ -1,0 +1,315 @@
+package panel
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+)
+
+func TestStatsPanel_Render(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    *RenderState
+		contains []string
+		notEmpty bool
+	}{
+		{
+			name: "full stats with metrics",
+			state: &RenderState{
+				Width:          80,
+				Height:         24,
+				SessionCreated: time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+				SessionMetrics: &orchestrator.SessionMetrics{
+					TotalInputTokens:  50000,
+					TotalOutputTokens: 25000,
+					TotalCacheRead:    10000,
+					TotalCacheWrite:   5000,
+					TotalCost:         1.25,
+					InstanceCount:     3,
+					ActiveCount:       2,
+				},
+				Instances: []*orchestrator.Instance{
+					{ID: "inst-1", Task: "Build feature", Metrics: &orchestrator.Metrics{Cost: 0.50}},
+					{ID: "inst-2", Task: "Fix bug", Metrics: &orchestrator.Metrics{Cost: 0.45}},
+					{ID: "inst-3", Task: "Write tests", Metrics: &orchestrator.Metrics{Cost: 0.30}},
+				},
+			},
+			contains: []string{
+				"Session Statistics",
+				"Session Summary",
+				"Total Instances: 3 (2 active)",
+				"2024-01-15 10:30:00",
+				"Token Usage",
+				"Input:",
+				"Output:",
+				"Total:",
+				"Cache:",
+				"Estimated Cost",
+				"$1.25",
+				"Top Instances by Cost",
+				"Build feature",
+				"Fix bug",
+				"Write tests",
+				"Press [m] to close",
+			},
+			notEmpty: true,
+		},
+		{
+			name: "no session metrics",
+			state: &RenderState{
+				Width:          80,
+				Height:         24,
+				SessionMetrics: nil,
+			},
+			contains: []string{
+				"Session Statistics",
+				"No active session",
+			},
+			notEmpty: true,
+		},
+		{
+			name: "cost warning threshold exceeded",
+			state: &RenderState{
+				Width:  80,
+				Height: 24,
+				SessionMetrics: &orchestrator.SessionMetrics{
+					TotalCost:     5.50,
+					InstanceCount: 1,
+					ActiveCount:   1,
+				},
+				CostWarningThreshold: 5.00,
+			},
+			contains: []string{
+				"exceeds warning threshold",
+			},
+			notEmpty: true,
+		},
+		{
+			name: "with cost limit",
+			state: &RenderState{
+				Width:  80,
+				Height: 24,
+				SessionMetrics: &orchestrator.SessionMetrics{
+					TotalCost:     2.00,
+					InstanceCount: 1,
+					ActiveCount:   1,
+				},
+				CostLimit: 10.00,
+			},
+			contains: []string{
+				"Limit: $10.00",
+			},
+			notEmpty: true,
+		},
+		{
+			name: "no cache tokens",
+			state: &RenderState{
+				Width:  80,
+				Height: 24,
+				SessionMetrics: &orchestrator.SessionMetrics{
+					TotalInputTokens:  1000,
+					TotalOutputTokens: 500,
+					TotalCacheRead:    0,
+					TotalCacheWrite:   0,
+					InstanceCount:     1,
+				},
+			},
+			notEmpty: true,
+		},
+		{
+			name: "invalid state returns error indicator",
+			state: &RenderState{
+				Width:  0,
+				Height: 0,
+			},
+			contains: []string{"render error"},
+			notEmpty: true,
+		},
+	}
+
+	panel := NewStatsPanel()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := panel.Render(tt.state)
+
+			if tt.notEmpty && result == "" {
+				t.Error("expected non-empty result, got empty")
+			}
+			if !tt.notEmpty && result != "" {
+				t.Errorf("expected empty result, got: %s", result)
+			}
+
+			for _, want := range tt.contains {
+				if !strings.Contains(result, want) {
+					t.Errorf("result missing %q\nGot:\n%s", want, result)
+				}
+			}
+		})
+	}
+}
+
+func TestStatsPanel_Height(t *testing.T) {
+	panel := NewStatsPanel()
+
+	// Render to set height
+	state := &RenderState{
+		Width:  80,
+		Height: 24,
+		SessionMetrics: &orchestrator.SessionMetrics{
+			TotalInputTokens:  1000,
+			TotalOutputTokens: 500,
+			InstanceCount:     1,
+			ActiveCount:       1,
+		},
+	}
+
+	panel.Render(state)
+
+	if panel.Height() <= 0 {
+		t.Errorf("Height() = %d, want positive value", panel.Height())
+	}
+}
+
+func TestStatsPanel_TopInstancesSorting(t *testing.T) {
+	panel := NewStatsPanel()
+
+	state := &RenderState{
+		Width:  80,
+		Height: 24,
+		SessionMetrics: &orchestrator.SessionMetrics{
+			InstanceCount: 3,
+			ActiveCount:   3,
+		},
+		Instances: []*orchestrator.Instance{
+			{ID: "low", Task: "Low cost task", Metrics: &orchestrator.Metrics{Cost: 0.10}},
+			{ID: "high", Task: "High cost task", Metrics: &orchestrator.Metrics{Cost: 0.90}},
+			{ID: "mid", Task: "Mid cost task", Metrics: &orchestrator.Metrics{Cost: 0.50}},
+		},
+	}
+
+	result := panel.Render(state)
+
+	// Find positions of each task name
+	highPos := strings.Index(result, "High cost task")
+	midPos := strings.Index(result, "Mid cost task")
+	lowPos := strings.Index(result, "Low cost task")
+
+	// High should come before mid, mid before low (descending order)
+	if highPos >= midPos {
+		t.Error("High cost task should appear before mid cost task")
+	}
+	if midPos >= lowPos {
+		t.Error("Mid cost task should appear before low cost task")
+	}
+}
+
+func TestStatsPanel_NoInstances(t *testing.T) {
+	panel := NewStatsPanel()
+
+	state := &RenderState{
+		Width:  80,
+		Height: 24,
+		SessionMetrics: &orchestrator.SessionMetrics{
+			InstanceCount: 0,
+		},
+		Instances: []*orchestrator.Instance{},
+	}
+
+	result := panel.Render(state)
+
+	if !strings.Contains(result, "No cost data available") {
+		t.Error("expected 'No cost data available' when no instances")
+	}
+}
+
+func TestStatsPanel_InstancesWithNoCost(t *testing.T) {
+	panel := NewStatsPanel()
+
+	state := &RenderState{
+		Width:  80,
+		Height: 24,
+		SessionMetrics: &orchestrator.SessionMetrics{
+			InstanceCount: 2,
+		},
+		Instances: []*orchestrator.Instance{
+			{ID: "no-metrics", Task: "Task 1", Metrics: nil},
+			{ID: "zero-cost", Task: "Task 2", Metrics: &orchestrator.Metrics{Cost: 0}},
+		},
+	}
+
+	result := panel.Render(state)
+
+	if !strings.Contains(result, "No cost data available") {
+		t.Error("expected 'No cost data available' when instances have no cost")
+	}
+}
+
+func TestStatsPanel_TopFiveLimit(t *testing.T) {
+	panel := NewStatsPanel()
+
+	// Create 10 instances
+	instances := make([]*orchestrator.Instance, 10)
+	for i := 0; i < 10; i++ {
+		instances[i] = &orchestrator.Instance{
+			ID:      "inst-" + string(rune('a'+i)),
+			Task:    "Task " + string(rune('A'+i)),
+			Metrics: &orchestrator.Metrics{Cost: float64(i+1) * 0.10},
+		}
+	}
+
+	state := &RenderState{
+		Width:  80,
+		Height: 24,
+		SessionMetrics: &orchestrator.SessionMetrics{
+			InstanceCount: 10,
+		},
+		Instances: instances,
+	}
+
+	result := panel.Render(state)
+
+	// Count how many "Task" lines appear (each instance shows as "N. [X] Task Y: $Z.ZZ")
+	lines := strings.Split(result, "\n")
+	taskLineCount := 0
+	for _, line := range lines {
+		if strings.Contains(line, ". [") && strings.Contains(line, "Task ") && strings.Contains(line, "$") {
+			taskLineCount++
+		}
+	}
+
+	if taskLineCount != 5 {
+		t.Errorf("expected 5 instance lines, got %d", taskLineCount)
+	}
+}
+
+func TestNewStatsPanel(t *testing.T) {
+	panel := NewStatsPanel()
+	if panel == nil {
+		t.Error("NewStatsPanel() returned nil")
+	}
+}
+
+func TestTruncateString(t *testing.T) {
+	tests := []struct {
+		input    string
+		maxLen   int
+		expected string
+	}{
+		{"hello", 10, "hello"},
+		{"hello world", 8, "hello..."},
+		{"hi", 2, "..."},
+		{"test", 3, "..."},
+		{"", 5, ""},
+		{"longstring", 10, "longstring"},
+	}
+
+	for _, tt := range tests {
+		result := truncateString(tt.input, tt.maxLen)
+		if result != tt.expected {
+			t.Errorf("truncateString(%q, %d) = %q, want %q", tt.input, tt.maxLen, result, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements 10 concrete components from the refactoring plan (#282), completing all prompt builders and panel renderers from Group 2.

### Prompt Builders (`internal/orchestrator/prompt/`)
- **PlanningBuilder** (#262): Builds plan selection prompts with candidate comparison for multi-pass planning
- **TaskBuilder** (#263): Builds individual task execution prompts with completion protocol
- **SynthesisBuilder** (#264): Aggregates completed task results for review phase
- **ConsolidationBuilder** (#265): Main and per-group consolidation prompts for branch merging
- **RevisionBuilder** (#266): Formats revision issues by task with severity levels

### Panel Renderers (`internal/tui/panel/`)
- **StatsPanel** (#268): Session statistics, token usage, and cost information
- **HelpPanel** (#269): Scrollable help overlay with keybindings
- **DiffPanel** (#270): Git diff display with syntax highlighting
- **InstancePanel** (#267): Adapts `DashboardView` to `PanelRenderer` interface
- **ConflictPanel** (#271): Adapts `ConflictsView` to `PanelRenderer` interface

### Additional Improvements
- Add `ErrMissingConsolidation` sentinel error for consistent error handling
- Remove unused `StrategyNames` field from `Context` struct
- Fix silent failures: panels now return visible error indicators instead of empty strings
- Fix silent task skips: missing tasks now show warnings in prompt output
- Add empty `SessionID` handling in branch name generation
- Add `Consolidation` nil check to `GroupConsolidatorBuilder` validation

## Test Coverage
- `internal/orchestrator/prompt`: **96.8%**
- `internal/tui/panel`: **92.3%**

## Test plan
- [x] All unit tests pass (`go test ./...`)
- [x] Build succeeds (`go build ./...`)
- [x] Linting passes (`golangci-lint run`)
- [x] Code formatting verified (`gofmt -d .`)

Closes #262, #263, #264, #265, #266, #267, #268, #269, #270, #271
Part of #282