### PR TITLE
Add experimental config for inline Plan/UltraPlan mode

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -196,6 +196,19 @@ type ExperimentalConfig struct {
 	// When enabled, :term, :t, and :termdir commands become available
 	// to interact with a terminal inside Claudio. (default: false)
 	TerminalSupport bool `mapstructure:"terminal_support"`
+
+	// InlinePlan enables the :plan command in the standard TUI, allowing users to
+	// start a Plan workflow directly from the main interface. (default: false)
+	InlinePlan bool `mapstructure:"inline_plan"`
+
+	// InlineUltraPlan enables the :ultraplan command in the standard TUI, allowing
+	// users to start an UltraPlan workflow directly from the main interface. (default: false)
+	InlineUltraPlan bool `mapstructure:"inline_ultraplan"`
+
+	// GroupedInstanceView enables visual grouping of instances by execution group
+	// in the TUI sidebar. Related tasks are organized together, with sub-groups
+	// for dependency chains. (default: false)
+	GroupedInstanceView bool `mapstructure:"grouped_instance_view"`
 }
 
 // ResolveWorktreeDir returns the resolved worktree directory path.
@@ -303,9 +316,12 @@ func Default() *Config {
 			WorktreeDir: "", // Empty means use default: .claudio/worktrees
 		},
 		Experimental: ExperimentalConfig{
-			IntelligentNaming: false, // Disabled by default until stable
-			TripleShot:        false, // Disabled by default until stable
-			TerminalSupport:   false, // Disabled by default until stable
+			IntelligentNaming:   false, // Disabled by default until stable
+			TripleShot:          false, // Disabled by default until stable
+			TerminalSupport:     false, // Disabled by default until stable
+			InlinePlan:          false, // Disabled by default until stable
+			InlineUltraPlan:     false, // Disabled by default until stable
+			GroupedInstanceView: false, // Disabled by default until stable
 		},
 	}
 }
@@ -399,6 +415,9 @@ func SetDefaults() {
 	viper.SetDefault("experimental.intelligent_naming", defaults.Experimental.IntelligentNaming)
 	viper.SetDefault("experimental.triple_shot", defaults.Experimental.TripleShot)
 	viper.SetDefault("experimental.terminal_support", defaults.Experimental.TerminalSupport)
+	viper.SetDefault("experimental.inline_plan", defaults.Experimental.InlinePlan)
+	viper.SetDefault("experimental.inline_ultraplan", defaults.Experimental.InlineUltraPlan)
+	viper.SetDefault("experimental.grouped_instance_view", defaults.Experimental.GroupedInstanceView)
 }
 
 // Load reads the configuration from viper into a Config struct and validates it


### PR DESCRIPTION
## Summary

This PR adds the experimental configuration flags needed to enable the inline Plan/UltraPlan feature in Claudio's TUI.

### Tasks Included
- **T1**: Add experimental config for inline Plan/UltraPlan

### Changes
- Adds three new experimental config flags:
  - `InlinePlan`: Enable the `:plan` command in TUI
  - `InlineUltraPlan`: Enable the `:ultraplan` command in TUI  
  - `GroupedInstanceView`: Enable grouped instance sidebar view
- Properly integrates with viper configuration binding

### Merge Order
This is PR 1 of 8 in the Plan/UltraPlan feature stack. Must merge before subsequent PRs.