### PR TITLE
Fix tmux crashes by using dedicated socket for Claudio sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Tmux Session Isolation** - Use dedicated tmux socket (`-L claudio`) to isolate Claudio sessions from other tmux clients (like iTerm2's tmux integration), preventing crashes from tmux control-mode notification bugs in tmux 3.6a
+
 ## [0.5.0] - 2026-01-13
 
 This release introduces **Triple-Shot Mode** - a powerful new execution strategy that runs three Claude instances in parallel on the same task, then uses a fourth "judge" instance to evaluate all solutions and pick the best approach.

--- a/internal/cmd/cleanup.go
+++ b/internal/cmd/cleanup.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Iron-Ham/claudio/internal/config"
 	"github.com/Iron-Ham/claudio/internal/orchestrator"
 	"github.com/Iron-Ham/claudio/internal/session"
+	"github.com/Iron-Ham/claudio/internal/tmux"
 	"github.com/Iron-Ham/claudio/internal/worktree"
 	"github.com/spf13/cobra"
 )
@@ -265,7 +266,7 @@ func findOrphanedTmuxSessions(activeIDs map[string]bool) []string {
 	var orphaned []string
 
 	// List all tmux sessions
-	cmd := exec.Command("tmux", "list-sessions", "-F", "#{session_name}")
+	cmd := tmux.Command("list-sessions", "-F", "#{session_name}")
 	output, err := cmd.Output()
 	if err != nil {
 		return orphaned // tmux might not be running
@@ -418,7 +419,7 @@ func performCleanup(baseDir string, result *CleanupResult, cleanAll bool) error 
 	// Clean tmux sessions
 	if cleanAll || cleanupTmux {
 		for _, sess := range result.OrphanedTmuxSess {
-			killCmd := exec.Command("tmux", "kill-session", "-t", sess)
+			killCmd := tmux.Command("kill-session", "-t", sess)
 			if err := killCmd.Run(); err != nil {
 				fmt.Printf("Warning: failed to kill tmux session %s: %v\n", sess, err)
 				continue
@@ -462,7 +463,7 @@ func performCleanup(baseDir string, result *CleanupResult, cleanAll bool) error 
 
 // killAllClaudioTmuxSessions kills all tmux sessions with claudio-* prefix
 func killAllClaudioTmuxSessions() int {
-	cmd := exec.Command("tmux", "list-sessions", "-F", "#{session_name}")
+	cmd := tmux.Command("list-sessions", "-F", "#{session_name}")
 	output, err := cmd.Output()
 	if err != nil {
 		// Check if it's just "no server running" which is expected
@@ -484,7 +485,7 @@ func killAllClaudioTmuxSessions() int {
 			continue
 		}
 
-		killCmd := exec.Command("tmux", "kill-session", "-t", sess)
+		killCmd := tmux.Command("kill-session", "-t", sess)
 		if err := killCmd.Run(); err != nil {
 			fmt.Printf("Warning: failed to kill tmux session %s: %v\n", sess, err)
 			continue

--- a/internal/cmd/sessions.go
+++ b/internal/cmd/sessions.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Iron-Ham/claudio/internal/config"
 	"github.com/Iron-Ham/claudio/internal/instance"
 	"github.com/Iron-Ham/claudio/internal/session"
+	"github.com/Iron-Ham/claudio/internal/tmux"
 	"github.com/spf13/cobra"
 )
 
@@ -290,7 +291,7 @@ func runSessionsClean(cmd *cobra.Command, args []string) error {
 		}
 		if !found {
 			// Kill orphaned session
-			killCmd := fmt.Sprintf("tmux kill-session -t %s", ts)
+			killCmd := fmt.Sprintf("tmux -L %s kill-session -t %s", tmux.SocketName, ts)
 			if _, err := runCommand(killCmd); err == nil {
 				orphanedKilled++
 			}

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Iron-Ham/claudio/internal/orchestrator"
 	orchsession "github.com/Iron-Ham/claudio/internal/orchestrator/session"
 	"github.com/Iron-Ham/claudio/internal/session"
+	"github.com/Iron-Ham/claudio/internal/tmux"
 	"github.com/Iron-Ham/claudio/internal/tui"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -532,7 +533,7 @@ func cleanEmptySessions(baseDir string) {
 
 // shutdownAllSessions kills all claudio-* tmux sessions
 func shutdownAllSessions() {
-	cmd := exec.Command("tmux", "list-sessions", "-F", "#{session_name}")
+	cmd := tmux.Command("list-sessions", "-F", "#{session_name}")
 	output, err := cmd.Output()
 	if err != nil {
 		// Check if it's just "no server running" which is expected
@@ -555,7 +556,7 @@ func shutdownAllSessions() {
 			continue
 		}
 
-		killCmd := exec.Command("tmux", "kill-session", "-t", sess)
+		killCmd := tmux.Command("kill-session", "-t", sess)
 		if err := killCmd.Run(); err != nil {
 			fmt.Printf("Warning: failed to kill tmux session %s: %v\n", sess, err)
 			continue
@@ -599,7 +600,7 @@ func checkStaleResourcesWarning(baseDir string) {
 	}
 
 	// Count orphaned tmux sessions
-	tmuxCmd := exec.Command("tmux", "list-sessions", "-F", "#{session_name}")
+	tmuxCmd := tmux.Command("list-sessions", "-F", "#{session_name}")
 	if output, err := tmuxCmd.Output(); err == nil {
 		sessions := strings.Split(strings.TrimSpace(string(output)), "\n")
 		for _, s := range sessions {

--- a/internal/instance/capture/output.go
+++ b/internal/instance/capture/output.go
@@ -2,9 +2,10 @@ package capture
 
 import (
 	"log"
-	"os/exec"
 	"sync"
 	"time"
+
+	"github.com/Iron-Ham/claudio/internal/tmux"
 )
 
 const (
@@ -205,7 +206,7 @@ func (t *TmuxCapture) captureLoop() {
 // captureTmuxPane captures the full pane content from a tmux session.
 // This includes visible content and scrollback, with ANSI escape sequences preserved.
 func captureTmuxPane(sessionName string) ([]byte, error) {
-	cmd := exec.Command("tmux",
+	cmd := tmux.Command(
 		"capture-pane",
 		"-t", sessionName,
 		"-p",      // print to stdout
@@ -218,6 +219,6 @@ func captureTmuxPane(sessionName string) ([]byte, error) {
 
 // SessionExists checks if the tmux session exists.
 func (t *TmuxCapture) SessionExists() bool {
-	cmd := exec.Command("tmux", "has-session", "-t", t.config.SessionName)
+	cmd := tmux.Command("has-session", "-t", t.config.SessionName)
 	return cmd.Run() == nil
 }

--- a/internal/instance/input/handler.go
+++ b/internal/instance/input/handler.go
@@ -9,10 +9,11 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os/exec"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Iron-Ham/claudio/internal/tmux"
 )
 
 // TmuxSender defines the interface for sending commands to tmux.
@@ -26,14 +27,14 @@ type TmuxSender interface {
 // DefaultTmuxSender is the production implementation of TmuxSender.
 type DefaultTmuxSender struct{}
 
-// SendKeys sends keys to a tmux session using exec.Command.
+// SendKeys sends keys to a tmux session using the tmux package.
 func (d *DefaultTmuxSender) SendKeys(sessionName string, keys string, literal bool) error {
 	args := []string{"send-keys", "-t", sessionName}
 	if literal {
 		args = append(args, "-l")
 	}
 	args = append(args, keys)
-	return exec.Command("tmux", args...).Run()
+	return tmux.Command(args...).Run()
 }
 
 // HistoryEntry represents a single entry in the input history.

--- a/internal/instance/input/persistent_sender.go
+++ b/internal/instance/input/persistent_sender.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Iron-Ham/claudio/internal/tmux"
 )
 
 // writeTimeout is the maximum time to wait for a write to the tmux control mode
@@ -201,7 +203,7 @@ func (p *PersistentTmuxSender) connectLocked() error {
 
 	// Start tmux in control mode, attached to the session
 	// Control mode (-C) keeps stdin open for commands and writes responses to stdout
-	cmd := exec.Command("tmux", "-C", "attach-session", "-t", p.sessionName)
+	cmd := tmux.Command("-C", "attach-session", "-t", p.sessionName)
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/internal/instance/manager_test.go
+++ b/internal/instance/manager_test.go
@@ -242,8 +242,12 @@ func TestManager_AttachCommand(t *testing.T) {
 	mgr := NewManager("abc123", "/tmp", "task")
 	cmd := mgr.AttachCommand()
 
-	if !strings.Contains(cmd, "tmux attach") {
-		t.Errorf("AttachCommand() should contain 'tmux attach', got %q", cmd)
+	if !strings.Contains(cmd, "tmux") || !strings.Contains(cmd, "attach") {
+		t.Errorf("AttachCommand() should contain 'tmux' and 'attach', got %q", cmd)
+	}
+
+	if !strings.Contains(cmd, "-L claudio") {
+		t.Errorf("AttachCommand() should specify claudio socket (-L claudio), got %q", cmd)
 	}
 
 	if !strings.Contains(cmd, "claudio-abc123") {

--- a/internal/instance/process/tmux_test.go
+++ b/internal/instance/process/tmux_test.go
@@ -75,7 +75,7 @@ func TestTmuxProcess_AttachCommand(t *testing.T) {
 
 	p := NewTmuxProcess(config)
 
-	want := "tmux attach -t test-session"
+	want := "tmux -L claudio attach -t test-session"
 	if got := p.AttachCommand(); got != want {
 		t.Errorf("AttachCommand() = %q, want %q", got, want)
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Iron-Ham/claudio/internal/orchestrator/prworkflow"
 	orchsession "github.com/Iron-Ham/claudio/internal/orchestrator/session"
 	"github.com/Iron-Ham/claudio/internal/session"
+	"github.com/Iron-Ham/claudio/internal/tmux"
 	"github.com/Iron-Ham/claudio/internal/worktree"
 	"github.com/spf13/viper"
 )
@@ -546,7 +547,7 @@ func (o *Orchestrator) CleanOrphanedTmuxSessions() (int, error) {
 
 	cleaned := 0
 	for _, sess := range orphaned {
-		cmd := exec.Command("tmux", "kill-session", "-t", sess)
+		cmd := tmux.Command("kill-session", "-t", sess)
 		if err := cmd.Run(); err != nil {
 			if o.logger != nil {
 				o.logger.Warn("failed to kill orphaned tmux session",

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1,0 +1,44 @@
+// Package tmux provides centralized configuration and helpers for tmux operations.
+//
+// Claudio uses a dedicated tmux socket to isolate its sessions from other tmux
+// clients (like iTerm2's tmux integration). This prevents crashes caused by
+// control-mode notification bugs in tmux when multiple clients share a server.
+package tmux
+
+import (
+	"context"
+	"os/exec"
+)
+
+// SocketName is the dedicated tmux socket name for Claudio.
+// Using a dedicated socket isolates Claudio from other tmux clients
+// that may use control mode (like iTerm2), preventing crashes from
+// tmux control-mode notification bugs.
+const SocketName = "claudio"
+
+// Command creates an exec.Cmd for tmux with the Claudio socket.
+// This ensures all Claudio tmux operations use the dedicated socket.
+func Command(args ...string) *exec.Cmd {
+	fullArgs := append([]string{"-L", SocketName}, args...)
+	return exec.Command("tmux", fullArgs...)
+}
+
+// CommandContext creates a context-aware exec.Cmd for tmux with the Claudio socket.
+// Use this when the command should be cancellable via context.
+func CommandContext(ctx context.Context, args ...string) *exec.Cmd {
+	fullArgs := append([]string{"-L", SocketName}, args...)
+	return exec.CommandContext(ctx, "tmux", fullArgs...)
+}
+
+// CommandArgs returns the arguments needed to run a tmux command
+// with the Claudio socket. Use this when you need to build the
+// command string differently (e.g., for display purposes).
+func CommandArgs(args ...string) []string {
+	return append([]string{"-L", SocketName}, args...)
+}
+
+// BaseArgs returns just the socket arguments [-L, claudio].
+// Use this when you need to prepend socket args to existing argument slices.
+func BaseArgs() []string {
+	return []string{"-L", SocketName}
+}

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -1,0 +1,89 @@
+package tmux
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSocketName(t *testing.T) {
+	if SocketName == "" {
+		t.Error("SocketName should not be empty")
+	}
+	if SocketName != "claudio" {
+		t.Errorf("SocketName = %q, want %q", SocketName, "claudio")
+	}
+}
+
+func TestCommand(t *testing.T) {
+	cmd := Command("list-sessions")
+	args := cmd.Args
+
+	if len(args) < 4 {
+		t.Fatalf("Expected at least 4 args, got %d: %v", len(args), args)
+	}
+
+	if args[0] != "tmux" {
+		t.Errorf("args[0] = %q, want %q", args[0], "tmux")
+	}
+	if args[1] != "-L" {
+		t.Errorf("args[1] = %q, want %q", args[1], "-L")
+	}
+	if args[2] != SocketName {
+		t.Errorf("args[2] = %q, want %q", args[2], SocketName)
+	}
+	if args[3] != "list-sessions" {
+		t.Errorf("args[3] = %q, want %q", args[3], "list-sessions")
+	}
+}
+
+func TestCommandArgs(t *testing.T) {
+	args := CommandArgs("kill-session", "-t", "test")
+
+	expected := []string{"-L", SocketName, "kill-session", "-t", "test"}
+	if len(args) != len(expected) {
+		t.Fatalf("len(args) = %d, want %d", len(args), len(expected))
+	}
+
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("args[%d] = %q, want %q", i, args[i], want)
+		}
+	}
+}
+
+func TestBaseArgs(t *testing.T) {
+	args := BaseArgs()
+
+	if len(args) != 2 {
+		t.Fatalf("len(args) = %d, want 2", len(args))
+	}
+	if args[0] != "-L" {
+		t.Errorf("args[0] = %q, want %q", args[0], "-L")
+	}
+	if args[1] != SocketName {
+		t.Errorf("args[1] = %q, want %q", args[1], SocketName)
+	}
+}
+
+func TestCommandContext(t *testing.T) {
+	ctx := context.Background()
+	cmd := CommandContext(ctx, "has-session", "-t", "test")
+	args := cmd.Args
+
+	if len(args) < 6 {
+		t.Fatalf("Expected at least 6 args, got %d: %v", len(args), args)
+	}
+
+	if args[0] != "tmux" {
+		t.Errorf("args[0] = %q, want %q", args[0], "tmux")
+	}
+	if args[1] != "-L" {
+		t.Errorf("args[1] = %q, want %q", args[1], "-L")
+	}
+	if args[2] != SocketName {
+		t.Errorf("args[2] = %q, want %q", args[2], SocketName)
+	}
+	if args[3] != "has-session" {
+		t.Errorf("args[3] = %q, want %q", args[3], "has-session")
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes crashes caused by tmux control-mode notification bugs when Claudio shares the tmux server with iTerm2 (or other control-mode clients)
- Introduces a centralized `internal/tmux` package that wraps all tmux commands with `-L claudio`
- Updates 50+ call sites across the codebase to use the new helpers
- Adds 100% test coverage for the new package

## Problem

When running UltraPlan, the tmux server would crash with a segfault:
```
EXC_BAD_ACCESS / SIGSEGV at 0x0000000000000020
control_write -> control_notify_session_created -> notify_callback
"crashed on child side of fork pre-exec"
```

This is a tmux 3.6a bug that occurs when:
1. A control-mode client (like iTerm2's tmux integration) is connected
2. A new session is created
3. tmux tries to notify control clients about the new session
4. NULL pointer dereference in the notification code

## Solution

Use a dedicated tmux socket (`-L claudio`) to isolate Claudio's sessions from other tmux clients. This creates a separate tmux server at `/tmp/tmux-{uid}/claudio` instead of the default socket.

## Test plan

- [x] All existing tests pass
- [x] New `internal/tmux` package has 100% test coverage
- [x] `go vet ./...` passes
- [x] `gofmt -d .` shows no formatting issues
- [ ] Manual test: Run UltraPlan with iTerm2's tmux integration enabled