### PR TITLE
Extract sessionFilePath helper in Orchestrator

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -327,15 +327,7 @@ func (o *Orchestrator) LoadSession() (*Session, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
-	// Determine session file path based on mode
-	var sessionFile string
-	if o.sessionDir != "" {
-		sessionFile = filepath.Join(o.sessionDir, "session.json")
-	} else {
-		// Legacy single-session mode
-		sessionFile = filepath.Join(o.claudioDir, "session.json")
-	}
-
+	sessionFile := o.sessionFilePath()
 	data, err := os.ReadFile(sessionFile)
 	if err != nil {
 		if o.logger != nil {
@@ -1231,12 +1223,7 @@ func (o *Orchestrator) StopSession(sess *Session, force bool) error {
 	}
 
 	// Remove session file
-	var sessionFile string
-	if o.sessionDir != "" {
-		sessionFile = filepath.Join(o.sessionDir, "session.json")
-	} else {
-		sessionFile = filepath.Join(o.claudioDir, "session.json")
-	}
+	sessionFile := o.sessionFilePath()
 	if err := os.Remove(sessionFile); err != nil && !os.IsNotExist(err) {
 		if o.logger != nil {
 			o.logger.Warn("failed to remove session file",
@@ -1402,15 +1389,7 @@ func (o *Orchestrator) saveSession() error {
 		return nil
 	}
 
-	// Determine session file path based on mode
-	var sessionFile string
-	if o.sessionDir != "" {
-		sessionFile = filepath.Join(o.sessionDir, "session.json")
-	} else {
-		// Legacy single-session mode
-		sessionFile = filepath.Join(o.claudioDir, "session.json")
-	}
-
+	sessionFile := o.sessionFilePath()
 	data, err := json.MarshalIndent(o.session, "", "  ")
 	if err != nil {
 		if o.logger != nil {
@@ -1438,6 +1417,15 @@ func (o *Orchestrator) saveSession() error {
 // like the Coordinator that need to trigger session persistence
 func (o *Orchestrator) SaveSession() error {
 	return o.saveSession()
+}
+
+// sessionFilePath returns the path to the session.json file.
+// Handles both multi-session mode (sessionDir) and legacy single-session mode (claudioDir).
+func (o *Orchestrator) sessionFilePath() string {
+	if o.sessionDir != "" {
+		return filepath.Join(o.sessionDir, "session.json")
+	}
+	return filepath.Join(o.claudioDir, "session.json")
 }
 
 // updateContext updates the shared context file in all worktrees


### PR DESCRIPTION
## Summary
- Extract repeated session file path determination into `sessionFilePath()` helper method
- Consolidate logic from `LoadSession`, `saveSession`, and `StopSession`
- Net reduction of 12 lines

## Changes
The `sessionFilePath` helper handles both:
- Multi-session mode (uses `sessionDir`)
- Legacy single-session mode (uses `claudioDir`)

Before:
```go
var sessionFile string
if o.sessionDir != "" {
    sessionFile = filepath.Join(o.sessionDir, "session.json")
} else {
    sessionFile = filepath.Join(o.claudioDir, "session.json")
}
```

After:
```go
sessionFile := o.sessionFilePath()
```

## Part of
Part of #273 (Refactor Orchestrator as cleaner facade)

## Test plan
- [x] All orchestrator tests pass
- [x] go vet passes
- [x] gofmt compliant