### PR TITLE
Trigger intelligent naming immediately on instance start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Intelligent Naming Triggers Immediately** - Instance renaming now triggers immediately when an instance starts, using only the task description. Previously required waiting for 200+ bytes of Claude output which could fail silently.
 - **Cleanup Command Respects Worktree Config** - The `claudio cleanup` command and stale resource warnings now correctly use the configured worktree directory instead of the hardcoded default
 - **TUI Scrollback and Input Visibility** - Fixed output scrollback being lost when using differential capture optimization. Visible-only captures now trigger a full capture on the next tick when content changes, ensuring both immediate input visibility and preserved scrollback history
 


### PR DESCRIPTION
## Summary

- Fixes intelligent naming to trigger immediately when an instance starts, instead of waiting for 200+ bytes of Claude output
- Uses only the task description to generate short display names (no need to wait for output context)
- Simplifies the namer interface by removing the output parameter

## Problem

Previously, the intelligent naming feature:
1. Waited for 200+ bytes of output from Claude before triggering
2. Required passing output through a callback chain (manager → orchestrator → namer)
3. Could fail silently if output wasn't captured properly

## Solution

- Trigger rename directly in `Orchestrator.StartInstance()` immediately after the instance starts
- Simplify `Client.Summarize()` and `Namer.RequestRename()` to only take task (not output)
- Remove `RenameCallback` from instance manager (now handled at orchestrator level)
- Update prompt to focus on task description with better examples

## Test plan

- [x] All namer tests pass (`go test ./internal/namer/...`)
- [x] Full test suite passes (`go test ./...`)
- [x] Build succeeds (`go build ./...`)
- [x] Code formatted (`gofmt -d .`)
- [x] Linting passes (`go vet ./...`)