### PR TITLE
Add session resume for ultraplan consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Group Keyboard Shortcuts** - Vim-style `g` prefix commands for group navigation: `gc` toggle collapse, `gC` collapse/expand all, `gn/gp` navigate groups, `gs` skip group, `gr` retry failed, `gf` force-start next group.
 - **Group Management Commands** - New commands for organizing instances: `:group create`, `:group add`, `:group remove`, `:group move`, `:group order`, `:group delete`.
 - **Group-aware PR Workflow** - Create PRs for task groups with `:pr --group` (stacked PRs), `:pr --group=all` (consolidated), or `:pr --group=single` (single group).
+- **Session Resume for Consolidation** - Resume paused consolidation after manually resolving merge conflicts using the `r` key in UltraPlan mode. The system validates conflicts are resolved before continuing.
 
 ### Changed
 

--- a/internal/orchestrator/consolidation.go
+++ b/internal/orchestrator/consolidation.go
@@ -54,6 +54,11 @@ type ConsolidationState struct {
 	CompletedAt      *time.Time         `json:"completed_at,omitempty"`
 }
 
+// HasConflict returns true if consolidation is paused due to a conflict.
+func (s *ConsolidationState) HasConflict() bool {
+	return s.Phase == ConsolidationPaused && len(s.ConflictFiles) > 0
+}
+
 // GroupConsolidationResult holds the result of consolidating one group
 type GroupConsolidationResult struct {
 	GroupIndex   int      `json:"group_index"`

--- a/internal/tui/ultraplan.go
+++ b/internal/tui/ultraplan.go
@@ -590,8 +590,20 @@ func (m Model) handleUltraPlanKeypress(msg tea.KeyMsg) (bool, tea.Model, tea.Cmd
 		if session.Phase == orchestrator.PhaseConsolidating &&
 			session.Consolidation != nil &&
 			session.Consolidation.Phase == orchestrator.ConsolidationPaused {
-			// TODO: Implement resume functionality when coordinator exposes it
-			m.infoMessage = "Resuming consolidation..."
+			// Capture worktree path before resume clears it
+			conflictWorktree := session.Consolidation.ConflictWorktree
+			if err := m.ultraPlan.Coordinator.ResumeConsolidation(); err != nil {
+				m.errorMessage = fmt.Sprintf("Failed to resume consolidation: %v", err)
+			} else {
+				m.infoMessage = "Resuming consolidation..."
+				// Log user decision
+				if m.logger != nil {
+					m.logger.Info("user decision",
+						"decision_type", "resume_consolidation",
+						"conflict_worktree", conflictWorktree,
+					)
+				}
+			}
 		}
 		return true, m, nil
 


### PR DESCRIPTION
## Summary

- Add `ResumeConsolidation()` method to Coordinator that allows resuming consolidation after merge conflicts have been manually resolved
- Validates that conflicts are actually resolved before proceeding (using `GetConflictingFiles`)
- Checks if a cherry-pick is in progress before attempting to continue it (using `IsCherryPickInProgress`)
- Properly propagates errors instead of silently ignoring them
- Adds `HasConflict()` helper method to `ConsolidationState` for checking conflict status
- Updates TUI 'r' key handler to call `ResumeConsolidation()` with proper error handling

## Test plan

- [ ] Run `go test ./internal/orchestrator/... -run "ResumeConsolidation|HasConflict" -v` to verify new tests pass
- [ ] Manual test: Start ultraplan consolidation, encounter a merge conflict, resolve it manually, press 'r' to resume
- [ ] Verify error messages are shown when trying to resume with unresolved conflicts