### PR TITLE
Extract budget management from orchestrator

### DIFF
--- a/internal/orchestrator/budget/manager.go
+++ b/internal/orchestrator/budget/manager.go
@@ -1,0 +1,229 @@
+// Package budget provides budget monitoring and enforcement for orchestrator sessions.
+package budget
+
+import (
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/config"
+	"github.com/Iron-Ham/claudio/internal/logging"
+)
+
+// InstanceMetrics represents metrics for a single instance.
+type InstanceMetrics struct {
+	ID           string
+	Status       string
+	InputTokens  int64
+	OutputTokens int64
+	CacheRead    int64
+	CacheWrite   int64
+	Cost         float64
+	APICalls     int
+	StartTime    time.Time
+	EndTime      *time.Time
+}
+
+// TotalTokens returns the sum of input and output tokens.
+func (m *InstanceMetrics) TotalTokens() int64 {
+	return m.InputTokens + m.OutputTokens
+}
+
+// Duration returns the duration of the instance if it has ended.
+func (m *InstanceMetrics) Duration() time.Duration {
+	if m.EndTime != nil {
+		return m.EndTime.Sub(m.StartTime)
+	}
+	if !m.StartTime.IsZero() {
+		return time.Since(m.StartTime)
+	}
+	return 0
+}
+
+// SessionMetrics holds aggregated metrics for the entire session.
+type SessionMetrics struct {
+	TotalInputTokens  int64
+	TotalOutputTokens int64
+	TotalCacheRead    int64
+	TotalCacheWrite   int64
+	TotalCost         float64
+	TotalAPICalls     int
+	TotalDuration     time.Duration
+	InstanceCount     int
+	ActiveCount       int
+}
+
+// InstanceProvider provides access to instance metrics.
+type InstanceProvider interface {
+	// GetAllInstanceMetrics returns metrics for all instances.
+	GetAllInstanceMetrics() []InstanceMetrics
+}
+
+// InstancePauser can pause instances that exceed limits.
+type InstancePauser interface {
+	// PauseInstance pauses the instance with the given ID.
+	PauseInstance(id string) error
+}
+
+// Callbacks defines callbacks for budget events.
+type Callbacks struct {
+	// OnBudgetLimit is called when the budget limit is exceeded.
+	OnBudgetLimit func()
+	// OnBudgetWarning is called when the budget warning threshold is reached.
+	OnBudgetWarning func()
+	// OnInstanceTokenLimit is called when an instance exceeds its token limit.
+	OnInstanceTokenLimit func(instanceID string)
+}
+
+// Config holds budget configuration.
+type Config struct {
+	CostLimit             float64
+	CostWarningThreshold  float64
+	TokenLimitPerInstance int64
+}
+
+// Manager monitors and enforces budget limits.
+type Manager struct {
+	config    Config
+	provider  InstanceProvider
+	pauser    InstancePauser
+	callbacks Callbacks
+	logger    *logging.Logger
+}
+
+// NewManager creates a new budget manager.
+func NewManager(cfg Config, provider InstanceProvider, pauser InstancePauser, callbacks Callbacks, logger *logging.Logger) *Manager {
+	if logger == nil {
+		logger = logging.NopLogger()
+	}
+	return &Manager{
+		config:    cfg,
+		provider:  provider,
+		pauser:    pauser,
+		callbacks: callbacks,
+		logger:    logger,
+	}
+}
+
+// NewManagerFromConfig creates a budget manager from application config.
+func NewManagerFromConfig(appCfg *config.Config, provider InstanceProvider, pauser InstancePauser, callbacks Callbacks, logger *logging.Logger) *Manager {
+	cfg := Config{}
+	if appCfg != nil {
+		cfg.CostLimit = appCfg.Resources.CostLimit
+		cfg.CostWarningThreshold = appCfg.Resources.CostWarningThreshold
+		cfg.TokenLimitPerInstance = appCfg.Resources.TokenLimitPerInstance
+	}
+	return NewManager(cfg, provider, pauser, callbacks, logger)
+}
+
+// UpdateConfig updates the budget configuration.
+func (m *Manager) UpdateConfig(cfg Config) {
+	m.config = cfg
+}
+
+// GetSessionMetrics aggregates metrics across all instances.
+func (m *Manager) GetSessionMetrics() *SessionMetrics {
+	if m.provider == nil {
+		return &SessionMetrics{}
+	}
+
+	allMetrics := m.provider.GetAllInstanceMetrics()
+	metrics := &SessionMetrics{
+		InstanceCount: len(allMetrics),
+	}
+
+	for _, inst := range allMetrics {
+		if inst.Status == "working" || inst.Status == "waiting_input" {
+			metrics.ActiveCount++
+		}
+
+		metrics.TotalInputTokens += inst.InputTokens
+		metrics.TotalOutputTokens += inst.OutputTokens
+		metrics.TotalCacheRead += inst.CacheRead
+		metrics.TotalCacheWrite += inst.CacheWrite
+		metrics.TotalCost += inst.Cost
+		metrics.TotalAPICalls += inst.APICalls
+		metrics.TotalDuration += inst.Duration()
+	}
+
+	return metrics
+}
+
+// CheckLimits checks all budget limits and pauses instances if necessary.
+// Returns true if any limit was exceeded.
+func (m *Manager) CheckLimits() bool {
+	if m.provider == nil {
+		return false
+	}
+
+	limitExceeded := false
+
+	// Get session totals
+	sessionMetrics := m.GetSessionMetrics()
+
+	// Check cost limit
+	if m.config.CostLimit > 0 && sessionMetrics.TotalCost >= m.config.CostLimit {
+		m.logger.Warn("budget limit exceeded, pausing all instances",
+			"total_cost", sessionMetrics.TotalCost,
+			"cost_limit", m.config.CostLimit,
+		)
+
+		// Pause all working instances
+		allMetrics := m.provider.GetAllInstanceMetrics()
+		for _, inst := range allMetrics {
+			if inst.Status == "working" && m.pauser != nil {
+				if err := m.pauser.PauseInstance(inst.ID); err != nil {
+					m.logger.Error("failed to pause instance during budget limit enforcement",
+						"instance_id", inst.ID,
+						"error", err,
+					)
+				}
+			}
+		}
+
+		if m.callbacks.OnBudgetLimit != nil {
+			m.callbacks.OnBudgetLimit()
+		}
+		limitExceeded = true
+	}
+
+	// Check cost warning threshold
+	if m.config.CostWarningThreshold > 0 && sessionMetrics.TotalCost >= m.config.CostWarningThreshold {
+		m.logger.Warn("budget warning threshold reached",
+			"total_cost", sessionMetrics.TotalCost,
+			"warning_threshold", m.config.CostWarningThreshold,
+		)
+
+		if m.callbacks.OnBudgetWarning != nil {
+			m.callbacks.OnBudgetWarning()
+		}
+	}
+
+	// Check per-instance token limit
+	if m.config.TokenLimitPerInstance > 0 {
+		allMetrics := m.provider.GetAllInstanceMetrics()
+		for _, inst := range allMetrics {
+			if inst.Status == "working" && inst.TotalTokens() >= m.config.TokenLimitPerInstance {
+				m.logger.Warn("instance token limit exceeded",
+					"instance_id", inst.ID,
+					"total_tokens", inst.TotalTokens(),
+					"token_limit", m.config.TokenLimitPerInstance,
+				)
+
+				if m.pauser != nil {
+					if err := m.pauser.PauseInstance(inst.ID); err != nil {
+						m.logger.Error("failed to pause instance after token limit exceeded",
+							"instance_id", inst.ID,
+							"error", err,
+						)
+					}
+				}
+
+				if m.callbacks.OnInstanceTokenLimit != nil {
+					m.callbacks.OnInstanceTokenLimit(inst.ID)
+				}
+				limitExceeded = true
+			}
+		}
+	}
+
+	return limitExceeded
+}

