### PR TITLE
Add GitHub Sponsors funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [Iron-Ham]


### PR DESCRIPTION
## Summary
- Adds `.github/FUNDING.yml` to enable the Sponsor button on the repository
- Configures GitHub Sponsors as the funding platform

## Test plan
- [ ] Verify the Sponsor button appears on the repository page after merge