### PR TITLE
Add Triple-Shot Mode for parallel problem solving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Triple-Shot Mode** - New `claudio tripleshot` command runs three Claude instances in parallel on the same task, then uses a fourth "judge" instance to evaluate all solutions and determine the best approach. Supports `--auto-approve` flag and provides a specialized TUI showing attempt status, judge evaluation, and results
 - **Configurable Worktree Directory** - Users can now configure where Claudio creates git worktrees via `paths.worktree_dir` in config. Supports absolute paths, relative paths, and `~` home directory expansion. Available in interactive config (`claudio config`) under the new "Paths" category.
 
 ### Fixed

--- a/internal/cmd/tripleshot.go
+++ b/internal/cmd/tripleshot.go
@@ -1,0 +1,160 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Iron-Ham/claudio/internal/config"
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	orchsession "github.com/Iron-Ham/claudio/internal/orchestrator/session"
+	sessutil "github.com/Iron-Ham/claudio/internal/session"
+	"github.com/Iron-Ham/claudio/internal/tui"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+var tripleshotCmd = &cobra.Command{
+	Use:   "tripleshot [task]",
+	Short: "Start a triple-shot session where three instances solve the same problem",
+	Long: `Triple-shot mode runs three Claude instances in parallel on the same task,
+then uses a fourth "judge" instance to evaluate all three solutions and determine
+which one is best - or if elements from multiple solutions can be combined.
+
+This approach is useful for:
+- Complex problems where different approaches might yield different solutions
+- Getting diverse perspectives on a problem before committing to one approach
+- Situations where you want the best solution, not just the first one
+
+The process has three phases:
+1. WORKING: Three Claude instances work on the task independently
+2. EVALUATING: A judge instance reviews all three solutions
+3. COMPLETE: The judge provides an evaluation with a recommended approach
+
+Examples:
+  # Start triple-shot with a task
+  claudio tripleshot "Implement a rate limiter for the API"
+
+  # Start with auto-approve (apply winning solution automatically)
+  claudio tripleshot --auto-approve "Refactor the authentication module"`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runTripleshot,
+}
+
+var (
+	tripleshotAutoApprove bool
+)
+
+func init() {
+	rootCmd.AddCommand(tripleshotCmd)
+
+	tripleshotCmd.Flags().BoolVar(&tripleshotAutoApprove, "auto-approve", false, "Auto-approve applying the winning solution")
+}
+
+func runTripleshot(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	// Get task from args or prompt
+	var task string
+	if len(args) > 0 {
+		task = args[0]
+	} else {
+		task, err = promptTripleShotTask()
+		if err != nil {
+			return err
+		}
+	}
+
+	// Generate a new session ID for this triple-shot
+	sessionID := orchsession.GenerateID()
+	cfg := config.Get()
+
+	// Create triple-shot configuration
+	tripleConfig := orchestrator.DefaultTripleShotConfig()
+	tripleConfig.AutoApprove = tripleshotAutoApprove
+
+	// Create logger if enabled
+	sessionDir := sessutil.GetSessionDir(cwd, sessionID)
+	logger := CreateLogger(sessionDir, cfg)
+	defer func() { _ = logger.Close() }()
+
+	// Create orchestrator with multi-session support
+	orch, err := orchestrator.NewWithSession(cwd, sessionID, cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create orchestrator: %w", err)
+	}
+
+	// Set the logger on the orchestrator
+	orch.SetLogger(logger)
+
+	// Start a new session for the triple-shot
+	words := strings.Fields(task)
+	if len(words) > 3 {
+		words = words[:3]
+	}
+	sessionName := "tripleshot-" + slugifyWords(words)
+
+	session, err := orch.StartSession(sessionName)
+	if err != nil {
+		return fmt.Errorf("failed to start session: %w", err)
+	}
+
+	// Log startup
+	logger.Info("tripleshot started",
+		"session_id", sessionID,
+		"task", truncateString(task, 100),
+		"auto_approve", tripleConfig.AutoApprove,
+	)
+
+	// Create triple-shot session
+	tripleSession := orchestrator.NewTripleShotSession(task, tripleConfig)
+
+	// Link triple-shot session to main session for persistence
+	session.TripleShot = tripleSession
+
+	// Create coordinator with logger
+	coordinator := orchestrator.NewTripleShotCoordinator(orch, session, tripleSession, logger)
+
+	// Get terminal dimensions
+	if termWidth, termHeight, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+		contentWidth, contentHeight := tui.CalculateContentDimensions(termWidth, termHeight)
+		if contentWidth > 0 && contentHeight > 0 {
+			orch.SetDisplayDimensions(contentWidth, contentHeight)
+		}
+	}
+
+	// Launch TUI with triple-shot mode
+	app := tui.NewWithTripleShot(orch, session, coordinator, logger.WithSession(session.ID))
+	if err := app.Run(); err != nil {
+		return fmt.Errorf("TUI error: %w", err)
+	}
+
+	return nil
+}
+
+// promptTripleShotTask prompts the user to enter a task
+func promptTripleShotTask() (string, error) {
+	fmt.Println("\nTriple-Shot Mode")
+	fmt.Println("================")
+	fmt.Println("Enter a task for three Claude instances to solve independently.")
+	fmt.Println("A fourth instance will then evaluate all solutions and pick the best one.")
+	fmt.Println()
+	fmt.Print("Task: ")
+
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("failed to read input: %w", err)
+	}
+
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "", fmt.Errorf("task cannot be empty")
+	}
+
+	return input, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -186,6 +186,11 @@ type ExperimentalConfig struct {
 	// for the sidebar based on the task and Claude's initial output.
 	// Requires ANTHROPIC_API_KEY to be set. (default: false)
 	IntelligentNaming bool `mapstructure:"intelligent_naming"`
+
+	// TripleShot enables the triple-shot mode which spawns three parallel instances
+	// working on the same problem, then uses a judge instance to evaluate and select
+	// the best solution. (default: false)
+	TripleShot bool `mapstructure:"triple_shot"`
 }
 
 // ResolveWorktreeDir returns the resolved worktree directory path.
@@ -294,6 +299,7 @@ func Default() *Config {
 		},
 		Experimental: ExperimentalConfig{
 			IntelligentNaming: false, // Disabled by default until stable
+			TripleShot:        false, // Disabled by default until stable
 		},
 	}
 }
@@ -385,6 +391,7 @@ func SetDefaults() {
 
 	// Experimental defaults
 	viper.SetDefault("experimental.intelligent_naming", defaults.Experimental.IntelligentNaming)
+	viper.SetDefault("experimental.triple_shot", defaults.Experimental.TripleShot)
 }
 
 // Load reads the configuration from viper into a Config struct and validates it

--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -105,6 +105,9 @@ type Session struct {
 
 	// UltraPlan holds the ultra-plan session state (nil for regular sessions)
 	UltraPlan *UltraPlanSession `json:"ultra_plan,omitempty"`
+
+	// TripleShot holds the triple-shot session state (nil for regular sessions)
+	TripleShot *TripleShotSession `json:"triple_shot,omitempty"`
 }
 
 // NewSession creates a new session with a generated ID

