### PR TITLE
Fix scrollback flashing from visible-only captures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Intelligent Naming Triggers Immediately** - Instance renaming now triggers immediately when an instance starts, using only the task description. Previously required waiting for 200+ bytes of Claude output which could fail silently.
 - **Cleanup Command Respects Worktree Config** - The `claudio cleanup` command and stale resource warnings now correctly use the configured worktree directory instead of the hardcoded default
-- **TUI Scrollback and Input Visibility** - Fixed output scrollback being lost when using differential capture optimization. Visible-only captures now trigger a full capture on the next tick when content changes, ensuring both immediate input visibility and preserved scrollback history
+- **TUI Scrollback Stability** - Fixed output display flashing and scroll position jumping when using differential capture optimization. Visible-only captures no longer write to the output buffer, preventing the display from rapidly alternating between short (visible-only) and full (scrollback) content
 
 ### Performance
 

--- a/internal/instance/input/persistent_sender.go
+++ b/internal/instance/input/persistent_sender.go
@@ -264,6 +264,12 @@ func (p *PersistentTmuxSender) connectLocked() error {
 			_ = stdin.Close()
 			_ = stdout.Close()
 			_ = stderr.Close()
+			// Kill the process before Wait() to prevent blocking indefinitely.
+			// Without Kill(), Wait() can hang if the verification goroutine is
+			// still reading from stdout when we closed the pipe.
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
 			_ = cmd.Wait()
 			return err
 		}


### PR DESCRIPTION
## Summary

- Visible-only captures no longer write to the output buffer, preventing display flashing
- Full captures are now the only source of output buffer updates, preserving scrollback history
- Scroll position remains stable when navigating output

## Problem

The differential capture optimization used visible-only captures for fast content change detection, then scheduled full captures to update the output buffer. However, the visible-only captures were *also* writing to the buffer, causing it to rapidly alternate between:

1. **Short content** (~30 lines from visible-only capture)
2. **Long content** (thousands of lines from full scrollback capture)

This caused the TUI to flash between states and broke scroll position when users tried to scroll up through history.

## Solution

Only full captures write to the output buffer. Visible-only captures are now used solely to detect content changes and trigger a full capture on the next tick (100ms later). This preserves scrollback stability while still detecting user input promptly.

## Test plan

- [x] Build succeeds: `go build ./...`
- [x] All tests pass: `go test ./...`
- [x] Linting clean: `go vet ./...`
- [ ] Manual testing: Scroll up in output while Claude is generating - display should be stable