### PR TITLE
Expand selected instance name when intelligent naming enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Triple-Shot Mode** - New `claudio tripleshot` command runs three Claude instances in parallel on the same task, then uses a fourth "judge" instance to evaluate all solutions and determine the best approach. Supports `--auto-approve` flag and provides a specialized TUI showing attempt status, judge evaluation, and results
 - **Configurable Worktree Directory** - Users can now configure where Claudio creates git worktrees via `paths.worktree_dir` in config. Supports absolute paths, relative paths, and `~` home directory expansion. Available in interactive config (`claudio config`) under the new "Paths" category.
+- **Expanded Instance Names in Sidebar** - When intelligent naming is enabled, the selected instance in the sidebar now expands to show up to 50 characters of its display name (with wrapping if needed), making it easier to identify active tasks without truncation
 
 ### Fixed
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -741,6 +741,12 @@ func (m Model) IsAddingTask() bool {
 	return m.addingTask
 }
 
+// IntelligentNamingEnabled returns whether intelligent naming is enabled in config
+func (m Model) IntelligentNamingEnabled() bool {
+	cfg := config.Get()
+	return cfg.Experimental.IntelligentNaming
+}
+
 // -----------------------------------------------------------------------------
 // command.Dependencies interface implementation
 // These methods implement the command.Dependencies interface, allowing the Model

--- a/internal/tui/panel/instance.go
+++ b/internal/tui/panel/instance.go
@@ -29,13 +29,14 @@ func (p *InstancePanel) Render(state *RenderState) string {
 
 	// Create adapter state from RenderState
 	adapterState := &instancePanelState{
-		session:             state.Session,
-		activeTab:           state.ActiveIndex,
-		sidebarScrollOffset: state.ScrollOffset,
-		conflicts:           state.Conflicts,
-		terminalWidth:       state.Width,
-		terminalHeight:      state.Height,
-		isAddingTask:        state.IsAddingTask,
+		session:                  state.Session,
+		activeTab:                state.ActiveIndex,
+		sidebarScrollOffset:      state.ScrollOffset,
+		conflicts:                state.Conflicts,
+		terminalWidth:            state.Width,
+		terminalHeight:           state.Height,
+		isAddingTask:             state.IsAddingTask,
+		intelligentNamingEnabled: state.IntelligentNamingEnabled,
 	}
 
 	result := p.view.RenderSidebar(adapterState, state.Width, state.Height)
@@ -53,13 +54,14 @@ func (p *InstancePanel) Height() int {
 
 // instancePanelState adapts RenderState to the view.DashboardState interface.
 type instancePanelState struct {
-	session             *orchestrator.Session
-	activeTab           int
-	sidebarScrollOffset int
-	conflicts           []conflict.FileConflict
-	terminalWidth       int
-	terminalHeight      int
-	isAddingTask        bool
+	session                  *orchestrator.Session
+	activeTab                int
+	sidebarScrollOffset      int
+	conflicts                []conflict.FileConflict
+	terminalWidth            int
+	terminalHeight           int
+	isAddingTask             bool
+	intelligentNamingEnabled bool
 }
 
 // Session implements view.DashboardState.
@@ -95,4 +97,9 @@ func (s *instancePanelState) TerminalHeight() int {
 // IsAddingTask implements view.DashboardState.
 func (s *instancePanelState) IsAddingTask() bool {
 	return s.isAddingTask
+}
+
+// IntelligentNamingEnabled implements view.DashboardState.
+func (s *instancePanelState) IntelligentNamingEnabled() bool {
+	return s.intelligentNamingEnabled
 }

--- a/internal/tui/panel/renderer.go
+++ b/internal/tui/panel/renderer.go
@@ -150,6 +150,10 @@ type RenderState struct {
 	// IsAddingTask indicates if the user is currently adding a new task.
 	// Used by the instance panel to show input mode state.
 	IsAddingTask bool
+
+	// IntelligentNamingEnabled indicates if intelligent naming feature is enabled.
+	// Used to expand the selected instance name in the sidebar.
+	IntelligentNamingEnabled bool
 }
 
 // Validate checks that the RenderState has valid values for rendering.


### PR DESCRIPTION
## Summary

- When `experimental.intelligent_naming` is enabled, the selected instance in the sidebar now expands to show up to 50 characters of its display name
- Long names wrap to continuation lines with proper indentation
- Non-selected instances continue to use standard truncation to avoid sidebar clutter

## Changes

- Extended `DashboardState` interface with `IntelligentNamingEnabled()` method
- Added `renderExpandedInstance()` for multi-line name rendering
- Added `ExpandedNameMaxLen` (50 chars) and `ExpandedNameContinuationIn` (4 spaces) constants
- Comprehensive tests for expansion behavior

## Test plan

- [x] Verify expansion works when intelligent naming is on and instance is selected
- [x] Verify no expansion when instance is not selected
- [x] Verify no expansion when intelligent naming is disabled
- [x] Verify names are capped at 50 characters with ellipsis
- [x] All existing tests pass
- [x] Build passes with `go build ./...`
- [x] Linting passes with `go vet ./...`