--- a/internal/orchestrator/tripleshot.go
+++ b/internal/orchestrator/tripleshot.go
@@ -1,0 +1,483 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/logging"
+)
+
+// TripleShotPhase represents the current phase of a triple-shot session
+type TripleShotPhase string
+
+const (
+	// PhaseTripleShotWorking - three instances are working on the problem
+	PhaseTripleShotWorking TripleShotPhase = "working"
+	// PhaseTripleShotEvaluating - the judge instance is evaluating the solutions
+	PhaseTripleShotEvaluating TripleShotPhase = "evaluating"
+	// PhaseTripleShotComplete - evaluation is complete
+	PhaseTripleShotComplete TripleShotPhase = "complete"
+	// PhaseTripleShotFailed - something went wrong
+	PhaseTripleShotFailed TripleShotPhase = "failed"
+)
+
+// AttemptStatus represents the status of a triple-shot attempt
+type AttemptStatus string
+
+const (
+	// AttemptStatusPending - attempt has not started yet
+	AttemptStatusPending AttemptStatus = ""
+	// AttemptStatusWorking - attempt is actively working on the problem
+	AttemptStatusWorking AttemptStatus = "working"
+	// AttemptStatusCompleted - attempt has completed successfully
+	AttemptStatusCompleted AttemptStatus = "completed"
+	// AttemptStatusFailed - attempt has failed
+	AttemptStatusFailed AttemptStatus = "failed"
+)
+
+// MergeStrategy represents the judge's recommended approach for the solution
+type MergeStrategy string
+
+const (
+	// MergeStrategySelect - select one attempt's solution as the winner
+	MergeStrategySelect MergeStrategy = "select"
+	// MergeStrategyMerge - merge elements from multiple attempts
+	MergeStrategyMerge MergeStrategy = "merge"
+	// MergeStrategyCombine - combine all attempts into a unified solution
+	MergeStrategyCombine MergeStrategy = "combine"
+)
+
+// TripleShotConfig holds configuration for a triple-shot session
+type TripleShotConfig struct {
+	// AutoApprove skips user confirmation for applying the winning solution
+	AutoApprove bool `json:"auto_approve"`
+}
+
+// DefaultTripleShotConfig returns the default configuration
+func DefaultTripleShotConfig() TripleShotConfig {
+	return TripleShotConfig{
+		AutoApprove: false,
+	}
+}
+
+// TripleShotAttempt represents one of the three solution attempts
+type TripleShotAttempt struct {
+	InstanceID   string        `json:"instance_id"`
+	WorktreePath string        `json:"worktree_path"`
+	Branch       string        `json:"branch"`
+	Status       AttemptStatus `json:"status"`
+	StartedAt    *time.Time    `json:"started_at,omitempty"`
+	CompletedAt  *time.Time    `json:"completed_at,omitempty"`
+}
+
+// TripleShotEvaluation holds the judge's evaluation of the three attempts
+type TripleShotEvaluation struct {
+	WinnerIndex       int                     `json:"winner_index"`        // 0, 1, or 2 (-1 if merged)
+	MergeStrategy     MergeStrategy           `json:"merge_strategy"`      // Strategy for applying solution
+	Reasoning         string                  `json:"reasoning"`           // Explanation of the decision
+	AttemptEvaluation []AttemptEvaluationItem `json:"attempt_evaluations"` // Evaluation of each attempt
+	SuggestedChanges  []string                `json:"suggested_changes"`   // If merging, changes to make
+}
+
+// AttemptEvaluationItem holds the evaluation for a single attempt
+type AttemptEvaluationItem struct {
+	AttemptIndex int      `json:"attempt_index"`
+	Score        int      `json:"score"` // 1-10
+	Strengths    []string `json:"strengths"`
+	Weaknesses   []string `json:"weaknesses"`
+}
+
+// TripleShotSession represents a triple-shot orchestration session
+type TripleShotSession struct {
+	ID          string                `json:"id"`
+	Task        string                `json:"task"` // The original task/problem
+	Phase       TripleShotPhase       `json:"phase"`
+	Config      TripleShotConfig      `json:"config"`
+	Attempts    [3]TripleShotAttempt  `json:"attempts"`           // Exactly 3 attempts
+	JudgeID     string                `json:"judge_id,omitempty"` // Instance ID of the judge
+	Created     time.Time             `json:"created"`
+	StartedAt   *time.Time            `json:"started_at,omitempty"`
+	CompletedAt *time.Time            `json:"completed_at,omitempty"`
+	Evaluation  *TripleShotEvaluation `json:"evaluation,omitempty"` // Judge's evaluation
+	Error       string                `json:"error,omitempty"`      // Error message if failed
+}
+
+// NewTripleShotSession creates a new triple-shot session
+func NewTripleShotSession(task string, config TripleShotConfig) *TripleShotSession {
+	return &TripleShotSession{
+		ID:      generateID(),
+		Task:    task,
+		Phase:   PhaseTripleShotWorking,
+		Config:  config,
+		Created: time.Now(),
+	}
+}
+
+// AllAttemptsComplete returns true if all three attempts have completed (success or failure)
+func (s *TripleShotSession) AllAttemptsComplete() bool {
+	for _, attempt := range s.Attempts {
+		if attempt.Status == AttemptStatusWorking || attempt.Status == AttemptStatusPending {
+			return false
+		}
+	}
+	return true
+}
+
+// SuccessfulAttemptCount returns the number of attempts that completed successfully
+func (s *TripleShotSession) SuccessfulAttemptCount() int {
+	count := 0
+	for _, attempt := range s.Attempts {
+		if attempt.Status == AttemptStatusCompleted {
+			count++
+		}
+	}
+	return count
+}
+
+// TripleShotCompletionFileName is the sentinel file that attempts write when complete
+const TripleShotCompletionFileName = ".claudio-tripleshot-complete.json"
+
+// TripleShotCompletionFile represents the completion report written by an attempt
+type TripleShotCompletionFile struct {
+	AttemptIndex  int      `json:"attempt_index"`
+	Status        string   `json:"status"` // "complete" or "failed"
+	Summary       string   `json:"summary"`
+	FilesModified []string `json:"files_modified"`
+	Approach      string   `json:"approach"` // Description of the approach taken
+	Notes         string   `json:"notes,omitempty"`
+}
+
+// TripleShotCompletionFilePath returns the full path to the completion file
+func TripleShotCompletionFilePath(worktreePath string) string {
+	return filepath.Join(worktreePath, TripleShotCompletionFileName)
+}
+
+// ParseTripleShotCompletionFile reads and parses a triple-shot completion file
+func ParseTripleShotCompletionFile(worktreePath string) (*TripleShotCompletionFile, error) {
+	completionPath := TripleShotCompletionFilePath(worktreePath)
+	data, err := os.ReadFile(completionPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var completion TripleShotCompletionFile
+	if err := json.Unmarshal(data, &completion); err != nil {
+		return nil, fmt.Errorf("failed to parse triple-shot completion JSON: %w", err)
+	}
+
+	return &completion, nil
+}
+
+// TripleShotEvaluationFileName is the sentinel file that the judge writes when evaluation is complete
+const TripleShotEvaluationFileName = ".claudio-tripleshot-evaluation.json"
+
+// TripleShotEvaluationFilePath returns the full path to the evaluation file
+func TripleShotEvaluationFilePath(worktreePath string) string {
+	return filepath.Join(worktreePath, TripleShotEvaluationFileName)
+}
+
+// ParseTripleShotEvaluationFile reads and parses the judge's evaluation file
+func ParseTripleShotEvaluationFile(worktreePath string) (*TripleShotEvaluation, error) {
+	evalPath := TripleShotEvaluationFilePath(worktreePath)
+	data, err := os.ReadFile(evalPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var evaluation TripleShotEvaluation
+	if err := json.Unmarshal(data, &evaluation); err != nil {
+		return nil, fmt.Errorf("failed to parse triple-shot evaluation JSON: %w", err)
+	}
+
+	return &evaluation, nil
+}
+
+// ParseTripleShotEvaluationFromOutput extracts evaluation from Claude's output
+// It looks for JSON wrapped in <evaluation></evaluation> tags
+func ParseTripleShotEvaluationFromOutput(output string) (*TripleShotEvaluation, error) {
+	re := regexp.MustCompile(`(?s)<evaluation>\s*(.*?)\s*</evaluation>`)
+	matches := re.FindStringSubmatch(output)
+
+	if len(matches) < 2 {
+		return nil, fmt.Errorf("no evaluation found in output (expected <evaluation>JSON</evaluation>)")
+	}
+
+	jsonStr := strings.TrimSpace(matches[1])
+
+	var evaluation TripleShotEvaluation
+	if err := json.Unmarshal([]byte(jsonStr), &evaluation); err != nil {
+		return nil, fmt.Errorf("failed to parse evaluation JSON: %w", err)
+	}
+
+	return &evaluation, nil
+}
+
+// TripleShotManager manages the execution of a triple-shot session
+type TripleShotManager struct {
+	session     *TripleShotSession
+	orch        *Orchestrator
+	baseSession *Session
+	logger      *logging.Logger
+
+	// Event handling
+	eventCallback func(TripleShotEvent)
+
+	// Synchronization
+	mu sync.RWMutex
+}
+
+// TripleShotEventType represents the type of triple-shot event
+type TripleShotEventType string
+
+const (
+	EventTripleShotAttemptStarted   TripleShotEventType = "attempt_started"
+	EventTripleShotAttemptComplete  TripleShotEventType = "attempt_complete"
+	EventTripleShotAttemptFailed    TripleShotEventType = "attempt_failed"
+	EventTripleShotAllAttemptsReady TripleShotEventType = "all_attempts_ready"
+	EventTripleShotJudgeStarted     TripleShotEventType = "judge_started"
+	EventTripleShotEvaluationReady  TripleShotEventType = "evaluation_ready"
+	EventTripleShotPhaseChange      TripleShotEventType = "phase_change"
+)
+
+// TripleShotEvent represents an event from the triple-shot manager
+type TripleShotEvent struct {
+	Type         TripleShotEventType `json:"type"`
+	AttemptIndex int                 `json:"attempt_index,omitempty"` // 0-2 for attempt events
+	InstanceID   string              `json:"instance_id,omitempty"`
+	Message      string              `json:"message,omitempty"`
+	Timestamp    time.Time           `json:"timestamp"`
+}
+
+// NewTripleShotManager creates a new triple-shot manager
+func NewTripleShotManager(orch *Orchestrator, baseSession *Session, tripleSession *TripleShotSession, logger *logging.Logger) *TripleShotManager {
+	if logger == nil {
+		logger = logging.NopLogger()
+	}
+	return &TripleShotManager{
+		session:     tripleSession,
+		orch:        orch,
+		baseSession: baseSession,
+		logger:      logger.WithPhase("tripleshot"),
+	}
+}
+
+// SetEventCallback sets the callback for triple-shot events
+func (m *TripleShotManager) SetEventCallback(cb func(TripleShotEvent)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.eventCallback = cb
+}
+
+// Session returns the triple-shot session
+func (m *TripleShotManager) Session() *TripleShotSession {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.session
+}
+
+// emitEvent sends an event to the callback
+func (m *TripleShotManager) emitEvent(event TripleShotEvent) {
+	event.Timestamp = time.Now()
+
+	m.mu.RLock()
+	cb := m.eventCallback
+	m.mu.RUnlock()
+
+	if cb != nil {
+		cb(event)
+	}
+}
+
+// SetPhase updates the session phase and emits an event
+func (m *TripleShotManager) SetPhase(phase TripleShotPhase) {
+	m.mu.Lock()
+	m.session.Phase = phase
+	m.mu.Unlock()
+
+	m.emitEvent(TripleShotEvent{
+		Type:    EventTripleShotPhaseChange,
+		Message: string(phase),
+	})
+}
+
+// MarkAttemptComplete marks an attempt as completed
+func (m *TripleShotManager) MarkAttemptComplete(attemptIndex int) {
+	m.mu.Lock()
+	if attemptIndex >= 0 && attemptIndex < 3 {
+		m.session.Attempts[attemptIndex].Status = AttemptStatusCompleted
+		now := time.Now()
+		m.session.Attempts[attemptIndex].CompletedAt = &now
+	}
+	m.mu.Unlock()
+
+	m.logger.Info("attempt completed", "attempt_index", attemptIndex)
+
+	m.emitEvent(TripleShotEvent{
+		Type:         EventTripleShotAttemptComplete,
+		AttemptIndex: attemptIndex,
+	})
+}
+
+// MarkAttemptFailed marks an attempt as failed
+func (m *TripleShotManager) MarkAttemptFailed(attemptIndex int, reason string) {
+	m.mu.Lock()
+	if attemptIndex >= 0 && attemptIndex < 3 {
+		m.session.Attempts[attemptIndex].Status = AttemptStatusFailed
+		now := time.Now()
+		m.session.Attempts[attemptIndex].CompletedAt = &now
+	}
+	m.mu.Unlock()
+
+	m.logger.Info("attempt failed", "attempt_index", attemptIndex, "reason", reason)
+
+	m.emitEvent(TripleShotEvent{
+		Type:         EventTripleShotAttemptFailed,
+		AttemptIndex: attemptIndex,
+		Message:      reason,
+	})
+}
+
+// SetEvaluation sets the evaluation on the session
+func (m *TripleShotManager) SetEvaluation(eval *TripleShotEvaluation) {
+	m.mu.Lock()
+	m.session.Evaluation = eval
+	m.mu.Unlock()
+
+	m.logger.Info("evaluation set",
+		"winner_index", eval.WinnerIndex,
+		"strategy", eval.MergeStrategy,
+	)
+
+	m.emitEvent(TripleShotEvent{
+		Type:    EventTripleShotEvaluationReady,
+		Message: eval.Reasoning,
+	})
+}
+
+// TripleShotAttemptPromptTemplate is the prompt template for each attempt
+const TripleShotAttemptPromptTemplate = `You are one of three Claude instances working on the same problem.
+Your goal is to solve the problem using your own approach - be creative and thorough.
+
+## Task
+%s
+
+## Important Instructions
+
+1. **Solve the problem independently** - Don't try to coordinate with other instances
+2. **Use your best judgment** - Choose the approach you think is most appropriate
+3. **Document your approach** - Write clear commit messages and code comments
+4. **Be thorough** - Make sure your solution is complete and well-tested
+
+## Completion Protocol
+
+When your solution is complete, you MUST write a completion file:
+
+1. Use Write tool to create ` + "`" + TripleShotCompletionFileName + "`" + ` in your worktree root
+2. Include this JSON structure:
+` + "```json" + `
+{
+  "attempt_index": %d,
+  "status": "complete",
+  "summary": "Brief summary of what you implemented",
+  "files_modified": ["file1.go", "file2.go"],
+  "approach": "Description of the approach you took and why",
+  "notes": "Any additional notes or concerns"
+}
+` + "```" + `
+
+3. Set status to "complete" if you finished successfully, or "failed" if you couldn't complete the task
+4. The approach field is important - it helps the judge understand your solution
+
+This file signals that your work is done and provides context for evaluation.`
+
+// TripleShotJudgePromptTemplate is the prompt template for the judge instance
+const TripleShotJudgePromptTemplate = `You are a senior software architect evaluating three different solutions to the same problem.
+
+## Original Task
+%s
+
+## Solution Summaries
+
+### Attempt 1 (Instance %s)
+Branch: %s
+Working Directory: %s
+Completion Summary:
+%s
+
+### Attempt 2 (Instance %s)
+Branch: %s
+Working Directory: %s
+Completion Summary:
+%s
+
+### Attempt 3 (Instance %s)
+Branch: %s
+Working Directory: %s
+Completion Summary:
+%s
+
+## Your Task
+
+1. **Review each solution** - Examine the code changes in each branch
+2. **Evaluate** each solution on:
+   - Correctness: Does it solve the problem correctly?
+   - Code quality: Is the code clean, maintainable, and idiomatic?
+   - Completeness: Does it handle edge cases and error conditions?
+   - Testing: Are there appropriate tests?
+3. **Decide** which solution to use:
+   - **Select**: Choose one solution as the winner
+   - **Merge**: Combine the best parts of multiple solutions
+   - **Combine**: Create a hybrid that takes specific elements from each
+
+## Output
+
+Write your evaluation to ` + "`" + TripleShotEvaluationFileName + "`" + ` using this structure:
+` + "```json" + `
+{
+  "winner_index": 0,
+  "merge_strategy": "select",
+  "reasoning": "Explanation of your decision",
+  "attempt_evaluations": [
+    {
+      "attempt_index": 0,
+      "score": 8,
+      "strengths": ["Good error handling", "Clean code"],
+      "weaknesses": ["Missing edge case"]
+    },
+    {
+      "attempt_index": 1,
+      "score": 7,
+      "strengths": ["Comprehensive tests"],
+      "weaknesses": ["Complex implementation"]
+    },
+    {
+      "attempt_index": 2,
+      "score": 6,
+      "strengths": ["Simple approach"],
+      "weaknesses": ["No tests", "Missing error handling"]
+    }
+  ],
+  "suggested_changes": []
+}
+` + "```" + `
+
+### Fields:
+- **winner_index**: 0, 1, or 2 for the winning solution. Use -1 if merging multiple solutions.
+- **merge_strategy**: "select" (use one as-is), "merge" (combine changes), or "combine" (cherry-pick specific changes)
+- **reasoning**: Detailed explanation of your evaluation and decision
+- **attempt_evaluations**: Score and analysis for each attempt (1-10 scale)
+- **suggested_changes**: If merge_strategy is "merge" or "combine", list the specific changes to make
+
+## Helpful Commands
+
+To compare branches:
+- ` + "`" + `git diff main..branch-name` + "`" + ` - See changes from main
+- ` + "`" + `git log main..branch-name --oneline` + "`" + ` - See commits
+
+To review code in each worktree, you can navigate to the directories listed above.`

--- a/internal/orchestrator/tripleshot_coordinator.go
+++ b/internal/orchestrator/tripleshot_coordinator.go
@@ -1,0 +1,490 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/logging"
+)
+
+// TripleShotCoordinatorCallbacks holds callbacks for coordinator events
+type TripleShotCoordinatorCallbacks struct {
+	// OnPhaseChange is called when the triple-shot phase changes
+	OnPhaseChange func(phase TripleShotPhase)
+
+	// OnAttemptStart is called when an attempt begins
+	OnAttemptStart func(attemptIndex int, instanceID string)
+
+	// OnAttemptComplete is called when an attempt completes
+	OnAttemptComplete func(attemptIndex int)
+
+	// OnAttemptFailed is called when an attempt fails
+	OnAttemptFailed func(attemptIndex int, reason string)
+
+	// OnJudgeStart is called when the judge starts evaluation
+	OnJudgeStart func(instanceID string)
+
+	// OnEvaluationReady is called when evaluation is complete
+	OnEvaluationReady func(evaluation *TripleShotEvaluation)
+
+	// OnComplete is called when the entire triple-shot completes
+	OnComplete func(success bool, summary string)
+}
+
+// TripleShotCoordinator orchestrates the execution of a triple-shot session
+type TripleShotCoordinator struct {
+	manager     *TripleShotManager
+	orch        *Orchestrator
+	baseSession *Session
+	callbacks   *TripleShotCoordinatorCallbacks
+	logger      *logging.Logger
+
+	// Running state
+	ctx        context.Context
+	cancelFunc context.CancelFunc
+	wg         sync.WaitGroup
+	mu         sync.RWMutex
+
+	// Tracking
+	runningAttempts map[int]string // attemptIndex -> instanceID
+}
+
+// NewTripleShotCoordinator creates a new coordinator for a triple-shot session
+func NewTripleShotCoordinator(orch *Orchestrator, baseSession *Session, tripleSession *TripleShotSession, logger *logging.Logger) *TripleShotCoordinator {
+	if logger == nil {
+		logger = logging.NopLogger()
+	}
+	manager := NewTripleShotManager(orch, baseSession, tripleSession, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	sessionLogger := logger.WithSession(tripleSession.ID).WithPhase("tripleshot-coordinator")
+
+	return &TripleShotCoordinator{
+		manager:         manager,
+		orch:            orch,
+		baseSession:     baseSession,
+		logger:          sessionLogger,
+		ctx:             ctx,
+		cancelFunc:      cancel,
+		runningAttempts: make(map[int]string),
+	}
+}
+
+// SetCallbacks sets the coordinator callbacks
+func (c *TripleShotCoordinator) SetCallbacks(cb *TripleShotCoordinatorCallbacks) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.callbacks = cb
+}
+
+// Manager returns the underlying triple-shot manager
+func (c *TripleShotCoordinator) Manager() *TripleShotManager {
+	return c.manager
+}
+
+// Session returns the triple-shot session
+func (c *TripleShotCoordinator) Session() *TripleShotSession {
+	return c.manager.Session()
+}
+
+// notifyPhaseChange notifies callbacks of phase change
+func (c *TripleShotCoordinator) notifyPhaseChange(phase TripleShotPhase) {
+	session := c.Session()
+	fromPhase := session.Phase
+
+	c.manager.SetPhase(phase)
+
+	c.logger.Info("phase changed",
+		"from_phase", string(fromPhase),
+		"to_phase", string(phase),
+		"session_id", session.ID,
+	)
+
+	// Persist the phase change
+	if err := c.orch.SaveSession(); err != nil {
+		c.logger.Error("failed to persist phase change", "error", err)
+	}
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnPhaseChange != nil {
+		cb.OnPhaseChange(phase)
+	}
+}
+
+// notifyAttemptStart notifies callbacks of attempt start
+func (c *TripleShotCoordinator) notifyAttemptStart(attemptIndex int, instanceID string) {
+	c.logger.Info("attempt started",
+		"attempt_index", attemptIndex,
+		"instance_id", instanceID,
+	)
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnAttemptStart != nil {
+		cb.OnAttemptStart(attemptIndex, instanceID)
+	}
+}
+
+// notifyAttemptComplete notifies callbacks of attempt completion
+func (c *TripleShotCoordinator) notifyAttemptComplete(attemptIndex int) {
+	c.manager.MarkAttemptComplete(attemptIndex)
+
+	// Persist completion
+	if err := c.orch.SaveSession(); err != nil {
+		c.logger.Error("failed to persist attempt completion", "attempt_index", attemptIndex, "error", err)
+	}
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnAttemptComplete != nil {
+		cb.OnAttemptComplete(attemptIndex)
+	}
+}
+
+// notifyAttemptFailed notifies callbacks of attempt failure
+func (c *TripleShotCoordinator) notifyAttemptFailed(attemptIndex int, reason string) {
+	c.manager.MarkAttemptFailed(attemptIndex, reason)
+
+	// Persist failure
+	if err := c.orch.SaveSession(); err != nil {
+		c.logger.Error("failed to persist attempt failure", "attempt_index", attemptIndex, "error", err)
+	}
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnAttemptFailed != nil {
+		cb.OnAttemptFailed(attemptIndex, reason)
+	}
+}
+
+// notifyJudgeStart notifies callbacks of judge start
+func (c *TripleShotCoordinator) notifyJudgeStart(instanceID string) {
+	c.logger.Info("judge started", "instance_id", instanceID)
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnJudgeStart != nil {
+		cb.OnJudgeStart(instanceID)
+	}
+}
+
+// notifyEvaluationReady notifies callbacks of evaluation completion
+func (c *TripleShotCoordinator) notifyEvaluationReady(evaluation *TripleShotEvaluation) {
+	c.manager.SetEvaluation(evaluation)
+
+	// Persist evaluation
+	if err := c.orch.SaveSession(); err != nil {
+		c.logger.Error("failed to persist evaluation", "error", err)
+	}
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnEvaluationReady != nil {
+		cb.OnEvaluationReady(evaluation)
+	}
+}
+
+// notifyComplete notifies callbacks of completion
+func (c *TripleShotCoordinator) notifyComplete(success bool, summary string) {
+	c.logger.Info("triple-shot complete",
+		"success", success,
+		"summary", summary,
+	)
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnComplete != nil {
+		cb.OnComplete(success, summary)
+	}
+}
+
+// StartAttempts starts all three attempt instances in parallel
+func (c *TripleShotCoordinator) StartAttempts() error {
+	session := c.Session()
+	task := session.Task
+
+	c.logger.Info("starting triple-shot attempts", "task", truncateString(task, 100))
+
+	now := time.Now()
+	session.StartedAt = &now
+
+	// Create and start all three attempts
+	for i := range 3 {
+		prompt := fmt.Sprintf(TripleShotAttemptPromptTemplate, task, i)
+
+		// Create instance for this attempt
+		inst, err := c.orch.AddInstance(c.baseSession, prompt)
+		if err != nil {
+			return fmt.Errorf("failed to create attempt %d instance: %w", i, err)
+		}
+
+		// Record attempt info
+		session.Attempts[i] = TripleShotAttempt{
+			InstanceID:   inst.ID,
+			WorktreePath: inst.WorktreePath,
+			Branch:       inst.Branch,
+			Status:       AttemptStatusWorking,
+			StartedAt:    &now,
+		}
+
+		c.mu.Lock()
+		c.runningAttempts[i] = inst.ID
+		c.mu.Unlock()
+
+		// Start the instance
+		if err := c.orch.StartInstance(inst); err != nil {
+			return fmt.Errorf("failed to start attempt %d: %w", i, err)
+		}
+
+		c.notifyAttemptStart(i, inst.ID)
+	}
+
+	// Persist session state
+	if err := c.orch.SaveSession(); err != nil {
+		c.logger.Error("failed to persist session after starting attempts", "error", err)
+	}
+
+	return nil
+}
+
+// StartJudge starts the judge instance to evaluate the three attempts
+func (c *TripleShotCoordinator) StartJudge() error {
+	session := c.Session()
+
+	// Build the completion summaries for each attempt
+	var summaries [3]string
+	for i, attempt := range session.Attempts {
+		completion, err := ParseTripleShotCompletionFile(attempt.WorktreePath)
+		if err != nil {
+			c.logger.Warn("failed to read completion file for attempt",
+				"attempt_index", i,
+				"worktree_path", attempt.WorktreePath,
+				"error", err,
+			)
+			summaries[i] = fmt.Sprintf("(Unable to read completion file: %v)", err)
+		} else {
+			summaries[i] = fmt.Sprintf("Status: %s\nSummary: %s\nApproach: %s\nFiles Modified: %v",
+				completion.Status, completion.Summary, completion.Approach, completion.FilesModified)
+		}
+	}
+
+	// Build the judge prompt
+	prompt := fmt.Sprintf(TripleShotJudgePromptTemplate,
+		session.Task,
+		// Attempt 1
+		session.Attempts[0].InstanceID, session.Attempts[0].Branch, session.Attempts[0].WorktreePath, summaries[0],
+		// Attempt 2
+		session.Attempts[1].InstanceID, session.Attempts[1].Branch, session.Attempts[1].WorktreePath, summaries[1],
+		// Attempt 3
+		session.Attempts[2].InstanceID, session.Attempts[2].Branch, session.Attempts[2].WorktreePath, summaries[2],
+	)
+
+	// Create judge instance
+	inst, err := c.orch.AddInstance(c.baseSession, prompt)
+	if err != nil {
+		return fmt.Errorf("failed to create judge instance: %w", err)
+	}
+
+	session.JudgeID = inst.ID
+
+	// Transition to evaluating phase
+	c.notifyPhaseChange(PhaseTripleShotEvaluating)
+
+	// Start the judge instance
+	if err := c.orch.StartInstance(inst); err != nil {
+		return fmt.Errorf("failed to start judge instance: %w", err)
+	}
+
+	c.notifyJudgeStart(inst.ID)
+
+	// Persist session state
+	if err := c.orch.SaveSession(); err != nil {
+		c.logger.Error("failed to persist session after starting judge", "error", err)
+	}
+
+	return nil
+}
+
+// CheckAttemptCompletion checks if an attempt has written its completion file
+func (c *TripleShotCoordinator) CheckAttemptCompletion(attemptIndex int) (bool, error) {
+	session := c.Session()
+	if attemptIndex < 0 || attemptIndex >= 3 {
+		return false, fmt.Errorf("invalid attempt index: %d", attemptIndex)
+	}
+
+	attempt := session.Attempts[attemptIndex]
+	if attempt.WorktreePath == "" {
+		return false, nil
+	}
+
+	completionPath := TripleShotCompletionFilePath(attempt.WorktreePath)
+	_, err := os.Stat(completionPath)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	// Propagate actual errors (permission denied, I/O errors, etc.)
+	return false, fmt.Errorf("failed to check completion file: %w", err)
+}
+
+// CheckJudgeCompletion checks if the judge has written its evaluation file
+func (c *TripleShotCoordinator) CheckJudgeCompletion() (bool, error) {
+	session := c.Session()
+	if session.JudgeID == "" {
+		return false, nil
+	}
+
+	// Find the judge instance to get its worktree path
+	judgeInst := c.baseSession.GetInstance(session.JudgeID)
+	if judgeInst == nil {
+		return false, fmt.Errorf("judge instance %s not found", session.JudgeID)
+	}
+
+	evalPath := TripleShotEvaluationFilePath(judgeInst.WorktreePath)
+	_, err := os.Stat(evalPath)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	// Propagate actual errors (permission denied, I/O errors, etc.)
+	return false, fmt.Errorf("failed to check evaluation file: %w", err)
+}
+
+// ProcessAttemptCompletion handles when an attempt completes
+func (c *TripleShotCoordinator) ProcessAttemptCompletion(attemptIndex int) error {
+	if attemptIndex < 0 || attemptIndex >= 3 {
+		return fmt.Errorf("invalid attempt index: %d", attemptIndex)
+	}
+
+	session := c.Session()
+	attempt := session.Attempts[attemptIndex]
+
+	// Parse the completion file
+	completion, err := ParseTripleShotCompletionFile(attempt.WorktreePath)
+	if err != nil {
+		c.notifyAttemptFailed(attemptIndex, fmt.Sprintf("failed to parse completion file: %v", err))
+		return err
+	}
+
+	if completion.Status == "complete" {
+		c.notifyAttemptComplete(attemptIndex)
+	} else {
+		c.notifyAttemptFailed(attemptIndex, completion.Summary)
+	}
+
+	// Check if all attempts are complete
+	if session.AllAttemptsComplete() {
+		c.logger.Info("all attempts complete", "successful_count", session.SuccessfulAttemptCount())
+
+		// Only proceed to judge if we have at least 2 successful attempts
+		if session.SuccessfulAttemptCount() >= 2 {
+			c.manager.emitEvent(TripleShotEvent{
+				Type:    EventTripleShotAllAttemptsReady,
+				Message: "All attempts complete, ready for evaluation",
+			})
+		} else {
+			c.notifyPhaseChange(PhaseTripleShotFailed)
+			session.Error = "Fewer than 2 attempts succeeded"
+			return fmt.Errorf("fewer than 2 attempts succeeded")
+		}
+	}
+
+	return nil
+}
+
+// ProcessJudgeCompletion handles when the judge completes
+func (c *TripleShotCoordinator) ProcessJudgeCompletion() error {
+	session := c.Session()
+
+	// Find the judge instance
+	judgeInst := c.baseSession.GetInstance(session.JudgeID)
+	if judgeInst == nil {
+		return fmt.Errorf("judge instance not found")
+	}
+
+	// Parse the evaluation file
+	evaluation, err := ParseTripleShotEvaluationFile(judgeInst.WorktreePath)
+	if err != nil {
+		c.notifyPhaseChange(PhaseTripleShotFailed)
+		session.Error = fmt.Sprintf("failed to parse evaluation: %v", err)
+		return err
+	}
+
+	c.notifyEvaluationReady(evaluation)
+
+	// Transition to complete phase
+	now := time.Now()
+	session.CompletedAt = &now
+	c.notifyPhaseChange(PhaseTripleShotComplete)
+
+	// Build summary
+	var summary string
+	if evaluation.MergeStrategy == MergeStrategySelect {
+		if evaluation.WinnerIndex < 0 || evaluation.WinnerIndex >= 3 {
+			c.notifyPhaseChange(PhaseTripleShotFailed)
+			session.Error = fmt.Sprintf("invalid winner index: %d", evaluation.WinnerIndex)
+			return fmt.Errorf("invalid winner index in evaluation: %d", evaluation.WinnerIndex)
+		}
+		winnerAttempt := session.Attempts[evaluation.WinnerIndex]
+		summary = fmt.Sprintf("Selected attempt %d (branch: %s). Reasoning: %s",
+			evaluation.WinnerIndex+1, winnerAttempt.Branch, evaluation.Reasoning)
+	} else {
+		summary = fmt.Sprintf("Strategy: %s. Reasoning: %s", evaluation.MergeStrategy, evaluation.Reasoning)
+	}
+
+	c.notifyComplete(true, summary)
+
+	return nil
+}
+
+// Stop stops the triple-shot execution
+func (c *TripleShotCoordinator) Stop() {
+	c.cancelFunc()
+	c.wg.Wait()
+}
+
+// GetAttemptInstanceID returns the instance ID for an attempt
+func (c *TripleShotCoordinator) GetAttemptInstanceID(attemptIndex int) string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.runningAttempts[attemptIndex]
+}
+
+// GetWinningBranch returns the branch name of the winning solution
+// Returns empty string if evaluation is not complete or strategy is merge
+func (c *TripleShotCoordinator) GetWinningBranch() string {
+	session := c.Session()
+	if session.Evaluation == nil {
+		return ""
+	}
+	if session.Evaluation.MergeStrategy != MergeStrategySelect {
+		return ""
+	}
+	if session.Evaluation.WinnerIndex < 0 || session.Evaluation.WinnerIndex >= 3 {
+		return ""
+	}
+	return session.Attempts[session.Evaluation.WinnerIndex].Branch
+}

