### PR TITLE
Fix scrollback regression from PR #340 while preserving input visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Cleanup Command Respects Worktree Config** - The `claudio cleanup` command and stale resource warnings now correctly use the configured worktree directory instead of the hardcoded default
-- **Input Mode Text Visibility** - Fixed typed text being invisible during input mode until a full capture occurred (up to 5 seconds). Output buffer is now updated immediately on any content change, regardless of capture type
+- **TUI Scrollback and Input Visibility** - Fixed output scrollback being lost when using differential capture optimization. Visible-only captures now trigger a full capture on the next tick when content changes, ensuring both immediate input visibility and preserved scrollback history
 
 ### Performance
 


### PR DESCRIPTION
## Summary

- Fixed scrollback regression introduced by PR #340 where visible-only captures overwrote the output buffer
- Typed input is now visible within ~100ms while scrollback history is preserved
- Added `forceFullCapture` flag that schedules a full capture when visible content changes

## Root Cause

PR #340 fixed input visibility by always updating `outputBuf` when content changed. However, visible-only captures don't include scrollback history, so this caused scrollback to be lost (users saw "49/49" instead of "512/512" lines).

## Solution

Instead of updating the buffer from visible-only captures, we now set a `forceFullCapture` flag when visible content changes. The next tick (100ms later) will do a full capture that includes scrollback, ensuring both:
- Input is visible quickly (~100ms latency)
- Scrollback is preserved (only full captures update the buffer)

## Test Plan

- [ ] Start Claudio and create a new instance
- [ ] Enter input mode (press `i`)
- [ ] Type text - it should appear immediately (within ~100ms)
- [ ] Exit input mode and scroll up - scrollback should be accessible
- [ ] Verify scrollback shows full history (e.g., 512/512 lines, not 49/49)