### PR TITLE
Implement missing :accept command for triple-shot mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Triple-Shot Accept Command** - Implement missing `:accept` command that was referenced in UI message but never implemented. Users can now accept winning triple-shot solutions after evaluation completes.
+
 ### Added
 
 - **Inline Plan Mode** (Experimental) - New `:plan` command enables structured task planning directly within the TUI. Create task groups, define dependencies, and execute plans without leaving Claudio. Enable via `experimental.inline_plan` in config.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1434,6 +1434,11 @@ func (m *Model) applyCommandResult(result command.Result) {
 		m.taskInputCursor = 0
 	}
 
+	// Handle triple-shot accept
+	if result.AcceptTripleShot != nil && *result.AcceptTripleShot {
+		m.handleTripleShotAccept()
+	}
+
 	// Handle inline plan mode transition
 	if result.StartPlanMode != nil && *result.StartPlanMode {
 		m.initInlinePlanMode()
@@ -2611,6 +2616,7 @@ func (m Model) renderHelpPanel(width int) string {
 	lines = append(lines, helpLine(":plan", "Start inline plan mode"))
 	lines = append(lines, helpLine(":ultraplan  :up", "Start ultraplan mode"))
 	lines = append(lines, helpLine(":tripleshot", "Run 3 parallel attempts + judge"))
+	lines = append(lines, helpLine(":accept", "Accept winning triple-shot solution"))
 	lines = append(lines, helpLine(":cancel", "Cancel ultraplan execution"))
 	lines = append(lines, helpLine(":group", "Manage instance groups"))
 	lines = append(lines, "")

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -908,6 +908,14 @@ func (m Model) GetUltraPlanCoordinator() *orchestrator.Coordinator {
 	return m.ultraPlan.Coordinator
 }
 
+// GetTripleShotCoordinator returns the triple-shot coordinator if in triple-shot mode.
+func (m Model) GetTripleShotCoordinator() *orchestrator.TripleShotCoordinator {
+	if m.tripleShot == nil {
+		return nil
+	}
+	return m.tripleShot.Coordinator
+}
+
 // GetLogger returns the logger instance.
 func (m Model) GetLogger() *logging.Logger {
 	return m.logger


### PR DESCRIPTION
## Summary

- Implement the missing `:accept` command for triple-shot mode
- The command was referenced in a UI message but never implemented, causing users to get stuck in triple-shot mode after completion
- Add proper error handling and logging for all acceptance paths

## Changes

- Add `GetTripleShotCoordinator()` to command `Dependencies` interface
- Implement `cmdAccept()` with validation for:
  - Triple-shot mode active
  - Coordinator available  
  - Session phase is complete
  - Evaluation is available
- Implement `handleTripleShotAccept()` to:
  - Handle different merge strategies (select, merge, combine)
  - Display helpful info messages with branch/PR instructions
  - Exit triple-shot mode on success
  - Log all operations for debugging
- Register `:accept` command and add to help panel
- Add tests for accept command error paths

## Test plan

- [x] Run `go test ./...` - all tests pass
- [x] Run `go vet ./...` - no issues
- [x] Run `gofmt -d .` - no formatting issues
- [ ] Manual test: Start triple-shot, wait for completion, run `:accept`