--- a/internal/orchestrator/tripleshot_test.go
+++ b/internal/orchestrator/tripleshot_test.go
@@ -1,0 +1,884 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewTripleShotSession(t *testing.T) {
+	task := "Implement a rate limiter"
+	config := DefaultTripleShotConfig()
+
+	session := NewTripleShotSession(task, config)
+
+	if session.ID == "" {
+		t.Error("session ID should not be empty")
+	}
+	if session.Task != task {
+		t.Errorf("session.Task = %q, want %q", session.Task, task)
+	}
+	if session.Phase != PhaseTripleShotWorking {
+		t.Errorf("session.Phase = %v, want %v", session.Phase, PhaseTripleShotWorking)
+	}
+	if session.Created.IsZero() {
+		t.Error("session.Created should not be zero")
+	}
+}
+
+func TestTripleShotSession_AllAttemptsComplete(t *testing.T) {
+	tests := []struct {
+		name     string
+		attempts [3]TripleShotAttempt
+		want     bool
+	}{
+		{
+			name: "no attempts complete",
+			attempts: [3]TripleShotAttempt{
+				{Status: AttemptStatusWorking},
+				{Status: AttemptStatusWorking},
+				{Status: AttemptStatusWorking},
+			},
+			want: false,
+		},
+		{
+			name: "some attempts complete",
+			attempts: [3]TripleShotAttempt{
+				{Status: AttemptStatusCompleted},
+				{Status: AttemptStatusWorking},
+				{Status: AttemptStatusCompleted},
+			},
+			want: false,
+		},
+		{
+			name: "all attempts complete",
+			attempts: [3]TripleShotAttempt{
+				{Status: AttemptStatusCompleted},
+				{Status: AttemptStatusCompleted},
+				{Status: AttemptStatusCompleted},
+			},
+			want: true,
+		},
+		{
+			name: "mixed completed and failed",
+			attempts: [3]TripleShotAttempt{
+				{Status: AttemptStatusCompleted},
+				{Status: AttemptStatusFailed},
+				{Status: AttemptStatusCompleted},
+			},
+			want: true,
+		},
+		{
+			name: "all failed",
+			attempts: [3]TripleShotAttempt{
+				{Status: AttemptStatusFailed},
+				{Status: AttemptStatusFailed},
+				{Status: AttemptStatusFailed},
+			},
+			want: true,
+		},
+		{
+			name: "one pending one working one complete",
+			attempts: [3]TripleShotAttempt{
+				{Status: AttemptStatusPending},
+				{Status: AttemptStatusWorking},
+				{Status: AttemptStatusCompleted},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := &TripleShotSession{
+				Attempts: tt.attempts,
+			}
+			got := session.AllAttemptsComplete()
+			if got != tt.want {
+				t.Errorf("AllAttemptsComplete() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTripleShotSession_SuccessfulAttemptCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		attempts [3]TripleShotAttempt
+		want     int
+	}{
+		{
+			name: "no successful attempts",
+			attempts: [3]TripleShotAttempt{
+				{Status: AttemptStatusWorking},
+				{Status: AttemptStatusFailed},
+				{Status: AttemptStatusWorking},
+			},
+			want: 0,
+		},
+		{
+			name: "one successful",
+			attempts: [3]TripleShotAttempt{
+				{Status: AttemptStatusCompleted},
+				{Status: AttemptStatusFailed},
+				{Status: AttemptStatusWorking},
+			},
+			want: 1,
+		},
+		{
+			name: "all successful",
+			attempts: [3]TripleShotAttempt{
+				{Status: AttemptStatusCompleted},
+				{Status: AttemptStatusCompleted},
+				{Status: AttemptStatusCompleted},
+			},
+			want: 3,
+		},
+		{
+			name: "two successful",
+			attempts: [3]TripleShotAttempt{
+				{Status: AttemptStatusCompleted},
+				{Status: AttemptStatusFailed},
+				{Status: AttemptStatusCompleted},
+			},
+			want: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := &TripleShotSession{
+				Attempts: tt.attempts,
+			}
+			got := session.SuccessfulAttemptCount()
+			if got != tt.want {
+				t.Errorf("SuccessfulAttemptCount() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTripleShotCompletionFile(t *testing.T) {
+	// Create a temporary directory
+	tmpDir, err := os.MkdirTemp("", "tripleshot-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	// Write a completion file
+	completion := TripleShotCompletionFile{
+		AttemptIndex:  1,
+		Status:        "complete",
+		Summary:       "Implemented rate limiter using token bucket algorithm",
+		FilesModified: []string{"ratelimiter.go", "ratelimiter_test.go"},
+		Approach:      "Used token bucket algorithm for its simplicity and effectiveness",
+		Notes:         "Added comprehensive tests",
+	}
+
+	completionPath := filepath.Join(tmpDir, TripleShotCompletionFileName)
+	data, err := json.MarshalIndent(completion, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal completion: %v", err)
+	}
+	if err := os.WriteFile(completionPath, data, 0644); err != nil {
+		t.Fatalf("failed to write completion file: %v", err)
+	}
+
+	// Parse it back
+	parsed, err := ParseTripleShotCompletionFile(tmpDir)
+	if err != nil {
+		t.Fatalf("ParseTripleShotCompletionFile() error = %v", err)
+	}
+
+	if parsed.AttemptIndex != completion.AttemptIndex {
+		t.Errorf("AttemptIndex = %d, want %d", parsed.AttemptIndex, completion.AttemptIndex)
+	}
+	if parsed.Status != completion.Status {
+		t.Errorf("Status = %q, want %q", parsed.Status, completion.Status)
+	}
+	if parsed.Summary != completion.Summary {
+		t.Errorf("Summary = %q, want %q", parsed.Summary, completion.Summary)
+	}
+	if len(parsed.FilesModified) != len(completion.FilesModified) {
+		t.Errorf("len(FilesModified) = %d, want %d", len(parsed.FilesModified), len(completion.FilesModified))
+	}
+}
+
+func TestParseTripleShotCompletionFile_NotFound(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "tripleshot-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	_, err = ParseTripleShotCompletionFile(tmpDir)
+	if err == nil {
+		t.Error("expected error when file doesn't exist")
+	}
+}
+
+func TestParseTripleShotCompletionFile_InvalidJSON(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "tripleshot-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	// Write invalid JSON to the completion file
+	completionPath := filepath.Join(tmpDir, TripleShotCompletionFileName)
+	if err := os.WriteFile(completionPath, []byte("{ invalid json }"), 0644); err != nil {
+		t.Fatalf("failed to write invalid completion file: %v", err)
+	}
+
+	_, err = ParseTripleShotCompletionFile(tmpDir)
+	if err == nil {
+		t.Error("expected error when file contains invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "failed to parse triple-shot completion JSON") {
+		t.Errorf("error message should mention JSON parsing failure, got: %v", err)
+	}
+}
+
+func TestParseTripleShotEvaluationFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "tripleshot-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	evaluation := TripleShotEvaluation{
+		WinnerIndex:   1,
+		MergeStrategy: MergeStrategySelect,
+		Reasoning:     "Attempt 2 had the cleanest implementation with comprehensive tests",
+		AttemptEvaluation: []AttemptEvaluationItem{
+			{AttemptIndex: 0, Score: 7, Strengths: []string{"Good error handling"}, Weaknesses: []string{"Missing tests"}},
+			{AttemptIndex: 1, Score: 9, Strengths: []string{"Clean code", "Good tests"}, Weaknesses: []string{}},
+			{AttemptIndex: 2, Score: 6, Strengths: []string{"Simple"}, Weaknesses: []string{"No error handling"}},
+		},
+	}
+
+	evalPath := filepath.Join(tmpDir, TripleShotEvaluationFileName)
+	data, err := json.MarshalIndent(evaluation, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal evaluation: %v", err)
+	}
+	if err := os.WriteFile(evalPath, data, 0644); err != nil {
+		t.Fatalf("failed to write evaluation file: %v", err)
+	}
+
+	parsed, err := ParseTripleShotEvaluationFile(tmpDir)
+	if err != nil {
+		t.Fatalf("ParseTripleShotEvaluationFile() error = %v", err)
+	}
+
+	if parsed.WinnerIndex != evaluation.WinnerIndex {
+		t.Errorf("WinnerIndex = %d, want %d", parsed.WinnerIndex, evaluation.WinnerIndex)
+	}
+	if parsed.MergeStrategy != evaluation.MergeStrategy {
+		t.Errorf("MergeStrategy = %q, want %q", parsed.MergeStrategy, evaluation.MergeStrategy)
+	}
+	if len(parsed.AttemptEvaluation) != len(evaluation.AttemptEvaluation) {
+		t.Errorf("len(AttemptEvaluation) = %d, want %d", len(parsed.AttemptEvaluation), len(evaluation.AttemptEvaluation))
+	}
+}
+
+func TestParseTripleShotEvaluationFile_InvalidJSON(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "tripleshot-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	// Write invalid JSON to the evaluation file
+	evalPath := filepath.Join(tmpDir, TripleShotEvaluationFileName)
+	if err := os.WriteFile(evalPath, []byte("{ invalid json }"), 0644); err != nil {
+		t.Fatalf("failed to write invalid evaluation file: %v", err)
+	}
+
+	_, err = ParseTripleShotEvaluationFile(tmpDir)
+	if err == nil {
+		t.Error("expected error when file contains invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "failed to parse triple-shot evaluation JSON") {
+		t.Errorf("error message should mention JSON parsing failure, got: %v", err)
+	}
+}
+
+func TestParseTripleShotEvaluationFromOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		want    *TripleShotEvaluation
+		wantErr bool
+	}{
+		{
+			name: "valid evaluation",
+			output: `Some Claude output text here...
+<evaluation>
+{
+  "winner_index": 0,
+  "merge_strategy": "select",
+  "reasoning": "Attempt 1 is best",
+  "attempt_evaluations": []
+}
+</evaluation>
+More text after...`,
+			want: &TripleShotEvaluation{
+				WinnerIndex:       0,
+				MergeStrategy:     "select",
+				Reasoning:         "Attempt 1 is best",
+				AttemptEvaluation: []AttemptEvaluationItem{},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "no evaluation tag",
+			output:  "Just some regular output without evaluation tags",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "invalid JSON inside tag",
+			output: `<evaluation>
+not valid json
+</evaluation>`,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "evaluation with whitespace",
+			output: `<evaluation>
+  {
+    "winner_index": 2,
+    "merge_strategy": "merge",
+    "reasoning": "Combined approach"
+  }
+</evaluation>`,
+			want: &TripleShotEvaluation{
+				WinnerIndex:   2,
+				MergeStrategy: "merge",
+				Reasoning:     "Combined approach",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseTripleShotEvaluationFromOutput(tt.output)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseTripleShotEvaluationFromOutput() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.want != nil {
+				if got.WinnerIndex != tt.want.WinnerIndex {
+					t.Errorf("WinnerIndex = %d, want %d", got.WinnerIndex, tt.want.WinnerIndex)
+				}
+				if got.MergeStrategy != tt.want.MergeStrategy {
+					t.Errorf("MergeStrategy = %q, want %q", got.MergeStrategy, tt.want.MergeStrategy)
+				}
+			}
+		})
+	}
+}
+
+func TestTripleShotManager_MarkAttemptComplete(t *testing.T) {
+	session := NewTripleShotSession("test task", DefaultTripleShotConfig())
+	session.Attempts[0] = TripleShotAttempt{InstanceID: "inst-1", Status: AttemptStatusWorking}
+	session.Attempts[1] = TripleShotAttempt{InstanceID: "inst-2", Status: AttemptStatusWorking}
+	session.Attempts[2] = TripleShotAttempt{InstanceID: "inst-3", Status: AttemptStatusWorking}
+
+	manager := NewTripleShotManager(nil, nil, session, nil)
+
+	// Mark attempt 1 complete
+	manager.MarkAttemptComplete(1)
+
+	if session.Attempts[1].Status != AttemptStatusCompleted {
+		t.Errorf("attempt 1 status = %q, want %q", session.Attempts[1].Status, AttemptStatusCompleted)
+	}
+	if session.Attempts[1].CompletedAt == nil {
+		t.Error("attempt 1 CompletedAt should not be nil")
+	}
+
+	// Other attempts should be unchanged
+	if session.Attempts[0].Status != AttemptStatusWorking {
+		t.Errorf("attempt 0 status = %q, want %q", session.Attempts[0].Status, AttemptStatusWorking)
+	}
+	if session.Attempts[2].Status != AttemptStatusWorking {
+		t.Errorf("attempt 2 status = %q, want %q", session.Attempts[2].Status, AttemptStatusWorking)
+	}
+}
+
+func TestTripleShotManager_MarkAttemptFailed(t *testing.T) {
+	session := NewTripleShotSession("test task", DefaultTripleShotConfig())
+	session.Attempts[0] = TripleShotAttempt{InstanceID: "inst-1", Status: AttemptStatusWorking}
+	session.Attempts[1] = TripleShotAttempt{InstanceID: "inst-2", Status: AttemptStatusWorking}
+	session.Attempts[2] = TripleShotAttempt{InstanceID: "inst-3", Status: AttemptStatusWorking}
+
+	manager := NewTripleShotManager(nil, nil, session, nil)
+
+	manager.MarkAttemptFailed(0, "timeout exceeded")
+
+	if session.Attempts[0].Status != AttemptStatusFailed {
+		t.Errorf("attempt 0 status = %q, want %q", session.Attempts[0].Status, AttemptStatusFailed)
+	}
+	if session.Attempts[0].CompletedAt == nil {
+		t.Error("attempt 0 CompletedAt should not be nil")
+	}
+}
+
+func TestTripleShotManager_SetPhase(t *testing.T) {
+	session := NewTripleShotSession("test task", DefaultTripleShotConfig())
+	manager := NewTripleShotManager(nil, nil, session, nil)
+
+	var receivedEvent TripleShotEvent
+	manager.SetEventCallback(func(event TripleShotEvent) {
+		receivedEvent = event
+	})
+
+	manager.SetPhase(PhaseTripleShotEvaluating)
+
+	if session.Phase != PhaseTripleShotEvaluating {
+		t.Errorf("session.Phase = %v, want %v", session.Phase, PhaseTripleShotEvaluating)
+	}
+	if receivedEvent.Type != EventTripleShotPhaseChange {
+		t.Errorf("event type = %v, want %v", receivedEvent.Type, EventTripleShotPhaseChange)
+	}
+	if receivedEvent.Message != string(PhaseTripleShotEvaluating) {
+		t.Errorf("event message = %q, want %q", receivedEvent.Message, string(PhaseTripleShotEvaluating))
+	}
+}
+
+func TestTripleShotManager_SetEvaluation(t *testing.T) {
+	session := NewTripleShotSession("test task", DefaultTripleShotConfig())
+	manager := NewTripleShotManager(nil, nil, session, nil)
+
+	var receivedEvent TripleShotEvent
+	manager.SetEventCallback(func(event TripleShotEvent) {
+		receivedEvent = event
+	})
+
+	eval := &TripleShotEvaluation{
+		WinnerIndex:   0,
+		MergeStrategy: MergeStrategySelect,
+		Reasoning:     "Best implementation",
+	}
+
+	manager.SetEvaluation(eval)
+
+	if session.Evaluation == nil {
+		t.Error("session.Evaluation should not be nil")
+	}
+	if session.Evaluation.WinnerIndex != eval.WinnerIndex {
+		t.Errorf("WinnerIndex = %d, want %d", session.Evaluation.WinnerIndex, eval.WinnerIndex)
+	}
+	if receivedEvent.Type != EventTripleShotEvaluationReady {
+		t.Errorf("event type = %v, want %v", receivedEvent.Type, EventTripleShotEvaluationReady)
+	}
+}
+
+func TestTripleShotConfig_Default(t *testing.T) {
+	config := DefaultTripleShotConfig()
+
+	if config.AutoApprove {
+		t.Error("default AutoApprove should be false")
+	}
+}
+
+func TestTripleShotPhases(t *testing.T) {
+	// Verify phase constants are distinct
+	phases := []TripleShotPhase{
+		PhaseTripleShotWorking,
+		PhaseTripleShotEvaluating,
+		PhaseTripleShotComplete,
+		PhaseTripleShotFailed,
+	}
+
+	seen := make(map[TripleShotPhase]bool)
+	for _, phase := range phases {
+		if seen[phase] {
+			t.Errorf("duplicate phase constant: %v", phase)
+		}
+		seen[phase] = true
+	}
+}
+
+func TestTripleShotAttemptPromptTemplate(t *testing.T) {
+	// Verify the template contains expected placeholders
+	if len(TripleShotAttemptPromptTemplate) == 0 {
+		t.Error("TripleShotAttemptPromptTemplate should not be empty")
+	}
+	if !strings.Contains(TripleShotAttemptPromptTemplate, "%s") {
+		t.Error("template should contain task placeholder")
+	}
+	if !strings.Contains(TripleShotAttemptPromptTemplate, "%d") {
+		t.Error("template should contain attempt index placeholder")
+	}
+	if !strings.Contains(TripleShotAttemptPromptTemplate, TripleShotCompletionFileName) {
+		t.Error("template should reference completion file name")
+	}
+}
+
+func TestTripleShotJudgePromptTemplate(t *testing.T) {
+	if len(TripleShotJudgePromptTemplate) == 0 {
+		t.Error("TripleShotJudgePromptTemplate should not be empty")
+	}
+	if !strings.Contains(TripleShotJudgePromptTemplate, TripleShotEvaluationFileName) {
+		t.Error("template should reference evaluation file name")
+	}
+}
+
+func TestTripleShotAttempt_Timestamps(t *testing.T) {
+	now := time.Now()
+	later := now.Add(5 * time.Minute)
+
+	attempt := TripleShotAttempt{
+		InstanceID:   "test-id",
+		Status:       AttemptStatusCompleted,
+		StartedAt:    &now,
+		CompletedAt:  &later,
+		WorktreePath: "/tmp/test",
+		Branch:       "test-branch",
+	}
+
+	if attempt.StartedAt == nil {
+		t.Error("StartedAt should not be nil")
+	}
+	if attempt.CompletedAt == nil {
+		t.Error("CompletedAt should not be nil")
+	}
+	if !attempt.CompletedAt.After(*attempt.StartedAt) {
+		t.Error("CompletedAt should be after StartedAt")
+	}
+}
+
+// TestTripleShotCoordinator_CheckAttemptCompletion tests the CheckAttemptCompletion method
+func TestTripleShotCoordinator_CheckAttemptCompletion(t *testing.T) {
+	tests := []struct {
+		name         string
+		attemptIndex int
+		setupFunc    func(worktree string)
+		wantComplete bool
+		wantErr      bool
+		errSubstring string
+	}{
+		{
+			name:         "invalid index negative",
+			attemptIndex: -1,
+			wantComplete: false,
+			wantErr:      true,
+			errSubstring: "invalid attempt index",
+		},
+		{
+			name:         "invalid index too large",
+			attemptIndex: 3,
+			wantComplete: false,
+			wantErr:      true,
+			errSubstring: "invalid attempt index",
+		},
+		{
+			name:         "valid index no completion file",
+			attemptIndex: 0,
+			wantComplete: false,
+			wantErr:      false,
+		},
+		{
+			name:         "valid index with completion file",
+			attemptIndex: 1,
+			setupFunc: func(worktree string) {
+				completion := TripleShotCompletionFile{
+					Status:  "complete",
+					Summary: "Test completed",
+				}
+				data, _ := json.Marshal(completion)
+				_ = os.WriteFile(filepath.Join(worktree, TripleShotCompletionFileName), data, 0644)
+			},
+			wantComplete: true,
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp directory for worktree
+			tmpDir := t.TempDir()
+
+			// Create coordinator with minimal setup
+			baseSession := &Session{ID: "test-session"}
+			tripleSession := NewTripleShotSession("test task", DefaultTripleShotConfig())
+
+			// Set up attempts with worktree paths
+			for i := range 3 {
+				tripleSession.Attempts[i] = TripleShotAttempt{
+					InstanceID:   "inst-" + string(rune('0'+i)),
+					WorktreePath: filepath.Join(tmpDir, "attempt-"+string(rune('0'+i))),
+					Status:       AttemptStatusWorking,
+				}
+				_ = os.MkdirAll(tripleSession.Attempts[i].WorktreePath, 0755)
+			}
+
+			// Run setup if provided
+			if tt.setupFunc != nil && tt.attemptIndex >= 0 && tt.attemptIndex < 3 {
+				tt.setupFunc(tripleSession.Attempts[tt.attemptIndex].WorktreePath)
+			}
+
+			coordinator := &TripleShotCoordinator{
+				manager:     NewTripleShotManager(nil, baseSession, tripleSession, nil),
+				baseSession: baseSession,
+			}
+
+			complete, err := coordinator.CheckAttemptCompletion(tt.attemptIndex)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				} else if tt.errSubstring != "" && !strings.Contains(err.Error(), tt.errSubstring) {
+					t.Errorf("error = %q, want substring %q", err.Error(), tt.errSubstring)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if complete != tt.wantComplete {
+				t.Errorf("complete = %v, want %v", complete, tt.wantComplete)
+			}
+		})
+	}
+}
+
+// TestTripleShotCoordinator_ProcessAttemptCompletion_BoundsCheck tests the bounds checking
+func TestTripleShotCoordinator_ProcessAttemptCompletion_BoundsCheck(t *testing.T) {
+	tests := []struct {
+		name         string
+		attemptIndex int
+		wantErr      bool
+		errSubstring string
+	}{
+		{
+			name:         "negative index",
+			attemptIndex: -1,
+			wantErr:      true,
+			errSubstring: "invalid attempt index",
+		},
+		{
+			name:         "index too large",
+			attemptIndex: 3,
+			wantErr:      true,
+			errSubstring: "invalid attempt index",
+		},
+		{
+			name:         "index at boundary",
+			attemptIndex: 4,
+			wantErr:      true,
+			errSubstring: "invalid attempt index",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseSession := &Session{ID: "test-session"}
+			tripleSession := NewTripleShotSession("test task", DefaultTripleShotConfig())
+
+			coordinator := &TripleShotCoordinator{
+				manager:     NewTripleShotManager(nil, baseSession, tripleSession, nil),
+				baseSession: baseSession,
+			}
+
+			err := coordinator.ProcessAttemptCompletion(tt.attemptIndex)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				} else if tt.errSubstring != "" && !strings.Contains(err.Error(), tt.errSubstring) {
+					t.Errorf("error = %q, want substring %q", err.Error(), tt.errSubstring)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestTripleShotCoordinator_GetWinningBranch tests the GetWinningBranch method
+func TestTripleShotCoordinator_GetWinningBranch(t *testing.T) {
+	tests := []struct {
+		name       string
+		evaluation *TripleShotEvaluation
+		attempts   [3]TripleShotAttempt
+		wantBranch string
+	}{
+		{
+			name:       "no evaluation",
+			evaluation: nil,
+			wantBranch: "",
+		},
+		{
+			name: "merge strategy not select",
+			evaluation: &TripleShotEvaluation{
+				MergeStrategy: MergeStrategyMerge,
+				WinnerIndex:   0,
+			},
+			wantBranch: "",
+		},
+		{
+			name: "winner index negative",
+			evaluation: &TripleShotEvaluation{
+				MergeStrategy: MergeStrategySelect,
+				WinnerIndex:   -1,
+			},
+			wantBranch: "",
+		},
+		{
+			name: "winner index too large",
+			evaluation: &TripleShotEvaluation{
+				MergeStrategy: MergeStrategySelect,
+				WinnerIndex:   3,
+			},
+			wantBranch: "",
+		},
+		{
+			name: "valid winner index 0",
+			evaluation: &TripleShotEvaluation{
+				MergeStrategy: MergeStrategySelect,
+				WinnerIndex:   0,
+			},
+			attempts: [3]TripleShotAttempt{
+				{Branch: "branch-0"},
+				{Branch: "branch-1"},
+				{Branch: "branch-2"},
+			},
+			wantBranch: "branch-0",
+		},
+		{
+			name: "valid winner index 2",
+			evaluation: &TripleShotEvaluation{
+				MergeStrategy: MergeStrategySelect,
+				WinnerIndex:   2,
+			},
+			attempts: [3]TripleShotAttempt{
+				{Branch: "branch-0"},
+				{Branch: "branch-1"},
+				{Branch: "branch-2"},
+			},
+			wantBranch: "branch-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseSession := &Session{ID: "test-session"}
+			tripleSession := NewTripleShotSession("test task", DefaultTripleShotConfig())
+			tripleSession.Evaluation = tt.evaluation
+			tripleSession.Attempts = tt.attempts
+
+			coordinator := &TripleShotCoordinator{
+				manager:     NewTripleShotManager(nil, baseSession, tripleSession, nil),
+				baseSession: baseSession,
+			}
+
+			got := coordinator.GetWinningBranch()
+			if got != tt.wantBranch {
+				t.Errorf("GetWinningBranch() = %q, want %q", got, tt.wantBranch)
+			}
+		})
+	}
+}
+
+// TestTripleShotCoordinator_CheckJudgeCompletion tests the CheckJudgeCompletion method
+func TestTripleShotCoordinator_CheckJudgeCompletion(t *testing.T) {
+	tests := []struct {
+		name         string
+		judgeID      string
+		setupFunc    func(session *Session, worktree string)
+		wantComplete bool
+		wantErr      bool
+	}{
+		{
+			name:         "no judge ID",
+			judgeID:      "",
+			wantComplete: false,
+			wantErr:      false,
+		},
+		{
+			name:    "judge instance not found",
+			judgeID: "nonexistent",
+			setupFunc: func(session *Session, worktree string) {
+				// Don't add the instance to the session
+			},
+			wantComplete: false,
+			wantErr:      true,
+		},
+		{
+			name:    "judge instance found no evaluation file",
+			judgeID: "judge-1",
+			setupFunc: func(session *Session, worktree string) {
+				session.Instances = append(session.Instances, &Instance{
+					ID:           "judge-1",
+					WorktreePath: worktree,
+				})
+			},
+			wantComplete: false,
+			wantErr:      false,
+		},
+		{
+			name:    "judge instance found with evaluation file",
+			judgeID: "judge-2",
+			setupFunc: func(session *Session, worktree string) {
+				session.Instances = append(session.Instances, &Instance{
+					ID:           "judge-2",
+					WorktreePath: worktree,
+				})
+				// Write evaluation file
+				eval := TripleShotEvaluation{
+					WinnerIndex:   1,
+					MergeStrategy: MergeStrategySelect,
+					Reasoning:     "Test reasoning",
+				}
+				data, _ := json.Marshal(eval)
+				_ = os.WriteFile(filepath.Join(worktree, TripleShotEvaluationFileName), data, 0644)
+			},
+			wantComplete: true,
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			baseSession := &Session{
+				ID:        "test-session",
+				Instances: []*Instance{},
+			}
+			tripleSession := NewTripleShotSession("test task", DefaultTripleShotConfig())
+			tripleSession.JudgeID = tt.judgeID
+
+			if tt.setupFunc != nil {
+				tt.setupFunc(baseSession, tmpDir)
+			}
+
+			coordinator := &TripleShotCoordinator{
+				manager:     NewTripleShotManager(nil, baseSession, tripleSession, nil),
+				baseSession: baseSession,
+			}
+
+			complete, err := coordinator.CheckJudgeCompletion()
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if complete != tt.wantComplete {
+				t.Errorf("complete = %v, want %v", complete, tt.wantComplete)
+			}
+		})
+	}
+}

--- a/internal/tui/command/handler_test.go
+++ b/internal/tui/command/handler_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Iron-Ham/claudio/internal/conflict"
 	"github.com/Iron-Ham/claudio/internal/logging"
 	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/spf13/viper"
 )
 
 // mockDeps implements Dependencies for testing
@@ -36,6 +37,7 @@ type mockDeps struct {
 	diffVisible      bool
 	diffContent      string
 	ultraPlanMode    bool
+	tripleShotMode   bool
 	ultraCoordinator *orchestrator.Coordinator
 	logger           *logging.Logger
 	startTime        time.Time
@@ -50,6 +52,7 @@ func (m *mockDeps) IsTerminalVisible() bool                     { return m.termi
 func (m *mockDeps) IsDiffVisible() bool                         { return m.diffVisible }
 func (m *mockDeps) GetDiffContent() string                      { return m.diffContent }
 func (m *mockDeps) IsUltraPlanMode() bool                       { return m.ultraPlanMode }
+func (m *mockDeps) IsTripleShotMode() bool                      { return m.tripleShotMode }
 func (m *mockDeps) GetUltraPlanCoordinator() *orchestrator.Coordinator {
 	return m.ultraCoordinator
 }
@@ -915,6 +918,105 @@ func TestClearCompletedNoOrchestrator(t *testing.T) {
 		if result.ErrorMessage == "" {
 			t.Error("expected error without session")
 		}
+	})
+}
+
+// TestTripleShotCommand tests the tripleshot command with config check
+func TestTripleShotCommand(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		// Reset viper to ensure clean state
+		viper.Reset()
+
+		h := New()
+		deps := newMockDeps()
+
+		result := h.Execute("tripleshot", deps)
+
+		if result.ErrorMessage == "" {
+			t.Error("expected error when triple-shot is disabled")
+		}
+		if result.ErrorMessage != "Triple-shot mode is disabled. Enable it in :config under Experimental" {
+			t.Errorf("unexpected error message: %q", result.ErrorMessage)
+		}
+		if result.StartTripleShot != nil {
+			t.Error("StartTripleShot should be nil when disabled")
+		}
+	})
+
+	t.Run("enabled via config", func(t *testing.T) {
+		// Reset and enable triple-shot
+		viper.Reset()
+		viper.Set("experimental.triple_shot", true)
+
+		h := New()
+		deps := newMockDeps()
+
+		result := h.Execute("tripleshot", deps)
+
+		if result.ErrorMessage != "" {
+			t.Errorf("unexpected error: %q", result.ErrorMessage)
+		}
+		if result.StartTripleShot == nil || !*result.StartTripleShot {
+			t.Error("expected StartTripleShot to be true")
+		}
+		if result.InfoMessage != "Enter a task for triple-shot mode" {
+			t.Errorf("unexpected info message: %q", result.InfoMessage)
+		}
+
+		// Clean up
+		viper.Reset()
+	})
+
+	t.Run("blocked in ultraplan mode", func(t *testing.T) {
+		viper.Reset()
+		viper.Set("experimental.triple_shot", true)
+
+		h := New()
+		deps := newMockDeps()
+		deps.ultraPlanMode = true
+
+		result := h.Execute("tripleshot", deps)
+
+		if result.ErrorMessage != "Cannot start triple-shot while in ultraplan mode" {
+			t.Errorf("expected ultraplan mode error, got: %q", result.ErrorMessage)
+		}
+
+		viper.Reset()
+	})
+
+	t.Run("blocked when already in triple-shot mode", func(t *testing.T) {
+		viper.Reset()
+		viper.Set("experimental.triple_shot", true)
+
+		h := New()
+		deps := newMockDeps()
+		deps.tripleShotMode = true
+
+		result := h.Execute("tripleshot", deps)
+
+		if result.ErrorMessage != "Already in triple-shot mode" {
+			t.Errorf("expected already in mode error, got: %q", result.ErrorMessage)
+		}
+
+		viper.Reset()
+	})
+
+	t.Run("aliases work", func(t *testing.T) {
+		viper.Reset()
+		viper.Set("experimental.triple_shot", true)
+
+		h := New()
+		deps := newMockDeps()
+
+		aliases := []string{"tripleshot", "triple", "3shot"}
+		for _, alias := range aliases {
+			result := h.Execute(alias, deps)
+			if result.StartTripleShot == nil || !*result.StartTripleShot {
+				t.Errorf("alias %q should start triple-shot mode", alias)
+			}
+		}
+
+		viper.Reset()
 	})
 }
 

--- a/internal/tui/config/config.go
+++ b/internal/tui/config/config.go
@@ -333,6 +333,13 @@ func New() Model {
 					Type:        "bool",
 					Category:    "experimental",
 				},
+				{
+					Key:         "experimental.triple_shot",
+					Label:       "Triple-Shot Mode",
+					Description: "Enable :tripleshot command to spawn 3 parallel attempts with a judge evaluator",
+					Type:        "bool",
+					Category:    "experimental",
+				},
 			},
 		},
 	}
@@ -802,6 +809,7 @@ func (m *Model) resetCurrentToDefault() {
 		"paths.worktree_dir": defaults.Paths.WorktreeDir,
 		// Experimental
 		"experimental.intelligent_naming": defaults.Experimental.IntelligentNaming,
+		"experimental.triple_shot":        defaults.Experimental.TripleShot,
 	}
 
 	if defaultVal, ok := defaultValues[item.Key]; ok {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -90,6 +90,9 @@ type Model struct {
 	// Ultra-plan mode (nil if not in ultra-plan mode)
 	ultraPlan *UltraPlanState
 
+	// Triple-shot mode (nil if not in triple-shot mode)
+	tripleShot *TripleShotState
+
 	// Plan editor mode (nil if not in plan editor mode)
 	planEditor *PlanEditorState
 
@@ -107,9 +110,13 @@ type Model struct {
 	// Dependent task state (for :chain command - adding a task that depends on another)
 	addingDependentTask   bool   // When true, taskInput will create a dependent task
 	dependentOnInstanceID string // The instance ID that the new task will depend on
-	errorMessage          string
-	infoMessage           string // Non-error status message
-	inputMode             bool   // When true, all keys are forwarded to the active instance's tmux session
+
+	// Triple-shot task state (for :tripleshot command)
+	startingTripleShot bool // When true, taskInput will start a triple-shot session
+
+	errorMessage string
+	infoMessage  string // Non-error status message
+	inputMode    bool   // When true, all keys are forwarded to the active instance's tmux session
 
 	// Command mode state (vim-style ex commands with ':' prefix)
 	commandMode   bool   // When true, we're typing a command after ':'
@@ -161,6 +168,11 @@ type Model struct {
 // IsUltraPlanMode returns true if the model is in ultra-plan mode
 func (m Model) IsUltraPlanMode() bool {
 	return m.ultraPlan != nil
+}
+
+// IsTripleShotMode returns true if the model is in triple-shot mode
+func (m Model) IsTripleShotMode() bool {
+	return m.tripleShot != nil
 }
 
 // IsPlanEditorActive returns true if the plan editor is currently active and visible

--- a/internal/tui/tripleshot.go
+++ b/internal/tui/tripleshot.go
@@ -1,0 +1,120 @@
+package tui
+
+import (
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/tui/view"
+)
+
+// TripleShotState is an alias to the view package's TripleShotState.
+// This allows the main tui package to use the state without importing view.
+type TripleShotState = view.TripleShotState
+
+// checkForTripleShotCompletion checks if any triple-shot attempts or the judge have completed.
+// This is called from the tick handler to poll for completion files.
+func (m *Model) checkForTripleShotCompletion() {
+	if m.tripleShot == nil || m.tripleShot.Coordinator == nil {
+		return
+	}
+
+	coordinator := m.tripleShot.Coordinator
+	session := coordinator.Session()
+	if session == nil {
+		return
+	}
+
+	switch session.Phase {
+	case orchestrator.PhaseTripleShotWorking:
+		m.checkTripleShotAttempts(coordinator, session)
+	case orchestrator.PhaseTripleShotEvaluating:
+		m.checkTripleShotJudge(coordinator)
+	case orchestrator.PhaseTripleShotComplete:
+		m.handleTripleShotComplete(session)
+	case orchestrator.PhaseTripleShotFailed:
+		m.handleTripleShotFailed(session)
+	}
+}
+
+// checkTripleShotAttempts checks if any attempts have completed their work
+func (m *Model) checkTripleShotAttempts(coordinator *orchestrator.TripleShotCoordinator, session *orchestrator.TripleShotSession) {
+	allComplete := true
+	for i := range 3 {
+		attempt := session.Attempts[i]
+		if attempt.Status == orchestrator.AttemptStatusWorking {
+			complete, err := coordinator.CheckAttemptCompletion(i)
+			if err != nil {
+				if m.logger != nil {
+					m.logger.Warn("failed to check attempt completion",
+						"attempt_index", i,
+						"error", err,
+					)
+				}
+				continue
+			}
+			if complete {
+				if err := coordinator.ProcessAttemptCompletion(i); err != nil {
+					if m.logger != nil {
+						m.logger.Error("failed to process attempt completion",
+							"attempt_index", i,
+							"error", err,
+						)
+					}
+				} else {
+					m.infoMessage = "Attempt completed - checking progress..."
+				}
+			} else {
+				allComplete = false
+			}
+		}
+	}
+
+	// If all attempts are complete and we haven't started the judge yet, start it
+	if allComplete && session.AllAttemptsComplete() && session.JudgeID == "" {
+		if session.SuccessfulAttemptCount() >= 2 {
+			if err := coordinator.StartJudge(); err != nil {
+				if m.logger != nil {
+					m.logger.Error("failed to start judge", "error", err)
+				}
+				m.errorMessage = "Failed to start judge evaluation"
+			} else {
+				m.infoMessage = "All attempts complete - judge is evaluating solutions..."
+			}
+		}
+	}
+}
+
+// checkTripleShotJudge checks if the judge has completed evaluation
+func (m *Model) checkTripleShotJudge(coordinator *orchestrator.TripleShotCoordinator) {
+	complete, err := coordinator.CheckJudgeCompletion()
+	if err != nil {
+		if m.logger != nil {
+			m.logger.Warn("failed to check judge completion", "error", err)
+		}
+		return
+	}
+
+	if complete {
+		if err := coordinator.ProcessJudgeCompletion(); err != nil {
+			if m.logger != nil {
+				m.logger.Error("failed to process judge completion", "error", err)
+			}
+			m.errorMessage = "Failed to process judge evaluation"
+		} else {
+			m.infoMessage = "Triple-shot complete! Use :accept to apply the winning solution"
+			m.tripleShot.NeedsNotification = true
+		}
+	}
+}
+
+// handleTripleShotComplete handles when triple-shot has completed successfully
+func (m *Model) handleTripleShotComplete(session *orchestrator.TripleShotSession) {
+	// Nothing to poll for - the user should take action
+	// The notification was already shown when we transitioned to complete
+}
+
+// handleTripleShotFailed handles when triple-shot has failed
+func (m *Model) handleTripleShotFailed(session *orchestrator.TripleShotSession) {
+	// Show error message if we have one
+	if session.Error != "" && m.errorMessage == "" {
+		m.errorMessage = "Triple-shot failed: " + session.Error
+	}
+}

--- a/internal/tui/view/tripleshot.go
+++ b/internal/tui/view/tripleshot.go
@@ -1,0 +1,307 @@
+package view
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/tui/styles"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Triple-shot specific style aliases for better readability
+var (
+	tsHighlight = styles.Primary
+	tsSuccess   = styles.Secondary
+	tsWarning   = styles.Warning
+	tsError     = styles.Error
+	tsSubtle    = styles.Muted
+	tsPurple    = styles.PrimaryColor
+)
+
+// TripleShotState holds the state for triple-shot mode
+type TripleShotState struct {
+	Coordinator       *orchestrator.TripleShotCoordinator
+	NeedsNotification bool // Set when user input is needed (checked on tick)
+}
+
+// TripleShotRenderContext provides the necessary context for rendering triple-shot views
+type TripleShotRenderContext struct {
+	Orchestrator *orchestrator.Orchestrator
+	Session      *orchestrator.Session
+	TripleShot   *TripleShotState
+	ActiveTab    int
+	Width        int
+	Height       int
+}
+
+// RenderTripleShotHeader renders a compact header showing triple-shot status
+func RenderTripleShotHeader(ctx TripleShotRenderContext) string {
+	if ctx.TripleShot == nil || ctx.TripleShot.Coordinator == nil {
+		return ""
+	}
+
+	session := ctx.TripleShot.Coordinator.Session()
+	if session == nil {
+		return ""
+	}
+
+	// Build phase indicator
+	var phaseIcon string
+	var phaseText string
+	var phaseStyle lipgloss.Style
+
+	switch session.Phase {
+	case orchestrator.PhaseTripleShotWorking:
+		phaseIcon = "⚡"
+		phaseText = "Working"
+		phaseStyle = tsHighlight
+	case orchestrator.PhaseTripleShotEvaluating:
+		phaseIcon = "🔍"
+		phaseText = "Evaluating"
+		phaseStyle = tsWarning
+	case orchestrator.PhaseTripleShotComplete:
+		phaseIcon = "✓"
+		phaseText = "Complete"
+		phaseStyle = tsSuccess
+	case orchestrator.PhaseTripleShotFailed:
+		phaseIcon = "✗"
+		phaseText = "Failed"
+		phaseStyle = tsError
+	}
+
+	// Build attempt status
+	var attemptStatuses []string
+	for i, attempt := range session.Attempts {
+		var statusIcon string
+		switch attempt.Status {
+		case orchestrator.AttemptStatusWorking:
+			statusIcon = "⏳"
+		case orchestrator.AttemptStatusCompleted:
+			statusIcon = "✓"
+		case orchestrator.AttemptStatusFailed:
+			statusIcon = "✗"
+		default:
+			statusIcon = "○"
+		}
+		attemptStatuses = append(attemptStatuses, fmt.Sprintf("%s%d", statusIcon, i+1))
+	}
+
+	// Build the header line
+	header := fmt.Sprintf("%s %s | Attempts: %s",
+		phaseIcon,
+		phaseStyle.Render(phaseText),
+		strings.Join(attemptStatuses, " "),
+	)
+
+	// Add judge status if in evaluating phase
+	if session.Phase == orchestrator.PhaseTripleShotEvaluating && session.JudgeID != "" {
+		header += " | Judge: ⏳"
+	} else if session.Phase == orchestrator.PhaseTripleShotComplete {
+		header += " | Judge: ✓"
+	}
+
+	return tsSubtle.Render("Triple-Shot: ") + header
+}
+
+// RenderTripleShotSidebarSection renders a sidebar section for triple-shot mode
+func RenderTripleShotSidebarSection(ctx TripleShotRenderContext, width int) string {
+	if ctx.TripleShot == nil || ctx.TripleShot.Coordinator == nil {
+		return ""
+	}
+
+	session := ctx.TripleShot.Coordinator.Session()
+	if session == nil {
+		return ""
+	}
+
+	var lines []string
+
+	// Title
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(tsPurple)
+	lines = append(lines, titleStyle.Render("Triple-Shot"))
+	lines = append(lines, "")
+
+	// Task preview
+	task := session.Task
+	if len(task) > width-4 {
+		task = task[:width-7] + "..."
+	}
+	lines = append(lines, tsSubtle.Render("Task: ")+task)
+	lines = append(lines, "")
+
+	// Attempt status
+	lines = append(lines, tsSubtle.Render("Attempts:"))
+	for i, attempt := range session.Attempts {
+		var statusStyle lipgloss.Style
+		var statusText string
+
+		switch attempt.Status {
+		case orchestrator.AttemptStatusWorking:
+			statusStyle = tsHighlight
+			statusText = "working"
+		case orchestrator.AttemptStatusCompleted:
+			statusStyle = tsSuccess
+			statusText = "done"
+		case orchestrator.AttemptStatusFailed:
+			statusStyle = tsError
+			statusText = "failed"
+		default:
+			statusStyle = tsSubtle
+			statusText = "pending"
+		}
+
+		// Highlight if this attempt's instance is currently selected
+		var prefix string
+		if ctx.Session != nil && ctx.ActiveTab < len(ctx.Session.Instances) {
+			activeInst := ctx.Session.Instances[ctx.ActiveTab]
+			if activeInst != nil && activeInst.ID == attempt.InstanceID {
+				prefix = "▶ "
+			} else {
+				prefix = "  "
+			}
+		} else {
+			prefix = "  "
+		}
+
+		lines = append(lines, prefix+fmt.Sprintf("%d: %s", i+1, statusStyle.Render(statusText)))
+	}
+
+	// Judge status
+	if session.JudgeID != "" || session.Phase == orchestrator.PhaseTripleShotEvaluating || session.Phase == orchestrator.PhaseTripleShotComplete {
+		lines = append(lines, "")
+		lines = append(lines, tsSubtle.Render("Judge:"))
+
+		var judgeStatus string
+		var judgeStyle lipgloss.Style
+		switch session.Phase {
+		case orchestrator.PhaseTripleShotWorking:
+			judgeStatus = "waiting"
+			judgeStyle = tsSubtle
+		case orchestrator.PhaseTripleShotEvaluating:
+			judgeStatus = "evaluating"
+			judgeStyle = tsWarning
+		case orchestrator.PhaseTripleShotComplete:
+			judgeStatus = "done"
+			judgeStyle = tsSuccess
+		case orchestrator.PhaseTripleShotFailed:
+			judgeStatus = "failed"
+			judgeStyle = tsError
+		}
+
+		var prefix string
+		if ctx.Session != nil && ctx.ActiveTab < len(ctx.Session.Instances) {
+			activeInst := ctx.Session.Instances[ctx.ActiveTab]
+			if activeInst != nil && activeInst.ID == session.JudgeID {
+				prefix = "▶ "
+			} else {
+				prefix = "  "
+			}
+		} else {
+			prefix = "  "
+		}
+
+		lines = append(lines, prefix+judgeStyle.Render(judgeStatus))
+	}
+
+	// Evaluation result preview (if complete)
+	if session.Phase == orchestrator.PhaseTripleShotComplete && session.Evaluation != nil {
+		lines = append(lines, "")
+		lines = append(lines, tsSubtle.Render("Result:"))
+
+		eval := session.Evaluation
+		if eval.MergeStrategy == orchestrator.MergeStrategySelect && eval.WinnerIndex >= 0 && eval.WinnerIndex < 3 {
+			lines = append(lines, tsSuccess.Render(fmt.Sprintf("Winner: Attempt %d", eval.WinnerIndex+1)))
+		} else {
+			lines = append(lines, tsHighlight.Render(fmt.Sprintf("Strategy: %s", eval.MergeStrategy)))
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// RenderTripleShotEvaluation renders the full evaluation results
+func RenderTripleShotEvaluation(ctx TripleShotRenderContext) string {
+	if ctx.TripleShot == nil || ctx.TripleShot.Coordinator == nil {
+		return ""
+	}
+
+	session := ctx.TripleShot.Coordinator.Session()
+	if session == nil || session.Evaluation == nil {
+		return ""
+	}
+
+	eval := session.Evaluation
+	var lines []string
+
+	// Title
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(tsPurple)
+	lines = append(lines, titleStyle.Render("Evaluation Results"))
+	lines = append(lines, strings.Repeat("─", 40))
+	lines = append(lines, "")
+
+	// Strategy and winner
+	if eval.MergeStrategy == orchestrator.MergeStrategySelect && eval.WinnerIndex >= 0 && eval.WinnerIndex < 3 {
+		lines = append(lines, tsSuccess.Render(fmt.Sprintf("Winner: Attempt %d", eval.WinnerIndex+1)))
+	} else {
+		lines = append(lines, tsHighlight.Render(fmt.Sprintf("Strategy: %s", eval.MergeStrategy)))
+	}
+	lines = append(lines, "")
+
+	// Reasoning
+	lines = append(lines, tsSubtle.Render("Reasoning:"))
+	// Word wrap reasoning
+	words := strings.Fields(eval.Reasoning)
+	var line string
+	for _, word := range words {
+		if len(line)+len(word)+1 > ctx.Width-4 {
+			lines = append(lines, "  "+line)
+			line = word
+		} else if line == "" {
+			line = word
+		} else {
+			line += " " + word
+		}
+	}
+	if line != "" {
+		lines = append(lines, "  "+line)
+	}
+	lines = append(lines, "")
+
+	// Individual attempt scores
+	lines = append(lines, tsSubtle.Render("Attempt Scores:"))
+	for _, attemptEval := range eval.AttemptEvaluation {
+		var scoreStyle lipgloss.Style
+		switch {
+		case attemptEval.Score >= 8:
+			scoreStyle = tsSuccess
+		case attemptEval.Score >= 6:
+			scoreStyle = tsWarning
+		default:
+			scoreStyle = tsError
+		}
+
+		lines = append(lines, fmt.Sprintf("  Attempt %d: %s",
+			attemptEval.AttemptIndex+1,
+			scoreStyle.Render(fmt.Sprintf("%d/10", attemptEval.Score)),
+		))
+
+		if len(attemptEval.Strengths) > 0 {
+			lines = append(lines, tsSuccess.Render("    Strengths: ")+strings.Join(attemptEval.Strengths, ", "))
+		}
+		if len(attemptEval.Weaknesses) > 0 {
+			lines = append(lines, tsError.Render("    Weaknesses: ")+strings.Join(attemptEval.Weaknesses, ", "))
+		}
+	}
+
+	// Suggested changes if merging
+	if len(eval.SuggestedChanges) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, tsSubtle.Render("Suggested Changes:"))
+		for _, change := range eval.SuggestedChanges {
+			lines = append(lines, "  • "+change)
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}


### PR DESCRIPTION
## Summary

- Add new `claudio tripleshot` command that runs three Claude instances in parallel on the same task
- A fourth "judge" instance evaluates all three solutions and determines which is best (or if they can be combined)
- **NEW:** Users can now start triple-shot from within the standard TUI via `:tripleshot` command (or `:triple`, `:3shot` aliases)
- Useful for complex problems where different approaches might yield different solutions

## Details

**New Files:**
- `internal/orchestrator/tripleshot.go` - Core types and structures for triple-shot sessions
- `internal/orchestrator/tripleshot_coordinator.go` - Orchestration logic for the 3+1 execution pattern
- `internal/orchestrator/tripleshot_test.go` - Comprehensive test coverage
- `internal/cmd/tripleshot.go` - CLI command implementation
- `internal/tui/view/tripleshot.go` - TUI rendering for triple-shot status
- `internal/tui/tripleshot.go` - Type alias for cross-package access

**Modified Files:**
- `internal/tui/command/handler.go` - Added `:tripleshot` command and mode transition support
- `internal/tui/model.go` - Added `IsTripleShotMode()` and task input state for triple-shot
- `internal/tui/app.go` - Added triple-shot rendering, message handling, and mode initiation

**Key Features:**
- Three parallel attempts with independent worktrees and branches
- Coordinator pattern matching existing UltraPlan architecture
- Completion file protocol (`.claudio-tripleshot-complete.json`) for signaling task completion
- Evaluation file protocol (`.claudio-tripleshot-evaluation.json`) for judge decisions
- TUI integration showing attempt status, judge progress, and evaluation results
- Support for `--auto-approve` flag (CLI) 
- Can be started from within TUI via `:tripleshot` command
- Aliases: `:triple`, `:3shot`

**Error Handling:**
- Proper error propagation for missing judge instances
- I/O error handling for file stat operations
- Logging for parse failures and session persistence errors

## Test plan

- [x] Run `go test ./internal/orchestrator/...` - 20 tripleshot tests pass
- [x] Run `go test ./internal/tui/...` - All TUI tests pass  
- [x] Run `golangci-lint run` - No issues
- [x] Run `gofmt -d .` - No formatting issues
- [x] Run `go build ./...` - Builds successfully