### PR TITLE
Extract terminal pane management into TerminalManager

### DIFF
--- a/internal/tui/terminal_test.go
+++ b/internal/tui/terminal_test.go
@@ -307,25 +307,27 @@ func TestExitTerminalMode(t *testing.T) {
 
 func TestGetTerminalDir(t *testing.T) {
 	tests := []struct {
-		name            string
-		terminalDirMode TerminalDirMode
-		invocationDir   string
-		expectedDir     string
+		name          string
+		dirMode       terminal.DirMode
+		invocationDir string
+		expectedDir   string
 	}{
 		{
-			name:            "invocation mode returns invocation dir",
-			terminalDirMode: TerminalDirInvocation,
-			invocationDir:   "/home/user/project",
-			expectedDir:     "/home/user/project",
+			name:          "invocation mode returns invocation dir",
+			dirMode:       terminal.DirInvocation,
+			invocationDir: "/home/user/project",
+			expectedDir:   "/home/user/project",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			mgr := terminal.NewManagerWithConfig(terminal.ManagerConfig{
+				InvocationDir: tt.invocationDir,
+			})
+			mgr.SetDirMode(tt.dirMode)
 			m := Model{
-				terminalManager: terminal.NewManager(),
-				terminalDirMode: tt.terminalDirMode,
-				invocationDir:   tt.invocationDir,
+				terminalManager: mgr,
 			}
 
 			got := m.getTerminalDir()


### PR DESCRIPTION
## Summary

- Consolidates terminal pane concerns from the monolithic TUI Model into a dedicated `TerminalManager` component
- Moves `DirMode` type and constants into the terminal package
- Adds `ActiveInstanceProvider` interface for decoupling from orchestrator
- Enhances Manager to own Process lifecycle, directory mode, output, and key forwarding
- Refactors Model to delegate all terminal operations to TerminalManager
- Improves error/warning separation in Toggle return values
- Adds user feedback when SwitchDir called with terminal not running

## Test plan

- [x] All existing tests pass
- [x] New tests added for TerminalManager methods
- [x] Build passes
- [x] go vet passes
- [x] gofmt passes

Closes #255