--- a/internal/orchestrator/budget/manager_test.go
+++ b/internal/orchestrator/budget/manager_test.go
@@ -1,0 +1,353 @@
+package budget
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/config"
+)
+
+// mockProvider implements InstanceProvider for testing.
+type mockProvider struct {
+	metrics []InstanceMetrics
+}
+
+func (m *mockProvider) GetAllInstanceMetrics() []InstanceMetrics {
+	return m.metrics
+}
+
+// mockPauser implements InstancePauser for testing.
+type mockPauser struct {
+	paused []string
+}
+
+func (m *mockPauser) PauseInstance(id string) error {
+	m.paused = append(m.paused, id)
+	return nil
+}
+
+func TestNewManager(t *testing.T) {
+	cfg := Config{
+		CostLimit:             10.0,
+		CostWarningThreshold:  5.0,
+		TokenLimitPerInstance: 1000,
+	}
+
+	mgr := NewManager(cfg, nil, nil, Callbacks{}, nil)
+	if mgr == nil {
+		t.Fatal("NewManager returned nil")
+	}
+
+	if mgr.config.CostLimit != 10.0 {
+		t.Errorf("CostLimit = %v, want 10.0", mgr.config.CostLimit)
+	}
+}
+
+func TestNewManagerFromConfig(t *testing.T) {
+	appCfg := &config.Config{
+		Resources: config.ResourceConfig{
+			CostLimit:             15.0,
+			CostWarningThreshold:  8.0,
+			TokenLimitPerInstance: 2000,
+		},
+	}
+
+	mgr := NewManagerFromConfig(appCfg, nil, nil, Callbacks{}, nil)
+	if mgr == nil {
+		t.Fatal("NewManagerFromConfig returned nil")
+	}
+
+	if mgr.config.CostLimit != 15.0 {
+		t.Errorf("CostLimit = %v, want 15.0", mgr.config.CostLimit)
+	}
+	if mgr.config.TokenLimitPerInstance != 2000 {
+		t.Errorf("TokenLimitPerInstance = %v, want 2000", mgr.config.TokenLimitPerInstance)
+	}
+}
+
+func TestNewManagerFromConfig_NilConfig(t *testing.T) {
+	mgr := NewManagerFromConfig(nil, nil, nil, Callbacks{}, nil)
+	if mgr == nil {
+		t.Fatal("NewManagerFromConfig returned nil with nil config")
+	}
+
+	if mgr.config.CostLimit != 0 {
+		t.Errorf("CostLimit = %v, want 0 for nil config", mgr.config.CostLimit)
+	}
+}
+
+func TestGetSessionMetrics(t *testing.T) {
+	provider := &mockProvider{
+		metrics: []InstanceMetrics{
+			{
+				ID:           "inst-1",
+				Status:       "working",
+				InputTokens:  100,
+				OutputTokens: 50,
+				CacheRead:    10,
+				CacheWrite:   5,
+				Cost:         0.50,
+				APICalls:     3,
+			},
+			{
+				ID:           "inst-2",
+				Status:       "waiting_input",
+				InputTokens:  200,
+				OutputTokens: 100,
+				CacheRead:    20,
+				CacheWrite:   10,
+				Cost:         1.00,
+				APICalls:     5,
+			},
+			{
+				ID:           "inst-3",
+				Status:       "completed",
+				InputTokens:  50,
+				OutputTokens: 25,
+				Cost:         0.25,
+				APICalls:     2,
+			},
+		},
+	}
+
+	mgr := NewManager(Config{}, provider, nil, Callbacks{}, nil)
+	metrics := mgr.GetSessionMetrics()
+
+	if metrics.InstanceCount != 3 {
+		t.Errorf("InstanceCount = %d, want 3", metrics.InstanceCount)
+	}
+	if metrics.ActiveCount != 2 {
+		t.Errorf("ActiveCount = %d, want 2", metrics.ActiveCount)
+	}
+	if metrics.TotalInputTokens != 350 {
+		t.Errorf("TotalInputTokens = %d, want 350", metrics.TotalInputTokens)
+	}
+	if metrics.TotalOutputTokens != 175 {
+		t.Errorf("TotalOutputTokens = %d, want 175", metrics.TotalOutputTokens)
+	}
+	if metrics.TotalCost != 1.75 {
+		t.Errorf("TotalCost = %v, want 1.75", metrics.TotalCost)
+	}
+	if metrics.TotalAPICalls != 10 {
+		t.Errorf("TotalAPICalls = %d, want 10", metrics.TotalAPICalls)
+	}
+}
+
+func TestGetSessionMetrics_NilProvider(t *testing.T) {
+	mgr := NewManager(Config{}, nil, nil, Callbacks{}, nil)
+	metrics := mgr.GetSessionMetrics()
+
+	if metrics.InstanceCount != 0 {
+		t.Errorf("InstanceCount = %d, want 0 for nil provider", metrics.InstanceCount)
+	}
+}
+
+func TestCheckLimits_CostLimit(t *testing.T) {
+	provider := &mockProvider{
+		metrics: []InstanceMetrics{
+			{ID: "inst-1", Status: "working", Cost: 8.0},
+			{ID: "inst-2", Status: "working", Cost: 5.0},
+		},
+	}
+	pauser := &mockPauser{}
+
+	var budgetLimitCalled bool
+	callbacks := Callbacks{
+		OnBudgetLimit: func() {
+			budgetLimitCalled = true
+		},
+	}
+
+	cfg := Config{CostLimit: 10.0}
+	mgr := NewManager(cfg, provider, pauser, callbacks, nil)
+
+	exceeded := mgr.CheckLimits()
+
+	if !exceeded {
+		t.Error("CheckLimits should return true when cost limit exceeded")
+	}
+	if !budgetLimitCalled {
+		t.Error("OnBudgetLimit callback should be called")
+	}
+	if len(pauser.paused) != 2 {
+		t.Errorf("Should pause 2 instances, paused %d", len(pauser.paused))
+	}
+}
+
+func TestCheckLimits_CostWarning(t *testing.T) {
+	provider := &mockProvider{
+		metrics: []InstanceMetrics{
+			{ID: "inst-1", Status: "working", Cost: 6.0},
+		},
+	}
+
+	var warningCalled bool
+	callbacks := Callbacks{
+		OnBudgetWarning: func() {
+			warningCalled = true
+		},
+	}
+
+	cfg := Config{
+		CostLimit:            10.0,
+		CostWarningThreshold: 5.0,
+	}
+	mgr := NewManager(cfg, provider, nil, callbacks, nil)
+
+	exceeded := mgr.CheckLimits()
+
+	if exceeded {
+		t.Error("CheckLimits should return false when only warning threshold reached")
+	}
+	if !warningCalled {
+		t.Error("OnBudgetWarning callback should be called")
+	}
+}
+
+func TestCheckLimits_TokenLimit(t *testing.T) {
+	provider := &mockProvider{
+		metrics: []InstanceMetrics{
+			{ID: "inst-1", Status: "working", InputTokens: 800, OutputTokens: 300},
+			{ID: "inst-2", Status: "working", InputTokens: 400, OutputTokens: 200},
+		},
+	}
+	pauser := &mockPauser{}
+
+	var tokenLimitInstances []string
+	callbacks := Callbacks{
+		OnInstanceTokenLimit: func(id string) {
+			tokenLimitInstances = append(tokenLimitInstances, id)
+		},
+	}
+
+	cfg := Config{TokenLimitPerInstance: 1000}
+	mgr := NewManager(cfg, provider, pauser, callbacks, nil)
+
+	exceeded := mgr.CheckLimits()
+
+	if !exceeded {
+		t.Error("CheckLimits should return true when token limit exceeded")
+	}
+	if len(tokenLimitInstances) != 1 {
+		t.Errorf("Should trigger token limit for 1 instance, got %d", len(tokenLimitInstances))
+	}
+	if tokenLimitInstances[0] != "inst-1" {
+		t.Errorf("Token limit triggered for %s, want inst-1", tokenLimitInstances[0])
+	}
+	if len(pauser.paused) != 1 {
+		t.Errorf("Should pause 1 instance, paused %d", len(pauser.paused))
+	}
+}
+
+func TestCheckLimits_NoLimitsConfigured(t *testing.T) {
+	provider := &mockProvider{
+		metrics: []InstanceMetrics{
+			{ID: "inst-1", Status: "working", Cost: 100.0, InputTokens: 10000},
+		},
+	}
+
+	cfg := Config{} // No limits set
+	mgr := NewManager(cfg, provider, nil, Callbacks{}, nil)
+
+	exceeded := mgr.CheckLimits()
+
+	if exceeded {
+		t.Error("CheckLimits should return false when no limits configured")
+	}
+}
+
+func TestCheckLimits_NilProvider(t *testing.T) {
+	cfg := Config{CostLimit: 10.0}
+	mgr := NewManager(cfg, nil, nil, Callbacks{}, nil)
+
+	exceeded := mgr.CheckLimits()
+
+	if exceeded {
+		t.Error("CheckLimits should return false with nil provider")
+	}
+}
+
+func TestUpdateConfig(t *testing.T) {
+	mgr := NewManager(Config{CostLimit: 5.0}, nil, nil, Callbacks{}, nil)
+
+	mgr.UpdateConfig(Config{CostLimit: 20.0})
+
+	if mgr.config.CostLimit != 20.0 {
+		t.Errorf("CostLimit = %v, want 20.0 after update", mgr.config.CostLimit)
+	}
+}
+
+func TestInstanceMetrics_TotalTokens(t *testing.T) {
+	m := InstanceMetrics{
+		InputTokens:  100,
+		OutputTokens: 50,
+	}
+
+	if m.TotalTokens() != 150 {
+		t.Errorf("TotalTokens() = %d, want 150", m.TotalTokens())
+	}
+}
+
+func TestInstanceMetrics_Duration(t *testing.T) {
+	start := time.Now().Add(-time.Hour)
+	end := time.Now()
+
+	tests := []struct {
+		name    string
+		metrics InstanceMetrics
+		want    time.Duration
+	}{
+		{
+			name: "with end time",
+			metrics: InstanceMetrics{
+				StartTime: start,
+				EndTime:   &end,
+			},
+			want: time.Hour,
+		},
+		{
+			name: "zero start time",
+			metrics: InstanceMetrics{
+				StartTime: time.Time{},
+			},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.metrics.Duration()
+			// Allow small tolerance for "with end time" case
+			if tt.name == "with end time" {
+				diff := got - tt.want
+				if diff < -time.Second || diff > time.Second {
+					t.Errorf("Duration() = %v, want approximately %v", got, tt.want)
+				}
+			} else if got != tt.want {
+				t.Errorf("Duration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckLimits_SkipsNonWorkingInstances(t *testing.T) {
+	provider := &mockProvider{
+		metrics: []InstanceMetrics{
+			{ID: "inst-1", Status: "completed", InputTokens: 2000},
+			{ID: "inst-2", Status: "paused", InputTokens: 2000},
+		},
+	}
+	pauser := &mockPauser{}
+
+	cfg := Config{TokenLimitPerInstance: 1000}
+	mgr := NewManager(cfg, provider, pauser, Callbacks{}, nil)
+
+	exceeded := mgr.CheckLimits()
+
+	if exceeded {
+		t.Error("CheckLimits should not trigger for non-working instances")
+	}
+	if len(pauser.paused) != 0 {
+		t.Errorf("Should not pause any instances, paused %d", len(pauser.paused))
+	}
+}


### PR DESCRIPTION
## Summary

- Extracts budget monitoring and enforcement logic from Orchestrator to dedicated `internal/orchestrator/budget` package
- Implements `InstanceProvider` and `InstancePauser` interfaces in Orchestrator for budget manager integration
- Delegates `checkBudgetLimits()` and `GetSessionMetrics()` to budget manager

## Changes

### New Package: `internal/orchestrator/budget`
- `Manager` type handles budget limit checking, cost warnings, and per-instance token limits
- `InstanceMetrics` and `SessionMetrics` types for metrics aggregation
- `InstanceProvider` and `InstancePauser` interfaces for clean dependency injection
- Full test coverage (14 tests)

### Orchestrator Updates (`internal/orchestrator/orchestrator.go`)
- Add `budgetMgr` to composed managers
- Implement `GetAllInstanceMetrics()` (InstanceProvider interface)
- Implement `PauseInstance()` (InstancePauser interface)
- Add `initBudgetManager()` to wire callbacks for notifications
- Simplify `checkBudgetLimits()` to delegate to budget manager
- Simplify `GetSessionMetrics()` to delegate to budget manager

## Impact

This extraction improves:
- **Separation of concerns**: Budget logic is now self-contained and testable
- **Testability**: Budget manager can be tested independently with mock providers
- **Maintainability**: Budget rules can be modified without touching orchestrator

Note: Line count remains similar (~2003) due to added interface implementations. The value is in architectural improvement rather than line reduction. Further extractions toward the ~1200-1400 line target would require significant refactoring of instance lifecycle integration.

## Test plan

- [x] All existing tests pass (go test ./...)
- [x] New budget package tests pass (14 tests)
- [x] go vet passes
- [x] gofmt compliance

Part of #273