### PR TITLE
Add missing ultraplan configuration options

### DIFF
--- a/internal/cmd/ultraplan.go
+++ b/internal/cmd/ultraplan.go
@@ -129,11 +129,23 @@ func runUltraplan(cmd *cobra.Command, args []string) error {
 	// Create ultra-plan configuration from defaults, then override with config file, then flags
 	ultraConfig := orchestrator.DefaultUltraPlanConfig()
 
-	// Apply config file settings (viper default is 3, user can set to 0 for unlimited)
-	ultraConfig.MaxParallel = cfg.Ultraplan.MaxParallel
-
 	// Apply config file settings
+	ultraConfig.MaxParallel = cfg.Ultraplan.MaxParallel
 	ultraConfig.MultiPass = cfg.Ultraplan.MultiPass
+
+	// Apply consolidation settings from config
+	if cfg.Ultraplan.ConsolidationMode != "" {
+		ultraConfig.ConsolidationMode = orchestrator.ConsolidationMode(cfg.Ultraplan.ConsolidationMode)
+	}
+	ultraConfig.CreateDraftPRs = cfg.Ultraplan.CreateDraftPRs
+	if len(cfg.Ultraplan.PRLabels) > 0 {
+		ultraConfig.PRLabels = cfg.Ultraplan.PRLabels
+	}
+	ultraConfig.BranchPrefix = cfg.Ultraplan.BranchPrefix
+
+	// Apply task verification settings from config
+	ultraConfig.MaxTaskRetries = cfg.Ultraplan.MaxTaskRetries
+	ultraConfig.RequireVerifiedCommits = cfg.Ultraplan.RequireVerifiedCommits
 
 	// CLI flags override config file (only if explicitly set)
 	if cmd.Flags().Changed("max-parallel") {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -134,6 +134,23 @@ type UltraplanConfig struct {
 	MultiPass bool `mapstructure:"multi_pass"`
 	// Notifications controls audio notifications for user input
 	Notifications NotificationConfig `mapstructure:"notifications"`
+
+	// Consolidation settings
+	// ConsolidationMode controls how completed work is consolidated: "stacked" creates
+	// a chain of PRs, "single" merges all work into one PR (default: "stacked")
+	ConsolidationMode string `mapstructure:"consolidation_mode"`
+	// CreateDraftPRs creates PRs as drafts during consolidation (default: true)
+	CreateDraftPRs bool `mapstructure:"create_draft_prs"`
+	// PRLabels are labels to add to PRs created during consolidation (default: ["ultraplan"])
+	PRLabels []string `mapstructure:"pr_labels"`
+	// BranchPrefix overrides branch.prefix for ultraplan branches (default: "" uses branch.prefix)
+	BranchPrefix string `mapstructure:"branch_prefix"`
+
+	// Task verification settings
+	// MaxTaskRetries is the max retry attempts for tasks that produce no commits (default: 3)
+	MaxTaskRetries int `mapstructure:"max_task_retries"`
+	// RequireVerifiedCommits requires tasks to produce commits to be marked successful (default: true)
+	RequireVerifiedCommits bool `mapstructure:"require_verified_commits"`
 }
 
 // NotificationConfig controls notification behavior for ultraplan
@@ -299,6 +316,12 @@ func Default() *Config {
 				UseSound:  false,
 				SoundPath: "",
 			},
+			ConsolidationMode:      "stacked",
+			CreateDraftPRs:         true,
+			PRLabels:               []string{"ultraplan"},
+			BranchPrefix:           "", // Empty means use branch.prefix
+			MaxTaskRetries:         3,
+			RequireVerifiedCommits: true,
 		},
 		Plan: PlanConfig{
 			OutputFormat: "issues",
@@ -395,6 +418,12 @@ func SetDefaults() {
 	viper.SetDefault("ultraplan.notifications.enabled", defaults.Ultraplan.Notifications.Enabled)
 	viper.SetDefault("ultraplan.notifications.use_sound", defaults.Ultraplan.Notifications.UseSound)
 	viper.SetDefault("ultraplan.notifications.sound_path", defaults.Ultraplan.Notifications.SoundPath)
+	viper.SetDefault("ultraplan.consolidation_mode", defaults.Ultraplan.ConsolidationMode)
+	viper.SetDefault("ultraplan.create_draft_prs", defaults.Ultraplan.CreateDraftPRs)
+	viper.SetDefault("ultraplan.pr_labels", defaults.Ultraplan.PRLabels)
+	viper.SetDefault("ultraplan.branch_prefix", defaults.Ultraplan.BranchPrefix)
+	viper.SetDefault("ultraplan.max_task_retries", defaults.Ultraplan.MaxTaskRetries)
+	viper.SetDefault("ultraplan.require_verified_commits", defaults.Ultraplan.RequireVerifiedCommits)
 
 	// Plan defaults
 	viper.SetDefault("plan.output_format", defaults.Plan.OutputFormat)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -291,6 +291,36 @@ func TestConfig_UltraplanConfig_Values(t *testing.T) {
 	if cfg.Ultraplan.Notifications.SoundPath != "" {
 		t.Errorf("Ultraplan.Notifications.SoundPath should be empty, got %q", cfg.Ultraplan.Notifications.SoundPath)
 	}
+
+	// ConsolidationMode should default to "stacked"
+	if cfg.Ultraplan.ConsolidationMode != "stacked" {
+		t.Errorf("Ultraplan.ConsolidationMode = %q, want %q", cfg.Ultraplan.ConsolidationMode, "stacked")
+	}
+
+	// CreateDraftPRs should default to true
+	if !cfg.Ultraplan.CreateDraftPRs {
+		t.Error("Ultraplan.CreateDraftPRs should be true by default")
+	}
+
+	// PRLabels should default to ["ultraplan"]
+	if len(cfg.Ultraplan.PRLabels) != 1 || cfg.Ultraplan.PRLabels[0] != "ultraplan" {
+		t.Errorf("Ultraplan.PRLabels = %v, want [ultraplan]", cfg.Ultraplan.PRLabels)
+	}
+
+	// BranchPrefix should be empty by default (uses branch.prefix)
+	if cfg.Ultraplan.BranchPrefix != "" {
+		t.Errorf("Ultraplan.BranchPrefix should be empty, got %q", cfg.Ultraplan.BranchPrefix)
+	}
+
+	// MaxTaskRetries should default to 3
+	if cfg.Ultraplan.MaxTaskRetries != 3 {
+		t.Errorf("Ultraplan.MaxTaskRetries = %d, want 3", cfg.Ultraplan.MaxTaskRetries)
+	}
+
+	// RequireVerifiedCommits should default to true
+	if !cfg.Ultraplan.RequireVerifiedCommits {
+		t.Error("Ultraplan.RequireVerifiedCommits should be true by default")
+	}
 }
 
 func TestConfig_UltraplanMultiPass_ViperLoading(t *testing.T) {

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -329,6 +329,34 @@ func (c *Config) validateUltraplan() []ValidationError {
 		}
 	}
 
+	// Validate consolidation mode
+	if c.Ultraplan.ConsolidationMode != "" {
+		validModes := []string{"stacked", "single"}
+		valid := false
+		for _, mode := range validModes {
+			if c.Ultraplan.ConsolidationMode == mode {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			errors = append(errors, ValidationError{
+				Field:   "ultraplan.consolidation_mode",
+				Value:   c.Ultraplan.ConsolidationMode,
+				Message: "must be 'stacked' or 'single'",
+			})
+		}
+	}
+
+	// Validate max task retries
+	if c.Ultraplan.MaxTaskRetries < 0 {
+		errors = append(errors, ValidationError{
+			Field:   "ultraplan.max_task_retries",
+			Value:   c.Ultraplan.MaxTaskRetries,
+			Message: "cannot be negative",
+		})
+	}
+
 	return errors
 }
 

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -507,6 +507,66 @@ func TestConfig_Validate_Ultraplan(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("valid consolidation modes", func(t *testing.T) {
+		for _, mode := range []string{"stacked", "single", ""} {
+			cfg := Default()
+			cfg.Ultraplan.ConsolidationMode = mode
+			errs := cfg.Validate()
+
+			for _, err := range errs {
+				if err.Field == "ultraplan.consolidation_mode" {
+					t.Errorf("mode %q should be valid: %v", mode, err)
+				}
+			}
+		}
+	})
+
+	t.Run("invalid consolidation mode", func(t *testing.T) {
+		cfg := Default()
+		cfg.Ultraplan.ConsolidationMode = "invalid"
+		errs := cfg.Validate()
+
+		found := false
+		for _, err := range errs {
+			if err.Field == "ultraplan.consolidation_mode" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("expected error for invalid consolidation mode")
+		}
+	})
+
+	t.Run("negative max task retries", func(t *testing.T) {
+		cfg := Default()
+		cfg.Ultraplan.MaxTaskRetries = -1
+		errs := cfg.Validate()
+
+		found := false
+		for _, err := range errs {
+			if err.Field == "ultraplan.max_task_retries" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("expected error for negative max task retries")
+		}
+	})
+
+	t.Run("zero max task retries is valid", func(t *testing.T) {
+		cfg := Default()
+		cfg.Ultraplan.MaxTaskRetries = 0
+		errs := cfg.Validate()
+
+		for _, err := range errs {
+			if err.Field == "ultraplan.max_task_retries" {
+				t.Errorf("zero max task retries should be valid: %v", err)
+			}
+		}
+	})
 }
 
 func TestConfig_Validate_Plan(t *testing.T) {

--- a/internal/tui/command/group_commands_test.go
+++ b/internal/tui/command/group_commands_test.go
@@ -921,6 +921,9 @@ func TestGroupResolutionEdgeCases(t *testing.T) {
 		deps := newMockGroupDeps()
 
 		grp := orchestrator.NewInstanceGroup("Group")
+		// Use a deterministic ID that doesn't start with "0" to avoid
+		// flaky prefix matching (the randomly generated ID might start with "0")
+		grp.ID = "abcd1234"
 		deps.session.Groups = append(deps.session.Groups, grp)
 
 		inst := &orchestrator.Instance{ID: "inst-001", Task: "Test"}


### PR DESCRIPTION
## Summary
- Expose additional ultraplan settings in the config file that were previously only available as hardcoded defaults
- Add validation for new config fields
- Fix flaky test in group_commands_test.go caused by random ID generation

## New Config Options

Users can now configure these settings in `~/.config/claudio/config.yaml`:

```yaml
ultraplan:
  # Consolidation settings
  consolidation_mode: "stacked"  # or "single"
  create_draft_prs: true
  pr_labels: ["ultraplan"]
  branch_prefix: ""  # uses branch.prefix if empty
  
  # Task verification settings
  max_task_retries: 3
  require_verified_commits: true
```

## Test plan
- [x] All existing tests pass
- [x] New config defaults have test coverage
- [x] Validation rules have test coverage
- [x] `go vet` and `gofmt` pass
- [x] Build succeeds