### PR TITLE
Add comprehensive tests for internal/worktree package

### DIFF
--- a/.claude-prompt
+++ b/.claude-prompt
@@ -1,0 +1,1 @@
+Add tests for internal/worktree package (4.9% coverage)

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -4,9 +4,12 @@ package worktree
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/Iron-Ham/claudio/internal/logging"
 	"github.com/Iron-Ham/claudio/internal/testutil"
 )
 
@@ -738,5 +741,831 @@ func TestManager_CopyLocalClaudeFiles_PreservesPermissions(t *testing.T) {
 
 	if srcInfo.Mode() != dstInfo.Mode() {
 		t.Errorf("permissions not preserved: got %v, want %v", dstInfo.Mode(), srcInfo.Mode())
+	}
+}
+
+func TestManager_CreateFromBranch(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir := testutil.SetupTestRepo(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Create a base branch with some commits
+	testutil.CreateBranch(t, repoDir, "base-branch")
+	testutil.CheckoutBranch(t, repoDir, "base-branch")
+	testutil.CommitFile(t, repoDir, "base.txt", "base content", "Add base file")
+	testutil.CheckoutBranch(t, repoDir, "main")
+
+	// Create a worktree from the base branch
+	worktreePath := filepath.Join(t.TempDir(), "test-worktree")
+	if err := mgr.CreateFromBranch(worktreePath, "feature-branch", "base-branch"); err != nil {
+		t.Fatalf("CreateFromBranch() error = %v", err)
+	}
+
+	// Verify worktree exists
+	if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
+		t.Error("worktree directory was not created")
+	}
+
+	// Verify branch is checked out
+	branch, err := mgr.GetBranch(worktreePath)
+	if err != nil {
+		t.Fatalf("GetBranch() error = %v", err)
+	}
+	if branch != "feature-branch" {
+		t.Errorf("GetBranch() = %v, want feature-branch", branch)
+	}
+
+	// Verify the worktree contains the file from base-branch
+	baseFile := filepath.Join(worktreePath, "base.txt")
+	if _, err := os.Stat(baseFile); os.IsNotExist(err) {
+		t.Error("worktree should contain base.txt from base-branch")
+	}
+}
+
+func TestManager_CreateBranchFrom(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir := testutil.SetupTestRepo(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Create a base branch with some commits
+	testutil.CreateBranch(t, repoDir, "base-branch")
+	testutil.CheckoutBranch(t, repoDir, "base-branch")
+	testutil.CommitFile(t, repoDir, "base.txt", "base content", "Add base file")
+	testutil.CheckoutBranch(t, repoDir, "main")
+
+	// Create a branch from the base branch
+	if err := mgr.CreateBranchFrom("derived-branch", "base-branch"); err != nil {
+		t.Fatalf("CreateBranchFrom() error = %v", err)
+	}
+
+	// Verify branch was created by listing branches
+	branches, err := mgr.ListBranches()
+	if err != nil {
+		t.Fatalf("ListBranches() error = %v", err)
+	}
+
+	found := false
+	for _, b := range branches {
+		if b.Name == "derived-branch" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("CreateBranchFrom() did not create the branch")
+	}
+}
+
+func TestManager_CreateWorktreeFromBranch(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir := testutil.SetupTestRepo(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Create a branch with some commits
+	testutil.CreateBranch(t, repoDir, "feature-branch")
+	testutil.CheckoutBranch(t, repoDir, "feature-branch")
+	testutil.CommitFile(t, repoDir, "feature.txt", "feature content", "Add feature file")
+	testutil.CheckoutBranch(t, repoDir, "main")
+
+	// Create a worktree from the existing branch
+	worktreePath := filepath.Join(t.TempDir(), "test-worktree")
+	if err := mgr.CreateWorktreeFromBranch(worktreePath, "feature-branch"); err != nil {
+		t.Fatalf("CreateWorktreeFromBranch() error = %v", err)
+	}
+
+	// Verify worktree exists
+	if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
+		t.Error("worktree directory was not created")
+	}
+
+	// Verify branch is checked out
+	branch, err := mgr.GetBranch(worktreePath)
+	if err != nil {
+		t.Fatalf("GetBranch() error = %v", err)
+	}
+	if branch != "feature-branch" {
+		t.Errorf("GetBranch() = %v, want feature-branch", branch)
+	}
+
+	// Verify the worktree contains the file from the branch
+	featureFile := filepath.Join(worktreePath, "feature.txt")
+	if _, err := os.Stat(featureFile); os.IsNotExist(err) {
+		t.Error("worktree should contain feature.txt from feature-branch")
+	}
+}
+
+func TestManager_Push(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir, _ := testutil.SetupTestRepoWithRemote(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Create a new branch with commits
+	worktreePath := filepath.Join(t.TempDir(), "test-worktree")
+	if err := mgr.Create(worktreePath, "push-test-branch"); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// Add a commit
+	testFile := filepath.Join(worktreePath, "pushed.txt")
+	if err := os.WriteFile(testFile, []byte("push content"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+	if err := mgr.CommitAll(worktreePath, "Add pushed file"); err != nil {
+		t.Fatalf("CommitAll() error = %v", err)
+	}
+
+	// Push without force
+	if err := mgr.Push(worktreePath, false); err != nil {
+		t.Fatalf("Push() error = %v", err)
+	}
+
+	// Push with force (should succeed as no one else has pushed)
+	testFile2 := filepath.Join(worktreePath, "pushed2.txt")
+	if err := os.WriteFile(testFile2, []byte("more content"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+	if err := mgr.CommitAll(worktreePath, "Add another file"); err != nil {
+		t.Fatalf("CommitAll() error = %v", err)
+	}
+
+	if err := mgr.Push(worktreePath, true); err != nil {
+		t.Fatalf("Push(force=true) error = %v", err)
+	}
+}
+
+func TestManager_HasCommitsBeyond(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir := testutil.SetupTestRepo(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Create a worktree
+	worktreePath := filepath.Join(t.TempDir(), "test-worktree")
+	if err := mgr.Create(worktreePath, "feature"); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// Initially no commits beyond main
+	hasCommits, err := mgr.HasCommitsBeyond(worktreePath, "main")
+	if err != nil {
+		t.Fatalf("HasCommitsBeyond() error = %v", err)
+	}
+	if hasCommits {
+		t.Error("HasCommitsBeyond() = true, want false for new branch")
+	}
+
+	// Add a commit
+	testFile := filepath.Join(worktreePath, "feature.txt")
+	if err := os.WriteFile(testFile, []byte("content"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+	if err := mgr.CommitAll(worktreePath, "Add feature"); err != nil {
+		t.Fatalf("CommitAll() error = %v", err)
+	}
+
+	// Now should have commits beyond main
+	hasCommits, err = mgr.HasCommitsBeyond(worktreePath, "main")
+	if err != nil {
+		t.Fatalf("HasCommitsBeyond() error = %v", err)
+	}
+	if !hasCommits {
+		t.Error("HasCommitsBeyond() = false, want true after adding commit")
+	}
+}
+
+func TestManager_GetCommitsBetween(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir := testutil.SetupTestRepo(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Create a branch with multiple commits
+	testutil.CreateBranch(t, repoDir, "feature")
+	testutil.CheckoutBranch(t, repoDir, "feature")
+
+	for i := 1; i <= 3; i++ {
+		testutil.CommitFile(t, repoDir, "file.txt", "content "+string(rune('0'+i)), "Commit "+string(rune('0'+i)))
+	}
+
+	// Get commits between main and feature
+	commits, err := mgr.GetCommitsBetween(repoDir, "main", "feature")
+	if err != nil {
+		t.Fatalf("GetCommitsBetween() error = %v", err)
+	}
+
+	if len(commits) != 3 {
+		t.Errorf("GetCommitsBetween() returned %d commits, want 3", len(commits))
+	}
+}
+
+func TestManager_GetCommitsBetween_Empty(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir := testutil.SetupTestRepo(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Create a branch without any additional commits
+	testutil.CreateBranch(t, repoDir, "feature")
+
+	// Get commits between main and feature (should be empty)
+	commits, err := mgr.GetCommitsBetween(repoDir, "main", "feature")
+	if err != nil {
+		t.Fatalf("GetCommitsBetween() error = %v", err)
+	}
+
+	if len(commits) != 0 {
+		t.Errorf("GetCommitsBetween() returned %d commits, want 0", len(commits))
+	}
+}
+
+func TestManager_CountCommitsBetween(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir := testutil.SetupTestRepo(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Create a branch with multiple commits
+	testutil.CreateBranch(t, repoDir, "feature")
+	testutil.CheckoutBranch(t, repoDir, "feature")
+
+	for i := 1; i <= 5; i++ {
+		testutil.CommitFile(t, repoDir, "file.txt", "content "+string(rune('0'+i)), "Commit "+string(rune('0'+i)))
+	}
+
+	// Count commits between main and feature
+	count, err := mgr.CountCommitsBetween(repoDir, "main", "feature")
+	if err != nil {
+		t.Fatalf("CountCommitsBetween() error = %v", err)
+	}
+
+	if count != 5 {
+		t.Errorf("CountCommitsBetween() = %d, want 5", count)
+	}
+}
+
+func TestManager_FindMainBranch(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	// Test with 'main' branch (created by SetupTestRepo)
+	repoDir := testutil.SetupTestRepo(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	branch := mgr.FindMainBranch()
+	if branch != "main" {
+		t.Errorf("FindMainBranch() = %v, want 'main'", branch)
+	}
+}
+
+func TestManager_IsCherryPickInProgress(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir := testutil.SetupTestRepo(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Create a worktree
+	worktreePath := filepath.Join(t.TempDir(), "test-worktree")
+	if err := mgr.Create(worktreePath, "feature"); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// Initially no cherry-pick in progress
+	if mgr.IsCherryPickInProgress(worktreePath) {
+		t.Error("IsCherryPickInProgress() = true, want false")
+	}
+}
+
+func TestManager_GetConflictingFiles(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir := testutil.SetupTestRepo(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Initially no conflicting files
+	files, err := mgr.GetConflictingFiles(repoDir)
+	if err != nil {
+		t.Fatalf("GetConflictingFiles() error = %v", err)
+	}
+
+	if len(files) != 0 {
+		t.Errorf("GetConflictingFiles() returned %d files, want 0", len(files))
+	}
+}
+
+func TestManager_CherryPickBranch(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir := testutil.SetupTestRepo(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Create a source branch with commits
+	testutil.CreateBranch(t, repoDir, "source-branch")
+	testutil.CheckoutBranch(t, repoDir, "source-branch")
+	testutil.CommitFile(t, repoDir, "source1.txt", "source content 1", "Add source1")
+	testutil.CommitFile(t, repoDir, "source2.txt", "source content 2", "Add source2")
+
+	// Create a target worktree from main
+	testutil.CheckoutBranch(t, repoDir, "main")
+	worktreePath := filepath.Join(t.TempDir(), "target-worktree")
+	if err := mgr.Create(worktreePath, "target-branch"); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// Cherry-pick from source branch
+	if err := mgr.CherryPickBranch(worktreePath, "source-branch"); err != nil {
+		t.Fatalf("CherryPickBranch() error = %v", err)
+	}
+
+	// Verify the files from source branch are now in target
+	if _, err := os.Stat(filepath.Join(worktreePath, "source1.txt")); os.IsNotExist(err) {
+		t.Error("source1.txt should exist after cherry-pick")
+	}
+	if _, err := os.Stat(filepath.Join(worktreePath, "source2.txt")); os.IsNotExist(err) {
+		t.Error("source2.txt should exist after cherry-pick")
+	}
+}
+
+func TestManager_CherryPickBranch_Empty(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir := testutil.SetupTestRepo(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Create a source branch without extra commits
+	testutil.CreateBranch(t, repoDir, "source-branch")
+
+	// Create a target worktree
+	worktreePath := filepath.Join(t.TempDir(), "target-worktree")
+	if err := mgr.Create(worktreePath, "target-branch"); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// Cherry-pick from source branch (should be no-op)
+	if err := mgr.CherryPickBranch(worktreePath, "source-branch"); err != nil {
+		t.Fatalf("CherryPickBranch() error = %v for empty branch", err)
+	}
+}
+
+func TestManager_CherryPickBranch_Conflict(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir := testutil.SetupTestRepo(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Create a source branch with a commit that modifies a file
+	testutil.CreateBranch(t, repoDir, "source-branch")
+	testutil.CheckoutBranch(t, repoDir, "source-branch")
+	testutil.CommitFile(t, repoDir, "conflict.txt", "source content", "Add conflict file from source")
+
+	// Create a target worktree with a conflicting change
+	testutil.CheckoutBranch(t, repoDir, "main")
+	worktreePath := filepath.Join(t.TempDir(), "target-worktree")
+	if err := mgr.Create(worktreePath, "target-branch"); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// Add conflicting change in target
+	conflictFile := filepath.Join(worktreePath, "conflict.txt")
+	if err := os.WriteFile(conflictFile, []byte("target content"), 0644); err != nil {
+		t.Fatalf("failed to create conflict file: %v", err)
+	}
+	if err := mgr.CommitAll(worktreePath, "Add conflict file from target"); err != nil {
+		t.Fatalf("CommitAll() error = %v", err)
+	}
+
+	// Cherry-pick should fail with conflict
+	err = mgr.CherryPickBranch(worktreePath, "source-branch")
+	if err == nil {
+		t.Fatal("CherryPickBranch() should fail with conflict")
+	}
+
+	// Should be a CherryPickConflictError
+	var conflictErr *CherryPickConflictError
+	if _, ok := err.(*CherryPickConflictError); !ok {
+		// Check if it's any error containing conflict info
+		if !strings.Contains(err.Error(), "conflict") && !strings.Contains(err.Error(), "CONFLICT") {
+			t.Errorf("CherryPickBranch() error should be CherryPickConflictError, got %T: %v", err, err)
+		}
+	} else {
+		conflictErr = err.(*CherryPickConflictError)
+		if conflictErr.SourceBranch != "source-branch" {
+			t.Errorf("CherryPickConflictError.SourceBranch = %v, want source-branch", conflictErr.SourceBranch)
+		}
+	}
+
+	// Abort the cherry-pick
+	_ = mgr.AbortCherryPick(worktreePath)
+}
+
+func TestManager_CheckCherryPickConflicts(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir := testutil.SetupTestRepo(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Create a source branch with a commit
+	testutil.CreateBranch(t, repoDir, "source-branch")
+	testutil.CheckoutBranch(t, repoDir, "source-branch")
+	testutil.CommitFile(t, repoDir, "file.txt", "source content", "Add file from source")
+
+	// Create a target worktree without conflicts
+	testutil.CheckoutBranch(t, repoDir, "main")
+	worktreePath := filepath.Join(t.TempDir(), "target-worktree")
+	if err := mgr.Create(worktreePath, "target-branch"); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// Check for conflicts (should be none)
+	conflicts, err := mgr.CheckCherryPickConflicts(worktreePath, "source-branch")
+	if err != nil {
+		t.Fatalf("CheckCherryPickConflicts() error = %v", err)
+	}
+
+	if len(conflicts) != 0 {
+		t.Errorf("CheckCherryPickConflicts() returned %d conflicts, want 0", len(conflicts))
+	}
+}
+
+func TestManager_CheckCherryPickConflicts_WithConflicts(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir := testutil.SetupTestRepo(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Create a source branch with a commit that modifies a file
+	testutil.CreateBranch(t, repoDir, "source-branch")
+	testutil.CheckoutBranch(t, repoDir, "source-branch")
+	testutil.CommitFile(t, repoDir, "conflict.txt", "source version", "Add from source")
+
+	// Create a target worktree with a conflicting change
+	testutil.CheckoutBranch(t, repoDir, "main")
+	worktreePath := filepath.Join(t.TempDir(), "target-worktree")
+	if err := mgr.Create(worktreePath, "target-branch"); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// Add conflicting change in target
+	conflictFile := filepath.Join(worktreePath, "conflict.txt")
+	if err := os.WriteFile(conflictFile, []byte("target version"), 0644); err != nil {
+		t.Fatalf("failed to create conflict file: %v", err)
+	}
+	if err := mgr.CommitAll(worktreePath, "Add from target"); err != nil {
+		t.Fatalf("CommitAll() error = %v", err)
+	}
+
+	// Check for conflicts
+	conflicts, err := mgr.CheckCherryPickConflicts(worktreePath, "source-branch")
+	if err != nil {
+		t.Fatalf("CheckCherryPickConflicts() error = %v", err)
+	}
+
+	// Should report conflict in conflict.txt
+	if len(conflicts) == 0 {
+		t.Error("CheckCherryPickConflicts() should report conflicts")
+	}
+}
+
+func TestManager_AbortCherryPick(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir := testutil.SetupTestRepo(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// AbortCherryPick on a repo without cherry-pick in progress should error
+	err = mgr.AbortCherryPick(repoDir)
+	if err == nil {
+		t.Error("AbortCherryPick() should error when no cherry-pick in progress")
+	}
+}
+
+func TestManager_ContinueCherryPick(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir := testutil.SetupTestRepo(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// ContinueCherryPick on a repo without cherry-pick in progress should error
+	err = mgr.ContinueCherryPick(repoDir)
+	if err == nil {
+		t.Error("ContinueCherryPick() should error when no cherry-pick in progress")
+	}
+}
+
+func TestManager_SetLogger_Integration(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir := testutil.SetupTestRepo(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Set a logger and verify operations still work
+	logger, err := logging.NewLogger(t.TempDir(), "DEBUG")
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+	defer logger.Close()
+
+	mgr.SetLogger(logger)
+
+	// Create a worktree (this should log)
+	worktreePath := filepath.Join(t.TempDir(), "test-worktree")
+	if err := mgr.Create(worktreePath, "logged-branch"); err != nil {
+		t.Fatalf("Create() with logger error = %v", err)
+	}
+
+	// Remove the worktree (this should also log)
+	if err := mgr.Remove(worktreePath); err != nil {
+		t.Fatalf("Remove() with logger error = %v", err)
+	}
+
+	// Delete the branch (this should log)
+	if err := mgr.DeleteBranch("logged-branch"); err != nil {
+		t.Fatalf("DeleteBranch() with logger error = %v", err)
+	}
+}
+
+func TestManager_GetBehindCount(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Create a worktree
+	worktreePath := filepath.Join(t.TempDir(), "test-worktree")
+	if err := mgr.Create(worktreePath, "feature"); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// Initially should not be behind
+	behindCount, err := mgr.GetBehindCount(worktreePath)
+	if err != nil {
+		t.Fatalf("GetBehindCount() error = %v", err)
+	}
+	if behindCount != 0 {
+		t.Errorf("GetBehindCount() = %d, want 0", behindCount)
+	}
+
+	// Add commits to main on the remote
+	// First we need to clone the bare repo, add commits, and push
+	cloneDir := t.TempDir()
+	runGit(t, cloneDir, "clone", remoteDir, ".")
+	runGit(t, cloneDir, "config", "user.email", "test@claudio.dev")
+	runGit(t, cloneDir, "config", "user.name", "Claudio Test")
+
+	// Add commits to main
+	for i := 1; i <= 3; i++ {
+		testFile := filepath.Join(cloneDir, "remote_file.txt")
+		if err := os.WriteFile(testFile, []byte("content "+string(rune('0'+i))), 0644); err != nil {
+			t.Fatalf("failed to create test file: %v", err)
+		}
+		runGit(t, cloneDir, "add", "-A")
+		runGit(t, cloneDir, "commit", "-m", "Remote commit "+string(rune('0'+i)))
+	}
+	runGit(t, cloneDir, "push", "origin", "main")
+
+	// Now check behind count
+	behindCount, err = mgr.GetBehindCount(worktreePath)
+	if err != nil {
+		t.Fatalf("GetBehindCount() error = %v", err)
+	}
+	if behindCount != 3 {
+		t.Errorf("GetBehindCount() = %d, want 3", behindCount)
+	}
+}
+
+func TestManager_RebaseOnMain(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir, _ := testutil.SetupTestRepoWithRemote(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Create a worktree with commits
+	worktreePath := filepath.Join(t.TempDir(), "test-worktree")
+	if err := mgr.Create(worktreePath, "feature"); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// Add a commit to the feature branch
+	testFile := filepath.Join(worktreePath, "feature.txt")
+	if err := os.WriteFile(testFile, []byte("feature content"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+	if err := mgr.CommitAll(worktreePath, "Add feature"); err != nil {
+		t.Fatalf("CommitAll() error = %v", err)
+	}
+
+	// Rebase on main (should succeed since we're up to date)
+	if err := mgr.RebaseOnMain(worktreePath); err != nil {
+		t.Fatalf("RebaseOnMain() error = %v", err)
+	}
+
+	// Verify feature file still exists
+	if _, err := os.Stat(testFile); os.IsNotExist(err) {
+		t.Error("feature.txt should still exist after rebase")
+	}
+}
+
+func TestManager_RebaseOnMain_WithConflict(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Create a worktree with a commit that will conflict
+	worktreePath := filepath.Join(t.TempDir(), "test-worktree")
+	if err := mgr.Create(worktreePath, "feature"); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// Add a file in the worktree
+	testFile := filepath.Join(worktreePath, "conflict.txt")
+	if err := os.WriteFile(testFile, []byte("feature version"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+	if err := mgr.CommitAll(worktreePath, "Add conflict file from feature"); err != nil {
+		t.Fatalf("CommitAll() error = %v", err)
+	}
+
+	// Add conflicting commit to main on the remote
+	cloneDir := t.TempDir()
+	runGit(t, cloneDir, "clone", remoteDir, ".")
+	runGit(t, cloneDir, "config", "user.email", "test@claudio.dev")
+	runGit(t, cloneDir, "config", "user.name", "Claudio Test")
+
+	conflictFile := filepath.Join(cloneDir, "conflict.txt")
+	if err := os.WriteFile(conflictFile, []byte("main version"), 0644); err != nil {
+		t.Fatalf("failed to create conflict file: %v", err)
+	}
+	runGit(t, cloneDir, "add", "-A")
+	runGit(t, cloneDir, "commit", "-m", "Add conflict file from main")
+	runGit(t, cloneDir, "push", "origin", "main")
+
+	// Rebase on main should fail with conflict
+	err = mgr.RebaseOnMain(worktreePath)
+	if err == nil {
+		t.Fatal("RebaseOnMain() should fail with conflict")
+	}
+
+	// Error should mention conflict
+	if !strings.Contains(err.Error(), "conflict") && !strings.Contains(err.Error(), "CONFLICT") {
+		t.Errorf("RebaseOnMain() error should mention conflict, got: %v", err)
+	}
+}
+
+func TestManager_HasRebaseConflicts(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir, _ := testutil.SetupTestRepoWithRemote(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Create a worktree
+	worktreePath := filepath.Join(t.TempDir(), "test-worktree")
+	if err := mgr.Create(worktreePath, "feature"); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// Initially no conflicts (branch is up to date with main)
+	hasConflicts, err := mgr.HasRebaseConflicts(worktreePath)
+	if err != nil {
+		t.Fatalf("HasRebaseConflicts() error = %v", err)
+	}
+	if hasConflicts {
+		t.Error("HasRebaseConflicts() = true, want false when up to date")
+	}
+}
+
+func TestManager_HasRebaseConflicts_WithConflicts(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	mgr, err := New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Create a worktree with a file that will conflict
+	worktreePath := filepath.Join(t.TempDir(), "test-worktree")
+	if err := mgr.Create(worktreePath, "feature"); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// Add a file in the worktree
+	testFile := filepath.Join(worktreePath, "conflict.txt")
+	if err := os.WriteFile(testFile, []byte("feature version"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+	if err := mgr.CommitAll(worktreePath, "Add from feature"); err != nil {
+		t.Fatalf("CommitAll() error = %v", err)
+	}
+
+	// Add conflicting commit to main on the remote
+	cloneDir := t.TempDir()
+	runGit(t, cloneDir, "clone", remoteDir, ".")
+	runGit(t, cloneDir, "config", "user.email", "test@claudio.dev")
+	runGit(t, cloneDir, "config", "user.name", "Claudio Test")
+
+	conflictFile := filepath.Join(cloneDir, "conflict.txt")
+	if err := os.WriteFile(conflictFile, []byte("main version"), 0644); err != nil {
+		t.Fatalf("failed to create conflict file: %v", err)
+	}
+	runGit(t, cloneDir, "add", "-A")
+	runGit(t, cloneDir, "commit", "-m", "Add from main")
+	runGit(t, cloneDir, "push", "origin", "main")
+
+	// Check for conflicts
+	hasConflicts, err := mgr.HasRebaseConflicts(worktreePath)
+	if err != nil {
+		t.Fatalf("HasRebaseConflicts() error = %v", err)
+	}
+	if !hasConflicts {
+		t.Error("HasRebaseConflicts() = false, want true when conflicts exist")
+	}
+}
+
+// runGit is a helper to run git commands in tests
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=Claudio Test",
+		"GIT_AUTHOR_EMAIL=test@claudio.dev",
+		"GIT_COMMITTER_NAME=Claudio Test",
+		"GIT_COMMITTER_EMAIL=test@claudio.dev",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, output)
 	}
 }

--- a/internal/worktree/worktree_unit_test.go
+++ b/internal/worktree/worktree_unit_test.go
@@ -1,0 +1,120 @@
+package worktree
+
+import (
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/logging"
+)
+
+func TestTruncateOutput(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		maxLen int
+		want   string
+	}{
+		{
+			name:   "string shorter than max",
+			input:  "hello",
+			maxLen: 10,
+			want:   "hello",
+		},
+		{
+			name:   "string equal to max",
+			input:  "hello",
+			maxLen: 5,
+			want:   "hello",
+		},
+		{
+			name:   "string longer than max",
+			input:  "hello world",
+			maxLen: 5,
+			want:   "hello...",
+		},
+		{
+			name:   "empty string",
+			input:  "",
+			maxLen: 10,
+			want:   "",
+		},
+		{
+			name:   "max length zero",
+			input:  "hello",
+			maxLen: 0,
+			want:   "...",
+		},
+		{
+			name:   "unicode string truncation - full string fits",
+			input:  "hello 世界",
+			maxLen: 20, // "hello " (6 bytes) + 世界 (6 bytes for 2 chars) = 12 bytes total
+			want:   "hello 世界",
+		},
+		{
+			name:   "unicode string truncation - byte based",
+			input:  "hello 世界",
+			maxLen: 6, // Only "hello " fits
+			want:   "hello ...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateOutput(tt.input, tt.maxLen)
+			if got != tt.want {
+				t.Errorf("truncateOutput(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetLogger(t *testing.T) {
+	m := &Manager{repoDir: "/tmp/test"}
+
+	// Initially logger is nil
+	if m.logger != nil {
+		t.Error("expected logger to be nil initially")
+	}
+
+	// Create a test logger
+	logger := logging.NopLogger()
+
+	// Set the logger
+	m.SetLogger(logger)
+
+	// Verify logger is set
+	if m.logger != logger {
+		t.Error("SetLogger did not set the logger correctly")
+	}
+}
+
+func TestCherryPickConflictError(t *testing.T) {
+	err := &CherryPickConflictError{
+		Commit:       "abc123",
+		SourceBranch: "feature-branch",
+		Output:       "CONFLICT in file.txt",
+	}
+
+	expected := "cherry-pick conflict on commit abc123 from feature-branch"
+	if err.Error() != expected {
+		t.Errorf("Error() = %q, want %q", err.Error(), expected)
+	}
+}
+
+func TestBranchInfo(t *testing.T) {
+	// Test that BranchInfo struct works as expected
+	info := BranchInfo{
+		Name:      "feature-branch",
+		IsCurrent: true,
+		IsMain:    false,
+	}
+
+	if info.Name != "feature-branch" {
+		t.Errorf("Name = %q, want %q", info.Name, "feature-branch")
+	}
+	if !info.IsCurrent {
+		t.Error("IsCurrent = false, want true")
+	}
+	if info.IsMain {
+		t.Error("IsMain = true, want false")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds comprehensive unit tests for the `internal/worktree` package
- Tests cover `truncateOutput`, unicode handling, and edge cases
- Improves test coverage from 4.9% for this package

## Test plan
- [x] All new tests pass locally
- [ ] Review test coverage report