### PR TITLE
Implement GroupManager for group lifecycle

### DIFF
--- a/internal/orchestrator/group/manager.go
+++ b/internal/orchestrator/group/manager.go
@@ -1,0 +1,440 @@
+// Package group provides execution group tracking and management for orchestration.
+package group
+
+import (
+	"slices"
+	"sync"
+	"time"
+)
+
+// GroupPhase represents the current phase of an instance group.
+// This mirrors orchestrator.GroupPhase but is defined here to avoid import cycles.
+type GroupPhase string
+
+const (
+	GroupPhasePending   GroupPhase = "pending"
+	GroupPhaseExecuting GroupPhase = "executing"
+	GroupPhaseCompleted GroupPhase = "completed"
+	GroupPhaseFailed    GroupPhase = "failed"
+)
+
+// InstanceGroup represents a visual grouping of instances.
+// This mirrors the orchestrator.InstanceGroup type for use within the group package.
+type InstanceGroup struct {
+	ID             string           `json:"id"`
+	Name           string           `json:"name"`
+	Phase          GroupPhase       `json:"phase"`
+	Instances      []string         `json:"instances"`
+	SubGroups      []*InstanceGroup `json:"sub_groups"`
+	ParentID       string           `json:"parent_id"`
+	ExecutionOrder int              `json:"execution_order"`
+	DependsOn      []string         `json:"depends_on"`
+	Created        time.Time        `json:"created"`
+}
+
+// ManagerSessionData provides the session data interface needed by Manager.
+// This is a minimal interface to avoid coupling with the full Session type.
+type ManagerSessionData interface {
+	// GetGroups returns the current list of top-level groups.
+	GetGroups() []*InstanceGroup
+
+	// SetGroups replaces the current list of top-level groups.
+	SetGroups(groups []*InstanceGroup)
+
+	// GenerateID generates a unique ID for a new group.
+	GenerateID() string
+}
+
+// Manager handles active manipulation of instance groups within a session.
+// It provides methods for creating, modifying, and organizing groups,
+// complementing the read-only Tracker which is focused on execution state queries.
+//
+// Manager is safe for concurrent use.
+type Manager struct {
+	session ManagerSessionData
+	mu      sync.RWMutex
+}
+
+// NewManager creates a new group manager for the given session.
+// The session must implement ManagerSessionData and must not be nil.
+func NewManager(session ManagerSessionData) *Manager {
+	if session == nil {
+		panic("group.NewManager: session must not be nil")
+	}
+	return &Manager{
+		session: session,
+	}
+}
+
+// CreateGroup creates a new top-level group with the given name and instance IDs.
+// The group is appended to the end of the session's group list with an appropriate
+// execution order. Returns the newly created group.
+func (m *Manager) CreateGroup(name string, instanceIDs []string) *InstanceGroup {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	groups := m.session.GetGroups()
+
+	// Determine execution order (next available)
+	executionOrder := 0
+	for _, g := range groups {
+		if g.ExecutionOrder >= executionOrder {
+			executionOrder = g.ExecutionOrder + 1
+		}
+	}
+
+	group := &InstanceGroup{
+		ID:             m.session.GenerateID(),
+		Name:           name,
+		Phase:          GroupPhasePending,
+		Instances:      make([]string, len(instanceIDs)),
+		SubGroups:      make([]*InstanceGroup, 0),
+		DependsOn:      make([]string, 0),
+		ExecutionOrder: executionOrder,
+		Created:        time.Now(),
+	}
+	copy(group.Instances, instanceIDs)
+
+	groups = append(groups, group)
+	m.session.SetGroups(groups)
+
+	return group
+}
+
+// CreateSubGroup creates a new sub-group within the specified parent group.
+// Returns the newly created sub-group, or nil if the parent group is not found.
+func (m *Manager) CreateSubGroup(parentID, name string, instanceIDs []string) *InstanceGroup {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	parent := m.findGroupByID(parentID)
+	if parent == nil {
+		return nil
+	}
+
+	// Determine execution order for sub-group
+	executionOrder := 0
+	for _, sg := range parent.SubGroups {
+		if sg.ExecutionOrder >= executionOrder {
+			executionOrder = sg.ExecutionOrder + 1
+		}
+	}
+
+	subGroup := &InstanceGroup{
+		ID:             m.session.GenerateID(),
+		Name:           name,
+		Phase:          GroupPhasePending,
+		Instances:      make([]string, len(instanceIDs)),
+		SubGroups:      make([]*InstanceGroup, 0),
+		ParentID:       parentID,
+		DependsOn:      make([]string, 0),
+		ExecutionOrder: executionOrder,
+		Created:        time.Now(),
+	}
+	copy(subGroup.Instances, instanceIDs)
+
+	parent.SubGroups = append(parent.SubGroups, subGroup)
+
+	return subGroup
+}
+
+// MoveInstanceToGroup moves an instance from its current group to a new group.
+// If the instance is not currently in any group, it is simply added to the target group.
+// If the target group is not found, this method does nothing.
+func (m *Manager) MoveInstanceToGroup(instanceID, groupID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	targetGroup := m.findGroupByID(groupID)
+	if targetGroup == nil {
+		return
+	}
+
+	// Remove from current group (if any)
+	m.removeInstanceFromAllGroups(instanceID)
+
+	// Add to target group
+	targetGroup.Instances = append(targetGroup.Instances, instanceID)
+}
+
+// GetGroupForInstance returns the group containing the specified instance ID.
+// Returns nil if the instance is not found in any group.
+func (m *Manager) GetGroupForInstance(instanceID string) *InstanceGroup {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.findGroupContainingInstance(instanceID)
+}
+
+// AdvanceGroupPhase updates the phase of the specified group.
+// Does nothing if the group is not found.
+func (m *Manager) AdvanceGroupPhase(groupID string, phase GroupPhase) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	group := m.findGroupByID(groupID)
+	if group == nil {
+		return
+	}
+
+	group.Phase = phase
+}
+
+// ReorderGroups reorders the top-level groups according to the provided order.
+// The newOrder slice should contain group IDs in the desired order.
+// Groups not in newOrder are appended at the end in their original order.
+// Non-existent group IDs in newOrder are ignored.
+func (m *Manager) ReorderGroups(newOrder []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	groups := m.session.GetGroups()
+	if len(groups) == 0 {
+		return
+	}
+
+	// Build a map of group ID to group for quick lookup
+	groupMap := make(map[string]*InstanceGroup)
+	for _, g := range groups {
+		groupMap[g.ID] = g
+	}
+
+	// Build the reordered list
+	reordered := make([]*InstanceGroup, 0, len(groups))
+	seen := make(map[string]bool)
+
+	// First, add groups in the specified order
+	for _, id := range newOrder {
+		if g, exists := groupMap[id]; exists && !seen[id] {
+			reordered = append(reordered, g)
+			seen[id] = true
+		}
+	}
+
+	// Then, add any remaining groups that weren't in newOrder
+	for _, g := range groups {
+		if !seen[g.ID] {
+			reordered = append(reordered, g)
+		}
+	}
+
+	// Update execution orders to match new positions
+	for i, g := range reordered {
+		g.ExecutionOrder = i
+	}
+
+	m.session.SetGroups(reordered)
+}
+
+// FlattenGroups returns all instance IDs in execution order.
+// Groups are processed in execution order, and within each group,
+// instances are returned in their stored order. Sub-groups are processed
+// immediately after their parent group's direct instances.
+func (m *Manager) FlattenGroups() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	groups := m.session.GetGroups()
+	if len(groups) == 0 {
+		return nil
+	}
+
+	// Sort groups by execution order
+	sortedGroups := m.sortGroupsByExecutionOrder(groups)
+
+	var result []string
+	for _, g := range sortedGroups {
+		result = append(result, m.flattenGroup(g)...)
+	}
+
+	return result
+}
+
+// GetGroup returns the group with the specified ID, or nil if not found.
+// This searches both top-level groups and sub-groups.
+func (m *Manager) GetGroup(id string) *InstanceGroup {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.findGroupByID(id)
+}
+
+// GetAllGroups returns all top-level groups.
+func (m *Manager) GetAllGroups() []*InstanceGroup {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	groups := m.session.GetGroups()
+	result := make([]*InstanceGroup, len(groups))
+	copy(result, groups)
+	return result
+}
+
+// RemoveGroup removes a group by ID. If the group has sub-groups,
+// they are also removed. Instances in the group are not deleted,
+// they simply become ungrouped.
+func (m *Manager) RemoveGroup(id string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	groups := m.session.GetGroups()
+
+	// Check top-level groups
+	for i, g := range groups {
+		if g.ID == id {
+			groups = append(groups[:i], groups[i+1:]...)
+			m.session.SetGroups(groups)
+			return true
+		}
+
+		// Check sub-groups
+		if m.removeSubGroup(g, id) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// SetGroupDependencies sets the dependencies for a group.
+// dependsOn is a list of group IDs that must complete before this group can execute.
+func (m *Manager) SetGroupDependencies(groupID string, dependsOn []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	group := m.findGroupByID(groupID)
+	if group == nil {
+		return
+	}
+
+	group.DependsOn = make([]string, len(dependsOn))
+	copy(group.DependsOn, dependsOn)
+}
+
+// findGroupByID searches for a group by ID in all groups and sub-groups.
+// Must be called with lock held.
+func (m *Manager) findGroupByID(id string) *InstanceGroup {
+	groups := m.session.GetGroups()
+	for _, g := range groups {
+		if g.ID == id {
+			return g
+		}
+		if found := m.findGroupByIDRecursive(g, id); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// findGroupByIDRecursive recursively searches sub-groups for a group with the given ID.
+func (m *Manager) findGroupByIDRecursive(group *InstanceGroup, id string) *InstanceGroup {
+	for _, sg := range group.SubGroups {
+		if sg.ID == id {
+			return sg
+		}
+		if found := m.findGroupByIDRecursive(sg, id); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// findGroupContainingInstance searches for the group containing the given instance ID.
+// Must be called with lock held.
+func (m *Manager) findGroupContainingInstance(instanceID string) *InstanceGroup {
+	groups := m.session.GetGroups()
+	for _, g := range groups {
+		if found := m.findGroupContainingInstanceRecursive(g, instanceID); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// findGroupContainingInstanceRecursive recursively searches for a group containing an instance.
+func (m *Manager) findGroupContainingInstanceRecursive(group *InstanceGroup, instanceID string) *InstanceGroup {
+	if slices.Contains(group.Instances, instanceID) {
+		return group
+	}
+	for _, sg := range group.SubGroups {
+		if found := m.findGroupContainingInstanceRecursive(sg, instanceID); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// removeInstanceFromAllGroups removes an instance from all groups and sub-groups.
+// Must be called with lock held.
+func (m *Manager) removeInstanceFromAllGroups(instanceID string) {
+	groups := m.session.GetGroups()
+	for _, g := range groups {
+		m.removeInstanceFromGroupRecursive(g, instanceID)
+	}
+}
+
+// removeInstanceFromGroupRecursive removes an instance from a group and its sub-groups.
+func (m *Manager) removeInstanceFromGroupRecursive(group *InstanceGroup, instanceID string) {
+	// Remove from this group's instances
+	for i, id := range group.Instances {
+		if id == instanceID {
+			group.Instances = append(group.Instances[:i], group.Instances[i+1:]...)
+			break
+		}
+	}
+
+	// Remove from sub-groups
+	for _, sg := range group.SubGroups {
+		m.removeInstanceFromGroupRecursive(sg, instanceID)
+	}
+}
+
+// removeSubGroup removes a sub-group from a parent group by ID.
+// Returns true if the sub-group was found and removed.
+func (m *Manager) removeSubGroup(parent *InstanceGroup, id string) bool {
+	for i, sg := range parent.SubGroups {
+		if sg.ID == id {
+			parent.SubGroups = append(parent.SubGroups[:i], parent.SubGroups[i+1:]...)
+			return true
+		}
+		if m.removeSubGroup(sg, id) {
+			return true
+		}
+	}
+	return false
+}
+
+// sortGroupsByExecutionOrder returns a copy of groups sorted by ExecutionOrder.
+func (m *Manager) sortGroupsByExecutionOrder(groups []*InstanceGroup) []*InstanceGroup {
+	sorted := make([]*InstanceGroup, len(groups))
+	copy(sorted, groups)
+
+	// Simple insertion sort (groups list is typically small)
+	for i := 1; i < len(sorted); i++ {
+		key := sorted[i]
+		j := i - 1
+		for j >= 0 && sorted[j].ExecutionOrder > key.ExecutionOrder {
+			sorted[j+1] = sorted[j]
+			j--
+		}
+		sorted[j+1] = key
+	}
+
+	return sorted
+}
+
+// flattenGroup returns all instance IDs from a group and its sub-groups in order.
+func (m *Manager) flattenGroup(group *InstanceGroup) []string {
+	var result []string
+
+	// First, add this group's direct instances
+	result = append(result, group.Instances...)
+
+	// Then, add sub-groups' instances in execution order
+	sortedSubGroups := m.sortGroupsByExecutionOrder(group.SubGroups)
+	for _, sg := range sortedSubGroups {
+		result = append(result, m.flattenGroup(sg)...)
+	}
+
+	return result
+}

--- a/internal/orchestrator/group/manager_test.go
+++ b/internal/orchestrator/group/manager_test.go
@@ -1,0 +1,854 @@
+package group
+
+import (
+	"sync"
+	"testing"
+)
+
+// mockManagerSession implements ManagerSessionData for testing.
+type mockManagerSession struct {
+	groups    []*InstanceGroup
+	idCounter int
+	mu        sync.Mutex
+}
+
+func newMockManagerSession() *mockManagerSession {
+	return &mockManagerSession{
+		groups: make([]*InstanceGroup, 0),
+	}
+}
+
+func (m *mockManagerSession) GetGroups() []*InstanceGroup {
+	return m.groups
+}
+
+func (m *mockManagerSession) SetGroups(groups []*InstanceGroup) {
+	m.groups = groups
+}
+
+func (m *mockManagerSession) GenerateID() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.idCounter++
+	return "test-id-" + string(rune('0'+m.idCounter))
+}
+
+func TestNewManager(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	if manager == nil {
+		t.Fatal("NewManager returned nil")
+	}
+	if manager.session != session {
+		t.Error("manager.session does not match provided session")
+	}
+}
+
+func TestNewManager_NilSession(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when session is nil")
+		}
+	}()
+	NewManager(nil)
+}
+
+func TestCreateGroup(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	instances := []string{"inst-1", "inst-2"}
+	group := manager.CreateGroup("Test Group", instances)
+
+	if group == nil {
+		t.Fatal("CreateGroup returned nil")
+	}
+	if group.Name != "Test Group" {
+		t.Errorf("group.Name = %q, want %q", group.Name, "Test Group")
+	}
+	if group.Phase != GroupPhasePending {
+		t.Errorf("group.Phase = %q, want %q", group.Phase, GroupPhasePending)
+	}
+	if len(group.Instances) != 2 {
+		t.Errorf("len(group.Instances) = %d, want 2", len(group.Instances))
+	}
+	if group.ExecutionOrder != 0 {
+		t.Errorf("group.ExecutionOrder = %d, want 0", group.ExecutionOrder)
+	}
+	if group.Created.IsZero() {
+		t.Error("group.Created should not be zero")
+	}
+
+	// Verify group is added to session
+	groups := session.GetGroups()
+	if len(groups) != 1 {
+		t.Errorf("len(groups) = %d, want 1", len(groups))
+	}
+}
+
+func TestCreateGroup_ExecutionOrder(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	group1 := manager.CreateGroup("Group 1", nil)
+	group2 := manager.CreateGroup("Group 2", nil)
+	group3 := manager.CreateGroup("Group 3", nil)
+
+	if group1.ExecutionOrder != 0 {
+		t.Errorf("group1.ExecutionOrder = %d, want 0", group1.ExecutionOrder)
+	}
+	if group2.ExecutionOrder != 1 {
+		t.Errorf("group2.ExecutionOrder = %d, want 1", group2.ExecutionOrder)
+	}
+	if group3.ExecutionOrder != 2 {
+		t.Errorf("group3.ExecutionOrder = %d, want 2", group3.ExecutionOrder)
+	}
+}
+
+func TestCreateGroup_InstancesCopied(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	instances := []string{"inst-1", "inst-2"}
+	group := manager.CreateGroup("Test Group", instances)
+
+	// Modify original slice
+	instances[0] = "modified"
+
+	// Group should have original values
+	if group.Instances[0] != "inst-1" {
+		t.Error("group.Instances was not copied - shares memory with input")
+	}
+}
+
+func TestCreateSubGroup(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	parent := manager.CreateGroup("Parent", nil)
+	subGroup := manager.CreateSubGroup(parent.ID, "SubGroup", []string{"inst-1"})
+
+	if subGroup == nil {
+		t.Fatal("CreateSubGroup returned nil")
+	}
+	if subGroup.Name != "SubGroup" {
+		t.Errorf("subGroup.Name = %q, want %q", subGroup.Name, "SubGroup")
+	}
+	if subGroup.ParentID != parent.ID {
+		t.Errorf("subGroup.ParentID = %q, want %q", subGroup.ParentID, parent.ID)
+	}
+	if len(parent.SubGroups) != 1 {
+		t.Errorf("len(parent.SubGroups) = %d, want 1", len(parent.SubGroups))
+	}
+	if parent.SubGroups[0] != subGroup {
+		t.Error("subGroup not added to parent.SubGroups")
+	}
+}
+
+func TestCreateSubGroup_NonExistentParent(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	subGroup := manager.CreateSubGroup("non-existent", "SubGroup", nil)
+	if subGroup != nil {
+		t.Error("CreateSubGroup should return nil for non-existent parent")
+	}
+}
+
+func TestCreateSubGroup_ExecutionOrder(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	parent := manager.CreateGroup("Parent", nil)
+	sub1 := manager.CreateSubGroup(parent.ID, "Sub1", nil)
+	sub2 := manager.CreateSubGroup(parent.ID, "Sub2", nil)
+	sub3 := manager.CreateSubGroup(parent.ID, "Sub3", nil)
+
+	if sub1.ExecutionOrder != 0 {
+		t.Errorf("sub1.ExecutionOrder = %d, want 0", sub1.ExecutionOrder)
+	}
+	if sub2.ExecutionOrder != 1 {
+		t.Errorf("sub2.ExecutionOrder = %d, want 1", sub2.ExecutionOrder)
+	}
+	if sub3.ExecutionOrder != 2 {
+		t.Errorf("sub3.ExecutionOrder = %d, want 2", sub3.ExecutionOrder)
+	}
+}
+
+func TestMoveInstanceToGroup(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	group1 := manager.CreateGroup("Group 1", []string{"inst-1", "inst-2"})
+	group2 := manager.CreateGroup("Group 2", nil)
+
+	manager.MoveInstanceToGroup("inst-1", group2.ID)
+
+	// inst-1 should be removed from group1
+	if len(group1.Instances) != 1 || group1.Instances[0] != "inst-2" {
+		t.Errorf("inst-1 not removed from group1: %v", group1.Instances)
+	}
+
+	// inst-1 should be added to group2
+	if len(group2.Instances) != 1 || group2.Instances[0] != "inst-1" {
+		t.Errorf("inst-1 not added to group2: %v", group2.Instances)
+	}
+}
+
+func TestMoveInstanceToGroup_NonExistentTarget(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	group1 := manager.CreateGroup("Group 1", []string{"inst-1"})
+
+	// This should do nothing
+	manager.MoveInstanceToGroup("inst-1", "non-existent")
+
+	// inst-1 should still be in group1
+	if len(group1.Instances) != 1 || group1.Instances[0] != "inst-1" {
+		t.Errorf("inst-1 was moved when target doesn't exist: %v", group1.Instances)
+	}
+}
+
+func TestMoveInstanceToGroup_Ungrouped(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	group := manager.CreateGroup("Group", nil)
+
+	// Move an instance that isn't in any group
+	manager.MoveInstanceToGroup("new-inst", group.ID)
+
+	if len(group.Instances) != 1 || group.Instances[0] != "new-inst" {
+		t.Errorf("ungrouped instance not added: %v", group.Instances)
+	}
+}
+
+func TestMoveInstanceToGroup_FromSubGroup(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	parent := manager.CreateGroup("Parent", nil)
+	subGroup := manager.CreateSubGroup(parent.ID, "SubGroup", []string{"inst-1"})
+	target := manager.CreateGroup("Target", nil)
+
+	manager.MoveInstanceToGroup("inst-1", target.ID)
+
+	// inst-1 should be removed from subGroup
+	if len(subGroup.Instances) != 0 {
+		t.Errorf("inst-1 not removed from subGroup: %v", subGroup.Instances)
+	}
+
+	// inst-1 should be added to target
+	if len(target.Instances) != 1 || target.Instances[0] != "inst-1" {
+		t.Errorf("inst-1 not added to target: %v", target.Instances)
+	}
+}
+
+func TestGetGroupForInstance(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	group1 := manager.CreateGroup("Group 1", []string{"inst-1", "inst-2"})
+	manager.CreateGroup("Group 2", []string{"inst-3"})
+
+	found := manager.GetGroupForInstance("inst-1")
+	if found == nil {
+		t.Fatal("GetGroupForInstance returned nil")
+	}
+	if found.ID != group1.ID {
+		t.Errorf("found.ID = %q, want %q", found.ID, group1.ID)
+	}
+}
+
+func TestGetGroupForInstance_NotFound(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	manager.CreateGroup("Group", []string{"inst-1"})
+
+	found := manager.GetGroupForInstance("non-existent")
+	if found != nil {
+		t.Error("GetGroupForInstance should return nil for non-existent instance")
+	}
+}
+
+func TestGetGroupForInstance_InSubGroup(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	parent := manager.CreateGroup("Parent", []string{"inst-1"})
+	subGroup := manager.CreateSubGroup(parent.ID, "SubGroup", []string{"inst-2"})
+
+	found := manager.GetGroupForInstance("inst-2")
+	if found == nil {
+		t.Fatal("GetGroupForInstance returned nil")
+	}
+	if found.ID != subGroup.ID {
+		t.Errorf("found.ID = %q, want %q", found.ID, subGroup.ID)
+	}
+}
+
+func TestAdvanceGroupPhase(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	group := manager.CreateGroup("Group", nil)
+
+	if group.Phase != GroupPhasePending {
+		t.Fatalf("initial phase = %q, want %q", group.Phase, GroupPhasePending)
+	}
+
+	manager.AdvanceGroupPhase(group.ID, GroupPhaseExecuting)
+	if group.Phase != GroupPhaseExecuting {
+		t.Errorf("phase after advance = %q, want %q", group.Phase, GroupPhaseExecuting)
+	}
+
+	manager.AdvanceGroupPhase(group.ID, GroupPhaseCompleted)
+	if group.Phase != GroupPhaseCompleted {
+		t.Errorf("phase after second advance = %q, want %q", group.Phase, GroupPhaseCompleted)
+	}
+}
+
+func TestAdvanceGroupPhase_NonExistent(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	// Should not panic
+	manager.AdvanceGroupPhase("non-existent", GroupPhaseExecuting)
+}
+
+func TestAdvanceGroupPhase_SubGroup(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	parent := manager.CreateGroup("Parent", nil)
+	subGroup := manager.CreateSubGroup(parent.ID, "SubGroup", nil)
+
+	manager.AdvanceGroupPhase(subGroup.ID, GroupPhaseExecuting)
+	if subGroup.Phase != GroupPhaseExecuting {
+		t.Errorf("subGroup.Phase = %q, want %q", subGroup.Phase, GroupPhaseExecuting)
+	}
+}
+
+func TestReorderGroups(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	group1 := manager.CreateGroup("Group 1", nil)
+	group2 := manager.CreateGroup("Group 2", nil)
+	group3 := manager.CreateGroup("Group 3", nil)
+
+	// Reorder: 3, 1, 2
+	manager.ReorderGroups([]string{group3.ID, group1.ID, group2.ID})
+
+	groups := manager.GetAllGroups()
+	if groups[0].ID != group3.ID {
+		t.Errorf("groups[0].ID = %q, want %q", groups[0].ID, group3.ID)
+	}
+	if groups[1].ID != group1.ID {
+		t.Errorf("groups[1].ID = %q, want %q", groups[1].ID, group1.ID)
+	}
+	if groups[2].ID != group2.ID {
+		t.Errorf("groups[2].ID = %q, want %q", groups[2].ID, group2.ID)
+	}
+
+	// Check execution orders updated
+	if groups[0].ExecutionOrder != 0 {
+		t.Errorf("groups[0].ExecutionOrder = %d, want 0", groups[0].ExecutionOrder)
+	}
+	if groups[1].ExecutionOrder != 1 {
+		t.Errorf("groups[1].ExecutionOrder = %d, want 1", groups[1].ExecutionOrder)
+	}
+	if groups[2].ExecutionOrder != 2 {
+		t.Errorf("groups[2].ExecutionOrder = %d, want 2", groups[2].ExecutionOrder)
+	}
+}
+
+func TestReorderGroups_PartialOrder(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	group1 := manager.CreateGroup("Group 1", nil)
+	group2 := manager.CreateGroup("Group 2", nil)
+	group3 := manager.CreateGroup("Group 3", nil)
+
+	// Only specify group3 - others should be appended
+	manager.ReorderGroups([]string{group3.ID})
+
+	groups := manager.GetAllGroups()
+	if groups[0].ID != group3.ID {
+		t.Errorf("groups[0].ID = %q, want %q", groups[0].ID, group3.ID)
+	}
+	// group1 and group2 should follow in original order
+	if groups[1].ID != group1.ID {
+		t.Errorf("groups[1].ID = %q, want %q", groups[1].ID, group1.ID)
+	}
+	if groups[2].ID != group2.ID {
+		t.Errorf("groups[2].ID = %q, want %q", groups[2].ID, group2.ID)
+	}
+}
+
+func TestReorderGroups_NonExistentIDs(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	group1 := manager.CreateGroup("Group 1", nil)
+	group2 := manager.CreateGroup("Group 2", nil)
+
+	// Include non-existent ID
+	manager.ReorderGroups([]string{"non-existent", group2.ID, group1.ID})
+
+	groups := manager.GetAllGroups()
+	// Non-existent should be ignored
+	if groups[0].ID != group2.ID {
+		t.Errorf("groups[0].ID = %q, want %q", groups[0].ID, group2.ID)
+	}
+	if groups[1].ID != group1.ID {
+		t.Errorf("groups[1].ID = %q, want %q", groups[1].ID, group1.ID)
+	}
+}
+
+func TestReorderGroups_Empty(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	// Should not panic
+	manager.ReorderGroups([]string{})
+}
+
+func TestReorderGroups_DuplicateIDs(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	group1 := manager.CreateGroup("Group 1", nil)
+	group2 := manager.CreateGroup("Group 2", nil)
+
+	// Duplicate group1
+	manager.ReorderGroups([]string{group1.ID, group1.ID, group2.ID})
+
+	groups := manager.GetAllGroups()
+	// Should only appear once
+	if len(groups) != 2 {
+		t.Errorf("len(groups) = %d, want 2", len(groups))
+	}
+	if groups[0].ID != group1.ID {
+		t.Errorf("groups[0].ID = %q, want %q", groups[0].ID, group1.ID)
+	}
+	if groups[1].ID != group2.ID {
+		t.Errorf("groups[1].ID = %q, want %q", groups[1].ID, group2.ID)
+	}
+}
+
+func TestFlattenGroups(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	manager.CreateGroup("Group 1", []string{"inst-1", "inst-2"})
+	manager.CreateGroup("Group 2", []string{"inst-3"})
+
+	flat := manager.FlattenGroups()
+
+	expected := []string{"inst-1", "inst-2", "inst-3"}
+	if len(flat) != len(expected) {
+		t.Fatalf("len(flat) = %d, want %d", len(flat), len(expected))
+	}
+	for i, id := range expected {
+		if flat[i] != id {
+			t.Errorf("flat[%d] = %q, want %q", i, flat[i], id)
+		}
+	}
+}
+
+func TestFlattenGroups_WithSubGroups(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	parent := manager.CreateGroup("Parent", []string{"inst-1"})
+	manager.CreateSubGroup(parent.ID, "SubGroup", []string{"inst-2", "inst-3"})
+
+	flat := manager.FlattenGroups()
+
+	// Parent instances first, then sub-group instances
+	expected := []string{"inst-1", "inst-2", "inst-3"}
+	if len(flat) != len(expected) {
+		t.Fatalf("len(flat) = %d, want %d", len(flat), len(expected))
+	}
+	for i, id := range expected {
+		if flat[i] != id {
+			t.Errorf("flat[%d] = %q, want %q", i, flat[i], id)
+		}
+	}
+}
+
+func TestFlattenGroups_RespectsExecutionOrder(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	group1 := manager.CreateGroup("Group 1", []string{"inst-1"})
+	group2 := manager.CreateGroup("Group 2", []string{"inst-2"})
+	manager.CreateGroup("Group 3", []string{"inst-3"})
+
+	// Reorder to: 2, 3, 1
+	manager.ReorderGroups([]string{group2.ID, session.groups[2].ID, group1.ID})
+
+	flat := manager.FlattenGroups()
+
+	expected := []string{"inst-2", "inst-3", "inst-1"}
+	if len(flat) != len(expected) {
+		t.Fatalf("len(flat) = %d, want %d", len(flat), len(expected))
+	}
+	for i, id := range expected {
+		if flat[i] != id {
+			t.Errorf("flat[%d] = %q, want %q", i, flat[i], id)
+		}
+	}
+}
+
+func TestFlattenGroups_Empty(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	flat := manager.FlattenGroups()
+	if flat != nil {
+		t.Errorf("FlattenGroups on empty session = %v, want nil", flat)
+	}
+}
+
+func TestFlattenGroups_NestedSubGroups(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	parent := manager.CreateGroup("Parent", []string{"inst-1"})
+	sub1 := manager.CreateSubGroup(parent.ID, "Sub1", []string{"inst-2"})
+	manager.CreateSubGroup(sub1.ID, "Sub1-1", []string{"inst-3"})
+
+	flat := manager.FlattenGroups()
+
+	// Order: parent instances, sub1 instances, sub1-1 instances
+	expected := []string{"inst-1", "inst-2", "inst-3"}
+	if len(flat) != len(expected) {
+		t.Fatalf("len(flat) = %d, want %d", len(flat), len(expected))
+	}
+	for i, id := range expected {
+		if flat[i] != id {
+			t.Errorf("flat[%d] = %q, want %q", i, flat[i], id)
+		}
+	}
+}
+
+func TestGetGroup(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	group := manager.CreateGroup("Group", nil)
+	found := manager.GetGroup(group.ID)
+
+	if found == nil {
+		t.Fatal("GetGroup returned nil")
+	}
+	if found.ID != group.ID {
+		t.Errorf("found.ID = %q, want %q", found.ID, group.ID)
+	}
+}
+
+func TestGetGroup_SubGroup(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	parent := manager.CreateGroup("Parent", nil)
+	subGroup := manager.CreateSubGroup(parent.ID, "SubGroup", nil)
+
+	found := manager.GetGroup(subGroup.ID)
+	if found == nil {
+		t.Fatal("GetGroup returned nil for sub-group")
+	}
+	if found.ID != subGroup.ID {
+		t.Errorf("found.ID = %q, want %q", found.ID, subGroup.ID)
+	}
+}
+
+func TestGetGroup_NotFound(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	found := manager.GetGroup("non-existent")
+	if found != nil {
+		t.Error("GetGroup should return nil for non-existent ID")
+	}
+}
+
+func TestGetAllGroups(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	group1 := manager.CreateGroup("Group 1", nil)
+	group2 := manager.CreateGroup("Group 2", nil)
+
+	groups := manager.GetAllGroups()
+
+	if len(groups) != 2 {
+		t.Fatalf("len(groups) = %d, want 2", len(groups))
+	}
+	if groups[0].ID != group1.ID {
+		t.Errorf("groups[0].ID = %q, want %q", groups[0].ID, group1.ID)
+	}
+	if groups[1].ID != group2.ID {
+		t.Errorf("groups[1].ID = %q, want %q", groups[1].ID, group2.ID)
+	}
+}
+
+func TestGetAllGroups_Empty(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	groups := manager.GetAllGroups()
+	if len(groups) != 0 {
+		t.Errorf("len(groups) = %d, want 0", len(groups))
+	}
+}
+
+func TestRemoveGroup(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	group := manager.CreateGroup("Group", nil)
+
+	removed := manager.RemoveGroup(group.ID)
+	if !removed {
+		t.Error("RemoveGroup returned false")
+	}
+
+	groups := manager.GetAllGroups()
+	if len(groups) != 0 {
+		t.Errorf("len(groups) = %d, want 0", len(groups))
+	}
+}
+
+func TestRemoveGroup_SubGroup(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	parent := manager.CreateGroup("Parent", nil)
+	subGroup := manager.CreateSubGroup(parent.ID, "SubGroup", nil)
+
+	removed := manager.RemoveGroup(subGroup.ID)
+	if !removed {
+		t.Error("RemoveGroup returned false for sub-group")
+	}
+
+	if len(parent.SubGroups) != 0 {
+		t.Errorf("len(parent.SubGroups) = %d, want 0", len(parent.SubGroups))
+	}
+}
+
+func TestRemoveGroup_NonExistent(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	removed := manager.RemoveGroup("non-existent")
+	if removed {
+		t.Error("RemoveGroup should return false for non-existent ID")
+	}
+}
+
+func TestSetGroupDependencies(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	group1 := manager.CreateGroup("Group 1", nil)
+	group2 := manager.CreateGroup("Group 2", nil)
+
+	manager.SetGroupDependencies(group2.ID, []string{group1.ID})
+
+	if len(group2.DependsOn) != 1 {
+		t.Fatalf("len(group2.DependsOn) = %d, want 1", len(group2.DependsOn))
+	}
+	if group2.DependsOn[0] != group1.ID {
+		t.Errorf("group2.DependsOn[0] = %q, want %q", group2.DependsOn[0], group1.ID)
+	}
+}
+
+func TestSetGroupDependencies_NonExistent(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	// Should not panic
+	manager.SetGroupDependencies("non-existent", []string{"dep-1"})
+}
+
+func TestSetGroupDependencies_ReplacesPrevious(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	group := manager.CreateGroup("Group", nil)
+	manager.SetGroupDependencies(group.ID, []string{"dep-1", "dep-2"})
+	manager.SetGroupDependencies(group.ID, []string{"dep-3"})
+
+	if len(group.DependsOn) != 1 {
+		t.Fatalf("len(group.DependsOn) = %d, want 1", len(group.DependsOn))
+	}
+	if group.DependsOn[0] != "dep-3" {
+		t.Errorf("group.DependsOn[0] = %q, want %q", group.DependsOn[0], "dep-3")
+	}
+}
+
+func TestConcurrency_CreateGroup(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	var wg sync.WaitGroup
+	numGroups := 100
+
+	for i := 0; i < numGroups; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			manager.CreateGroup("Group", []string{"inst-" + string(rune('a'+idx%26))})
+		}(i)
+	}
+
+	wg.Wait()
+
+	groups := manager.GetAllGroups()
+	if len(groups) != numGroups {
+		t.Errorf("len(groups) = %d, want %d", len(groups), numGroups)
+	}
+}
+
+func TestConcurrency_MixedOperations(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	// Create initial groups
+	group := manager.CreateGroup("Initial", []string{"inst-1", "inst-2", "inst-3"})
+
+	var wg sync.WaitGroup
+
+	// Concurrent reads
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			manager.GetGroupForInstance("inst-1")
+			manager.GetAllGroups()
+			manager.FlattenGroups()
+		}()
+	}
+
+	// Concurrent writes
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			manager.AdvanceGroupPhase(group.ID, GroupPhaseExecuting)
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify no corruption
+	found := manager.GetGroupForInstance("inst-1")
+	if found == nil {
+		t.Error("instance not found after concurrent operations")
+	}
+}
+
+func TestDeeplyNestedSubGroups(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	// Create deeply nested structure
+	root := manager.CreateGroup("Root", []string{"root-inst"})
+	level1 := manager.CreateSubGroup(root.ID, "Level1", []string{"l1-inst"})
+	level2 := manager.CreateSubGroup(level1.ID, "Level2", []string{"l2-inst"})
+	level3 := manager.CreateSubGroup(level2.ID, "Level3", []string{"l3-inst"})
+
+	// Find instance in deepest level
+	found := manager.GetGroupForInstance("l3-inst")
+	if found == nil {
+		t.Fatal("GetGroupForInstance returned nil for deeply nested instance")
+	}
+	if found.ID != level3.ID {
+		t.Errorf("found.ID = %q, want %q", found.ID, level3.ID)
+	}
+
+	// Flatten should include all instances
+	flat := manager.FlattenGroups()
+	expected := []string{"root-inst", "l1-inst", "l2-inst", "l3-inst"}
+	if len(flat) != len(expected) {
+		t.Fatalf("len(flat) = %d, want %d", len(flat), len(expected))
+	}
+
+	// Find deeply nested group
+	foundGroup := manager.GetGroup(level3.ID)
+	if foundGroup == nil {
+		t.Error("GetGroup returned nil for deeply nested group")
+	}
+
+	// Remove deeply nested group
+	removed := manager.RemoveGroup(level3.ID)
+	if !removed {
+		t.Error("RemoveGroup returned false for deeply nested group")
+	}
+	if len(level2.SubGroups) != 0 {
+		t.Error("deeply nested group not removed from parent")
+	}
+}
+
+func TestComplexScenario_WorkflowSimulation(t *testing.T) {
+	session := newMockManagerSession()
+	manager := NewManager(session)
+
+	// Simulate a multi-group workflow
+
+	// 1. Create groups for different phases
+	foundation := manager.CreateGroup("Foundation", []string{"setup-db", "setup-auth"})
+	features := manager.CreateGroup("Features", []string{"feat-1", "feat-2", "feat-3"})
+	integration := manager.CreateGroup("Integration", []string{"int-1"})
+
+	// 2. Set dependencies: integration depends on features, features depends on foundation
+	manager.SetGroupDependencies(features.ID, []string{foundation.ID})
+	manager.SetGroupDependencies(integration.ID, []string{features.ID})
+
+	// 3. Create sub-groups for feature branches
+	manager.CreateSubGroup(features.ID, "Feature Subset A", []string{"feat-a1", "feat-a2"})
+	manager.CreateSubGroup(features.ID, "Feature Subset B", []string{"feat-b1"})
+
+	// 4. Advance phases
+	manager.AdvanceGroupPhase(foundation.ID, GroupPhaseExecuting)
+
+	// 5. Move an instance between groups
+	manager.MoveInstanceToGroup("feat-1", integration.ID)
+
+	// Verify final state
+	flat := manager.FlattenGroups()
+	t.Logf("Flattened order: %v", flat)
+
+	// foundation instances should come first
+	if flat[0] != "setup-db" || flat[1] != "setup-auth" {
+		t.Error("foundation instances not at start")
+	}
+
+	// feat-1 should now be in integration (at end)
+	integrationGroup := manager.GetGroup(integration.ID)
+	foundInIntegration := false
+	for _, id := range integrationGroup.Instances {
+		if id == "feat-1" {
+			foundInIntegration = true
+			break
+		}
+	}
+	if !foundInIntegration {
+		t.Error("feat-1 not found in integration group after move")
+	}
+
+	// Verify dependencies
+	if len(features.DependsOn) != 1 || features.DependsOn[0] != foundation.ID {
+		t.Errorf("features.DependsOn = %v, want [%s]", features.DependsOn, foundation.ID)
+	}
+	if len(integration.DependsOn) != 1 || integration.DependsOn[0] != features.ID {
+		t.Errorf("integration.DependsOn = %v, want [%s]", integration.DependsOn, features.ID)
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds the `GroupManager` that handles thread-safe lifecycle management for instance groups.

### Tasks Included
- **T3**: Implement GroupManager for group lifecycle

### Changes
- Adds `Manager` struct in `internal/orchestrator/group/manager.go`
- Thread-safe create/move/reorder operations
- Group retrieval and enumeration
- Support for group hierarchy management

### Merge Order
This is PR 3 of 8 in the Plan/UltraPlan feature stack.
- **Depends on**: PR #376 (Group 2)