### PR TITLE
Design InstanceGroup type for visual grouping

### DIFF
--- a/internal/orchestrator/instance_group.go
+++ b/internal/orchestrator/instance_group.go
@@ -1,0 +1,215 @@
+package orchestrator
+
+import "time"
+
+// GroupPhase represents the current phase of an instance group
+type GroupPhase string
+
+const (
+	GroupPhasePending   GroupPhase = "pending"
+	GroupPhaseExecuting GroupPhase = "executing"
+	GroupPhaseCompleted GroupPhase = "completed"
+	GroupPhaseFailed    GroupPhase = "failed"
+)
+
+// InstanceGroup represents a visual grouping of instances in the TUI.
+// Groups enable users to organize related tasks together, particularly useful
+// for Plan and UltraPlan workflows where tasks have natural dependencies.
+type InstanceGroup struct {
+	ID             string           `json:"id"`
+	Name           string           `json:"name"`            // e.g., "Group 1: Foundation" or auto-generated
+	Phase          GroupPhase       `json:"phase"`           // Current group status
+	Instances      []string         `json:"instances"`       // Instance IDs in this group
+	SubGroups      []*InstanceGroup `json:"sub_groups"`      // For nested dependencies
+	ParentID       string           `json:"parent_id"`       // If this is a sub-group
+	ExecutionOrder int              `json:"execution_order"` // Order of execution (0 = first)
+	DependsOn      []string         `json:"depends_on"`      // Group IDs this group depends on
+	Created        time.Time        `json:"created"`
+}
+
+// NewInstanceGroup creates a new instance group with a generated ID
+func NewInstanceGroup(name string) *InstanceGroup {
+	return &InstanceGroup{
+		ID:        generateID(),
+		Name:      name,
+		Phase:     GroupPhasePending,
+		Instances: make([]string, 0),
+		SubGroups: make([]*InstanceGroup, 0),
+		DependsOn: make([]string, 0),
+		Created:   time.Now(),
+	}
+}
+
+// AddInstance adds an instance ID to the group
+func (g *InstanceGroup) AddInstance(instanceID string) {
+	g.Instances = append(g.Instances, instanceID)
+}
+
+// RemoveInstance removes an instance ID from the group
+func (g *InstanceGroup) RemoveInstance(instanceID string) {
+	for i, id := range g.Instances {
+		if id == instanceID {
+			g.Instances = append(g.Instances[:i], g.Instances[i+1:]...)
+			return
+		}
+	}
+}
+
+// HasInstance checks if an instance ID is in this group
+func (g *InstanceGroup) HasInstance(instanceID string) bool {
+	for _, id := range g.Instances {
+		if id == instanceID {
+			return true
+		}
+	}
+	return false
+}
+
+// AddSubGroup adds a sub-group to this group
+func (g *InstanceGroup) AddSubGroup(subGroup *InstanceGroup) {
+	subGroup.ParentID = g.ID
+	g.SubGroups = append(g.SubGroups, subGroup)
+}
+
+// GetSubGroup returns a sub-group by ID
+func (g *InstanceGroup) GetSubGroup(id string) *InstanceGroup {
+	for _, sg := range g.SubGroups {
+		if sg.ID == id {
+			return sg
+		}
+	}
+	return nil
+}
+
+// AllInstanceIDs returns all instance IDs in this group and all sub-groups (recursively)
+func (g *InstanceGroup) AllInstanceIDs() []string {
+	ids := make([]string, len(g.Instances))
+	copy(ids, g.Instances)
+
+	for _, sg := range g.SubGroups {
+		ids = append(ids, sg.AllInstanceIDs()...)
+	}
+	return ids
+}
+
+// InstanceCount returns the total number of instances in this group and all sub-groups
+func (g *InstanceGroup) InstanceCount() int {
+	count := len(g.Instances)
+	for _, sg := range g.SubGroups {
+		count += sg.InstanceCount()
+	}
+	return count
+}
+
+// IsTopLevel returns true if this group has no parent (is not a sub-group)
+func (g *InstanceGroup) IsTopLevel() bool {
+	return g.ParentID == ""
+}
+
+// GetGroup finds a group by ID within the session's groups (including sub-groups)
+func (s *Session) GetGroup(id string) *InstanceGroup {
+	for _, g := range s.Groups {
+		if g.ID == id {
+			return g
+		}
+		// Search sub-groups recursively
+		if found := findGroupRecursive(g, id); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// findGroupRecursive searches for a group by ID in sub-groups
+func findGroupRecursive(group *InstanceGroup, id string) *InstanceGroup {
+	for _, sg := range group.SubGroups {
+		if sg.ID == id {
+			return sg
+		}
+		if found := findGroupRecursive(sg, id); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// GetGroupForInstance finds the group (or sub-group) containing the given instance ID
+func (s *Session) GetGroupForInstance(instanceID string) *InstanceGroup {
+	for _, g := range s.Groups {
+		if found := findGroupContainingInstance(g, instanceID); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// findGroupContainingInstance recursively searches for the group containing an instance
+func findGroupContainingInstance(group *InstanceGroup, instanceID string) *InstanceGroup {
+	if group.HasInstance(instanceID) {
+		return group
+	}
+	for _, sg := range group.SubGroups {
+		if found := findGroupContainingInstance(sg, instanceID); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// AddGroup adds a new group to the session
+func (s *Session) AddGroup(group *InstanceGroup) {
+	if s.Groups == nil {
+		s.Groups = make([]*InstanceGroup, 0)
+	}
+	s.Groups = append(s.Groups, group)
+}
+
+// RemoveGroup removes a group from the session by ID
+func (s *Session) RemoveGroup(id string) {
+	for i, g := range s.Groups {
+		if g.ID == id {
+			s.Groups = append(s.Groups[:i], s.Groups[i+1:]...)
+			return
+		}
+	}
+}
+
+// GetGroupsByPhase returns all groups (top-level only) in the given phase
+func (s *Session) GetGroupsByPhase(phase GroupPhase) []*InstanceGroup {
+	var groups []*InstanceGroup
+	for _, g := range s.Groups {
+		if g.Phase == phase {
+			groups = append(groups, g)
+		}
+	}
+	return groups
+}
+
+// AreGroupDependenciesMet checks if all dependencies for a group have completed
+func (s *Session) AreGroupDependenciesMet(group *InstanceGroup) bool {
+	if len(group.DependsOn) == 0 {
+		return true
+	}
+
+	for _, depID := range group.DependsOn {
+		dep := s.GetGroup(depID)
+		if dep == nil {
+			return false
+		}
+		if dep.Phase != GroupPhaseCompleted {
+			return false
+		}
+	}
+	return true
+}
+
+// GetReadyGroups returns all groups that are pending and have their dependencies met
+func (s *Session) GetReadyGroups() []*InstanceGroup {
+	var ready []*InstanceGroup
+	for _, g := range s.Groups {
+		if g.Phase == GroupPhasePending && s.AreGroupDependenciesMet(g) {
+			ready = append(ready, g)
+		}
+	}
+	return ready
+}

--- a/internal/orchestrator/instance_group_test.go
+++ b/internal/orchestrator/instance_group_test.go
@@ -1,0 +1,670 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGroupPhase_Constants(t *testing.T) {
+	tests := []struct {
+		phase    GroupPhase
+		expected string
+	}{
+		{GroupPhasePending, "pending"},
+		{GroupPhaseExecuting, "executing"},
+		{GroupPhaseCompleted, "completed"},
+		{GroupPhaseFailed, "failed"},
+	}
+
+	for _, tt := range tests {
+		if string(tt.phase) != tt.expected {
+			t.Errorf("GroupPhase constant = %q, want %q", tt.phase, tt.expected)
+		}
+	}
+}
+
+func TestNewInstanceGroup(t *testing.T) {
+	tests := []struct {
+		name         string
+		groupName    string
+		expectedName string
+	}{
+		{
+			name:         "with custom name",
+			groupName:    "Group 1: Foundation",
+			expectedName: "Group 1: Foundation",
+		},
+		{
+			name:         "with empty name",
+			groupName:    "",
+			expectedName: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			group := NewInstanceGroup(tt.groupName)
+
+			if group == nil {
+				t.Fatal("NewInstanceGroup returned nil")
+			}
+
+			if group.ID == "" {
+				t.Error("group ID should not be empty")
+			}
+
+			if group.Name != tt.expectedName {
+				t.Errorf("group.Name = %q, want %q", group.Name, tt.expectedName)
+			}
+
+			if group.Phase != GroupPhasePending {
+				t.Errorf("group.Phase = %q, want %q", group.Phase, GroupPhasePending)
+			}
+
+			if group.Instances == nil {
+				t.Error("group.Instances should not be nil")
+			}
+
+			if len(group.Instances) != 0 {
+				t.Errorf("group.Instances should be empty, got %d", len(group.Instances))
+			}
+
+			if group.SubGroups == nil {
+				t.Error("group.SubGroups should not be nil")
+			}
+
+			if group.DependsOn == nil {
+				t.Error("group.DependsOn should not be nil")
+			}
+
+			if group.Created.IsZero() {
+				t.Error("group.Created should be set")
+			}
+		})
+	}
+}
+
+func TestInstanceGroup_Created_Timestamp(t *testing.T) {
+	before := time.Now()
+	group := NewInstanceGroup("test group")
+	after := time.Now()
+
+	if group.Created.Before(before) || group.Created.After(after) {
+		t.Errorf("group.Created = %v, should be between %v and %v", group.Created, before, after)
+	}
+}
+
+func TestInstanceGroup_AddInstance(t *testing.T) {
+	group := NewInstanceGroup("test group")
+
+	group.AddInstance("inst-1")
+	group.AddInstance("inst-2")
+	group.AddInstance("inst-3")
+
+	if len(group.Instances) != 3 {
+		t.Errorf("len(group.Instances) = %d, want 3", len(group.Instances))
+	}
+
+	expected := []string{"inst-1", "inst-2", "inst-3"}
+	for i, id := range expected {
+		if group.Instances[i] != id {
+			t.Errorf("group.Instances[%d] = %q, want %q", i, group.Instances[i], id)
+		}
+	}
+}
+
+func TestInstanceGroup_RemoveInstance(t *testing.T) {
+	group := NewInstanceGroup("test group")
+	group.AddInstance("inst-1")
+	group.AddInstance("inst-2")
+	group.AddInstance("inst-3")
+
+	tests := []struct {
+		name        string
+		removeID    string
+		expectedLen int
+		expectedIDs []string
+	}{
+		{
+			name:        "remove middle instance",
+			removeID:    "inst-2",
+			expectedLen: 2,
+			expectedIDs: []string{"inst-1", "inst-3"},
+		},
+		{
+			name:        "remove first instance",
+			removeID:    "inst-1",
+			expectedLen: 1,
+			expectedIDs: []string{"inst-3"},
+		},
+		{
+			name:        "remove non-existent instance",
+			removeID:    "inst-999",
+			expectedLen: 1,
+			expectedIDs: []string{"inst-3"},
+		},
+		{
+			name:        "remove last instance",
+			removeID:    "inst-3",
+			expectedLen: 0,
+			expectedIDs: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			group.RemoveInstance(tt.removeID)
+			if len(group.Instances) != tt.expectedLen {
+				t.Errorf("len(group.Instances) = %d, want %d", len(group.Instances), tt.expectedLen)
+			}
+			for i, id := range tt.expectedIDs {
+				if i >= len(group.Instances) || group.Instances[i] != id {
+					t.Errorf("after removing %q, expected Instances[%d] = %q", tt.removeID, i, id)
+				}
+			}
+		})
+	}
+}
+
+func TestInstanceGroup_HasInstance(t *testing.T) {
+	group := NewInstanceGroup("test group")
+	group.AddInstance("inst-1")
+	group.AddInstance("inst-2")
+
+	tests := []struct {
+		name       string
+		instanceID string
+		expected   bool
+	}{
+		{"has first instance", "inst-1", true},
+		{"has second instance", "inst-2", true},
+		{"does not have instance", "inst-3", false},
+		{"empty id", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := group.HasInstance(tt.instanceID)
+			if result != tt.expected {
+				t.Errorf("HasInstance(%q) = %v, want %v", tt.instanceID, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestInstanceGroup_SubGroups(t *testing.T) {
+	parent := NewInstanceGroup("Parent Group")
+	child1 := NewInstanceGroup("Child 1")
+	child2 := NewInstanceGroup("Child 2")
+
+	parent.AddSubGroup(child1)
+	parent.AddSubGroup(child2)
+
+	if len(parent.SubGroups) != 2 {
+		t.Errorf("len(parent.SubGroups) = %d, want 2", len(parent.SubGroups))
+	}
+
+	// Verify parent ID is set
+	if child1.ParentID != parent.ID {
+		t.Errorf("child1.ParentID = %q, want %q", child1.ParentID, parent.ID)
+	}
+	if child2.ParentID != parent.ID {
+		t.Errorf("child2.ParentID = %q, want %q", child2.ParentID, parent.ID)
+	}
+}
+
+func TestInstanceGroup_GetSubGroup(t *testing.T) {
+	parent := NewInstanceGroup("Parent Group")
+	child1 := NewInstanceGroup("Child 1")
+	child2 := NewInstanceGroup("Child 2")
+	child1ID := child1.ID
+	child2ID := child2.ID
+
+	parent.AddSubGroup(child1)
+	parent.AddSubGroup(child2)
+
+	tests := []struct {
+		name     string
+		id       string
+		expected *InstanceGroup
+	}{
+		{"find first child", child1ID, child1},
+		{"find second child", child2ID, child2},
+		{"not found", "nonexistent", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parent.GetSubGroup(tt.id)
+			if result != tt.expected {
+				t.Errorf("GetSubGroup(%q) = %v, want %v", tt.id, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestInstanceGroup_AllInstanceIDs(t *testing.T) {
+	parent := NewInstanceGroup("Parent")
+	parent.AddInstance("inst-1")
+	parent.AddInstance("inst-2")
+
+	child := NewInstanceGroup("Child")
+	child.AddInstance("inst-3")
+	child.AddInstance("inst-4")
+
+	grandchild := NewInstanceGroup("Grandchild")
+	grandchild.AddInstance("inst-5")
+
+	child.AddSubGroup(grandchild)
+	parent.AddSubGroup(child)
+
+	allIDs := parent.AllInstanceIDs()
+
+	if len(allIDs) != 5 {
+		t.Errorf("len(AllInstanceIDs()) = %d, want 5", len(allIDs))
+	}
+
+	expectedIDs := map[string]bool{
+		"inst-1": true,
+		"inst-2": true,
+		"inst-3": true,
+		"inst-4": true,
+		"inst-5": true,
+	}
+
+	for _, id := range allIDs {
+		if !expectedIDs[id] {
+			t.Errorf("unexpected instance ID in AllInstanceIDs(): %q", id)
+		}
+	}
+}
+
+func TestInstanceGroup_InstanceCount(t *testing.T) {
+	parent := NewInstanceGroup("Parent")
+	parent.AddInstance("inst-1")
+	parent.AddInstance("inst-2")
+
+	child := NewInstanceGroup("Child")
+	child.AddInstance("inst-3")
+
+	parent.AddSubGroup(child)
+
+	if count := parent.InstanceCount(); count != 3 {
+		t.Errorf("InstanceCount() = %d, want 3", count)
+	}
+
+	if count := child.InstanceCount(); count != 1 {
+		t.Errorf("child.InstanceCount() = %d, want 1", count)
+	}
+}
+
+func TestInstanceGroup_IsTopLevel(t *testing.T) {
+	parent := NewInstanceGroup("Parent")
+	child := NewInstanceGroup("Child")
+
+	parent.AddSubGroup(child)
+
+	if !parent.IsTopLevel() {
+		t.Error("parent.IsTopLevel() should be true")
+	}
+
+	if child.IsTopLevel() {
+		t.Error("child.IsTopLevel() should be false")
+	}
+}
+
+func TestSession_Groups_Field(t *testing.T) {
+	session := NewSession("test", "/repo")
+
+	// Groups should be nil initially (optional field)
+	if session.Groups != nil {
+		t.Errorf("session.Groups should be nil initially, got %v", session.Groups)
+	}
+
+	// Create and add groups
+	group1 := NewInstanceGroup("Group 1")
+	group2 := NewInstanceGroup("Group 2")
+
+	session.AddGroup(group1)
+	session.AddGroup(group2)
+
+	if len(session.Groups) != 2 {
+		t.Errorf("len(session.Groups) = %d, want 2", len(session.Groups))
+	}
+}
+
+func TestSession_GetGroup(t *testing.T) {
+	session := NewSession("test", "/repo")
+
+	group1 := NewInstanceGroup("Group 1")
+	group2 := NewInstanceGroup("Group 2")
+	subGroup := NewInstanceGroup("Sub Group")
+	group2.AddSubGroup(subGroup)
+
+	session.AddGroup(group1)
+	session.AddGroup(group2)
+
+	tests := []struct {
+		name     string
+		id       string
+		expected *InstanceGroup
+	}{
+		{"find top-level group", group1.ID, group1},
+		{"find another top-level group", group2.ID, group2},
+		{"find sub-group", subGroup.ID, subGroup},
+		{"not found", "nonexistent", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := session.GetGroup(tt.id)
+			if result != tt.expected {
+				t.Errorf("GetGroup(%q) = %v, want %v", tt.id, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSession_GetGroupForInstance(t *testing.T) {
+	session := NewSession("test", "/repo")
+
+	group1 := NewInstanceGroup("Group 1")
+	group1.AddInstance("inst-1")
+	group1.AddInstance("inst-2")
+
+	group2 := NewInstanceGroup("Group 2")
+	group2.AddInstance("inst-3")
+
+	subGroup := NewInstanceGroup("Sub Group")
+	subGroup.AddInstance("inst-4")
+	group2.AddSubGroup(subGroup)
+
+	session.AddGroup(group1)
+	session.AddGroup(group2)
+
+	tests := []struct {
+		name       string
+		instanceID string
+		expected   *InstanceGroup
+	}{
+		{"instance in group1", "inst-1", group1},
+		{"another instance in group1", "inst-2", group1},
+		{"instance in group2", "inst-3", group2},
+		{"instance in sub-group", "inst-4", subGroup},
+		{"instance not in any group", "inst-999", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := session.GetGroupForInstance(tt.instanceID)
+			if result != tt.expected {
+				t.Errorf("GetGroupForInstance(%q) = %v, want %v", tt.instanceID, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSession_RemoveGroup(t *testing.T) {
+	session := NewSession("test", "/repo")
+
+	group1 := NewInstanceGroup("Group 1")
+	group2 := NewInstanceGroup("Group 2")
+	group3 := NewInstanceGroup("Group 3")
+
+	session.AddGroup(group1)
+	session.AddGroup(group2)
+	session.AddGroup(group3)
+
+	session.RemoveGroup(group2.ID)
+
+	if len(session.Groups) != 2 {
+		t.Errorf("len(session.Groups) = %d, want 2", len(session.Groups))
+	}
+
+	if session.GetGroup(group2.ID) != nil {
+		t.Error("group2 should have been removed")
+	}
+
+	// Remove non-existent group (should not panic)
+	session.RemoveGroup("nonexistent")
+	if len(session.Groups) != 2 {
+		t.Error("removing non-existent group should not change length")
+	}
+}
+
+func TestSession_GetGroupsByPhase(t *testing.T) {
+	session := NewSession("test", "/repo")
+
+	group1 := NewInstanceGroup("Group 1")
+	group1.Phase = GroupPhasePending
+
+	group2 := NewInstanceGroup("Group 2")
+	group2.Phase = GroupPhaseExecuting
+
+	group3 := NewInstanceGroup("Group 3")
+	group3.Phase = GroupPhasePending
+
+	group4 := NewInstanceGroup("Group 4")
+	group4.Phase = GroupPhaseCompleted
+
+	session.AddGroup(group1)
+	session.AddGroup(group2)
+	session.AddGroup(group3)
+	session.AddGroup(group4)
+
+	tests := []struct {
+		name          string
+		phase         GroupPhase
+		expectedCount int
+	}{
+		{"pending groups", GroupPhasePending, 2},
+		{"executing groups", GroupPhaseExecuting, 1},
+		{"completed groups", GroupPhaseCompleted, 1},
+		{"failed groups", GroupPhaseFailed, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			groups := session.GetGroupsByPhase(tt.phase)
+			if len(groups) != tt.expectedCount {
+				t.Errorf("GetGroupsByPhase(%q) returned %d groups, want %d",
+					tt.phase, len(groups), tt.expectedCount)
+			}
+		})
+	}
+}
+
+func TestSession_AreGroupDependenciesMet(t *testing.T) {
+	session := NewSession("test", "/repo")
+
+	group1 := NewInstanceGroup("Group 1")
+	group1.Phase = GroupPhaseCompleted
+
+	group2 := NewInstanceGroup("Group 2")
+	group2.Phase = GroupPhaseExecuting
+
+	group3 := NewInstanceGroup("Group 3")
+	group3.DependsOn = []string{group1.ID, group2.ID}
+
+	group4 := NewInstanceGroup("Group 4")
+	group4.DependsOn = []string{group1.ID}
+
+	group5 := NewInstanceGroup("Group 5")
+	// No dependencies
+
+	group6 := NewInstanceGroup("Group 6")
+	group6.DependsOn = []string{"nonexistent"}
+
+	session.AddGroup(group1)
+	session.AddGroup(group2)
+	session.AddGroup(group3)
+	session.AddGroup(group4)
+	session.AddGroup(group5)
+	session.AddGroup(group6)
+
+	tests := []struct {
+		name     string
+		group    *InstanceGroup
+		expected bool
+	}{
+		{"no dependencies", group5, true},
+		{"all dependencies completed", group4, true},
+		{"some dependencies not completed", group3, false},
+		{"dependency on non-existent group", group6, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := session.AreGroupDependenciesMet(tt.group)
+			if result != tt.expected {
+				t.Errorf("AreGroupDependenciesMet() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSession_GetReadyGroups(t *testing.T) {
+	session := NewSession("test", "/repo")
+
+	// Group 1: completed (can't be ready)
+	group1 := NewInstanceGroup("Group 1")
+	group1.Phase = GroupPhaseCompleted
+
+	// Group 2: pending, no dependencies (ready)
+	group2 := NewInstanceGroup("Group 2")
+	group2.Phase = GroupPhasePending
+
+	// Group 3: pending, depends on completed group1 (ready)
+	group3 := NewInstanceGroup("Group 3")
+	group3.Phase = GroupPhasePending
+	group3.DependsOn = []string{group1.ID}
+
+	// Group 4: pending, depends on non-completed group2 (not ready)
+	group4 := NewInstanceGroup("Group 4")
+	group4.Phase = GroupPhasePending
+	group4.DependsOn = []string{group2.ID}
+
+	// Group 5: executing (can't be ready)
+	group5 := NewInstanceGroup("Group 5")
+	group5.Phase = GroupPhaseExecuting
+
+	session.AddGroup(group1)
+	session.AddGroup(group2)
+	session.AddGroup(group3)
+	session.AddGroup(group4)
+	session.AddGroup(group5)
+
+	ready := session.GetReadyGroups()
+
+	if len(ready) != 2 {
+		t.Errorf("GetReadyGroups() returned %d groups, want 2", len(ready))
+	}
+
+	// Verify that group2 and group3 are in the ready list
+	foundGroup2, foundGroup3 := false, false
+	for _, g := range ready {
+		if g.ID == group2.ID {
+			foundGroup2 = true
+		}
+		if g.ID == group3.ID {
+			foundGroup3 = true
+		}
+	}
+
+	if !foundGroup2 {
+		t.Error("group2 should be in ready groups")
+	}
+	if !foundGroup3 {
+		t.Error("group3 should be in ready groups")
+	}
+}
+
+func TestInstanceGroup_ExecutionOrder(t *testing.T) {
+	group1 := NewInstanceGroup("Group 1")
+	group1.ExecutionOrder = 0
+
+	group2 := NewInstanceGroup("Group 2")
+	group2.ExecutionOrder = 1
+
+	group3 := NewInstanceGroup("Group 3")
+	group3.ExecutionOrder = 2
+
+	if group1.ExecutionOrder != 0 {
+		t.Errorf("group1.ExecutionOrder = %d, want 0", group1.ExecutionOrder)
+	}
+	if group2.ExecutionOrder != 1 {
+		t.Errorf("group2.ExecutionOrder = %d, want 1", group2.ExecutionOrder)
+	}
+	if group3.ExecutionOrder != 2 {
+		t.Errorf("group3.ExecutionOrder = %d, want 2", group3.ExecutionOrder)
+	}
+}
+
+func TestInstanceGroup_DeepNesting(t *testing.T) {
+	// Test deeply nested sub-groups
+	root := NewInstanceGroup("Root")
+	root.AddInstance("inst-root")
+
+	level1 := NewInstanceGroup("Level 1")
+	level1.AddInstance("inst-1")
+	root.AddSubGroup(level1)
+
+	level2 := NewInstanceGroup("Level 2")
+	level2.AddInstance("inst-2")
+	level1.AddSubGroup(level2)
+
+	level3 := NewInstanceGroup("Level 3")
+	level3.AddInstance("inst-3")
+	level2.AddSubGroup(level3)
+
+	// Test AllInstanceIDs includes all levels
+	allIDs := root.AllInstanceIDs()
+	if len(allIDs) != 4 {
+		t.Errorf("len(AllInstanceIDs()) = %d, want 4", len(allIDs))
+	}
+
+	// Test InstanceCount
+	if count := root.InstanceCount(); count != 4 {
+		t.Errorf("root.InstanceCount() = %d, want 4", count)
+	}
+
+	// Test GetSubGroup doesn't find deeply nested groups (only direct children)
+	if found := root.GetSubGroup(level3.ID); found != nil {
+		t.Error("GetSubGroup should only return direct children")
+	}
+}
+
+func TestSession_GetGroup_DeepRecursion(t *testing.T) {
+	session := NewSession("test", "/repo")
+
+	root := NewInstanceGroup("Root")
+	level1 := NewInstanceGroup("Level 1")
+	level2 := NewInstanceGroup("Level 2")
+	level3 := NewInstanceGroup("Level 3")
+
+	level2.AddSubGroup(level3)
+	level1.AddSubGroup(level2)
+	root.AddSubGroup(level1)
+	session.AddGroup(root)
+
+	// Session.GetGroup should find deeply nested groups
+	tests := []struct {
+		name     string
+		id       string
+		expected *InstanceGroup
+	}{
+		{"find root", root.ID, root},
+		{"find level1", level1.ID, level1},
+		{"find level2", level2.ID, level2},
+		{"find level3 (deeply nested)", level3.ID, level3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := session.GetGroup(tt.id)
+			if result != tt.expected {
+				t.Errorf("GetGroup(%q) = %v, want %v", tt.id, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -103,6 +103,12 @@ type Session struct {
 	Created   time.Time   `json:"created"`
 	Instances []*Instance `json:"instances"`
 
+	// Groups holds optional visual groupings of instances for the TUI.
+	// When GroupedInstanceView is enabled, instances are organized into groups
+	// rather than displayed as a flat list. Groups can have sub-groups for
+	// representing nested dependencies (e.g., in Plan/UltraPlan workflows).
+	Groups []*InstanceGroup `json:"groups,omitempty"`
+
 	// UltraPlan holds the ultra-plan session state (nil for regular sessions)
 	UltraPlan *UltraPlanSession `json:"ultra_plan,omitempty"`
 


### PR DESCRIPTION
## Summary

This PR introduces the `InstanceGroup` type that provides hierarchical grouping support for Claude instances.

### Tasks Included
- **T2**: Design InstanceGroup type for visual grouping

### Changes
- Adds `InstanceGroup` struct in `internal/orchestrator/instance_group.go`
- Full hierarchical grouping with phases and sub-groups
- Dependency tracking between groups
- Support for plan and ultraplan execution contexts

### Merge Order
This is PR 2 of 8 in the Plan/UltraPlan feature stack.
- **Depends on**: PR #375 (Group 1)