### PR TITLE
Isolate tmux sessions per instance to prevent crash propagation

### DIFF
--- a/internal/instance/input/handler_test.go
+++ b/internal/instance/input/handler_test.go
@@ -916,7 +916,7 @@ func TestHandler_SendInput_ErrorMidBatch(t *testing.T) {
 
 func TestNewHandler_WithPersistentSender(t *testing.T) {
 	// WithPersistentSender should set up a persistent sender
-	h := NewHandler(WithPersistentSender("test-session"))
+	h := NewHandler(WithPersistentSender("test-session", "claudio-test"))
 
 	if h == nil {
 		t.Fatal("NewHandler returned nil")
@@ -959,7 +959,7 @@ func TestHandler_Close(t *testing.T) {
 	})
 
 	t.Run("with persistent sender", func(t *testing.T) {
-		h := NewHandler(WithPersistentSender("test-session"))
+		h := NewHandler(WithPersistentSender("test-session", "claudio-test"))
 
 		// Close should work with persistent sender
 		err := h.Close()
@@ -970,7 +970,7 @@ func TestHandler_Close(t *testing.T) {
 }
 
 func TestHandler_Close_Multiple(t *testing.T) {
-	h := NewHandler(WithPersistentSender("test-session"))
+	h := NewHandler(WithPersistentSender("test-session", "claudio-test"))
 
 	// Multiple closes should be safe
 	err := h.Close()

--- a/internal/instance/lifecycle/manager_test.go
+++ b/internal/instance/lifecycle/manager_test.go
@@ -11,6 +11,7 @@ type mockInstance struct {
 	mu          sync.Mutex
 	id          string
 	sessionName string
+	socketName  string
 	workDir     string
 	task        string
 	config      InstanceConfig
@@ -24,6 +25,7 @@ func newMockInstance(id string) *mockInstance {
 	return &mockInstance{
 		id:          id,
 		sessionName: "claudio-" + id,
+		socketName:  "claudio-" + id, // Each instance gets its own socket
 		workDir:     "/tmp/test",
 		task:        "test task",
 		config: InstanceConfig{
@@ -35,6 +37,7 @@ func newMockInstance(id string) *mockInstance {
 
 func (m *mockInstance) ID() string          { return m.id }
 func (m *mockInstance) SessionName() string { return m.sessionName }
+func (m *mockInstance) SocketName() string  { return m.socketName }
 func (m *mockInstance) WorkDir() string     { return m.workDir }
 func (m *mockInstance) Task() string        { return m.task }
 func (m *mockInstance) Config() InstanceConfig {

--- a/internal/instance/process/interface.go
+++ b/internal/instance/process/interface.go
@@ -29,6 +29,11 @@ type Config struct {
 	// If empty, a name will be generated automatically.
 	TmuxSession string
 
+	// TmuxSocket is the tmux socket name to use for crash isolation.
+	// Each instance should use a unique socket so crashes don't affect others.
+	// If empty, defaults to the global "claudio" socket.
+	TmuxSocket string
+
 	// WorkDir is the working directory for the process.
 	// This is where the Claude Code instance will execute.
 	WorkDir string

--- a/internal/instance/process/tmux_test.go
+++ b/internal/instance/process/tmux_test.go
@@ -400,3 +400,57 @@ func TestTmuxProcess_Integration(t *testing.T) {
 func testTmuxAvailable() error {
 	return nil // tmux availability is handled by the test itself
 }
+
+func TestTmuxProcess_SocketName(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     Config
+		wantSocket string
+	}{
+		{
+			name: "custom socket",
+			config: Config{
+				TmuxSession:   "test-session",
+				TmuxSocket:    "claudio-custom123",
+				WorkDir:       "/tmp",
+				InitialPrompt: "test",
+			},
+			wantSocket: "claudio-custom123",
+		},
+		{
+			name: "default socket when empty",
+			config: Config{
+				TmuxSession:   "test-session",
+				TmuxSocket:    "", // empty should default to "claudio"
+				WorkDir:       "/tmp",
+				InitialPrompt: "test",
+			},
+			wantSocket: "claudio",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewTmuxProcess(tt.config)
+			if got := p.SocketName(); got != tt.wantSocket {
+				t.Errorf("SocketName() = %q, want %q", got, tt.wantSocket)
+			}
+		})
+	}
+}
+
+func TestTmuxProcess_AttachCommand_WithCustomSocket(t *testing.T) {
+	config := Config{
+		TmuxSession:   "test-session",
+		TmuxSocket:    "claudio-abc123",
+		WorkDir:       "/tmp",
+		InitialPrompt: "test",
+	}
+
+	p := NewTmuxProcess(config)
+
+	want := "tmux -L claudio-abc123 attach -t test-session"
+	if got := p.AttachCommand(); got != want {
+		t.Errorf("AttachCommand() = %q, want %q", got, want)
+	}
+}

--- a/internal/instance/prworkflow_test.go
+++ b/internal/instance/prworkflow_test.go
@@ -1,0 +1,68 @@
+package instance
+
+import "testing"
+
+func TestPRWorkflow_SocketName(t *testing.T) {
+	tests := []struct {
+		name       string
+		instanceID string
+		wantSocket string
+	}{
+		{
+			name:       "standard instance",
+			instanceID: "abc123",
+			wantSocket: "claudio-abc123",
+		},
+		{
+			name:       "longer instance ID",
+			instanceID: "instance-xyz-789",
+			wantSocket: "claudio-instance-xyz-789",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := PRWorkflowConfig{
+				TmuxWidth:  100,
+				TmuxHeight: 50,
+			}
+			workflow := NewPRWorkflow(tt.instanceID, "/tmp", "main", "test task", cfg)
+
+			if got := workflow.SocketName(); got != tt.wantSocket {
+				t.Errorf("SocketName() = %q, want %q", got, tt.wantSocket)
+			}
+		})
+	}
+}
+
+func TestNewPRWorkflowWithSocket(t *testing.T) {
+	customSocket := "claudio-custom-socket"
+	cfg := PRWorkflowConfig{
+		TmuxWidth:  100,
+		TmuxHeight: 50,
+	}
+
+	workflow := NewPRWorkflowWithSocket("inst1", customSocket, "/tmp", "main", "test task", cfg)
+
+	if got := workflow.SocketName(); got != customSocket {
+		t.Errorf("SocketName() = %q, want %q", got, customSocket)
+	}
+
+	// Verify session name format
+	expectedSession := "claudio-inst1-pr"
+	if got := workflow.SessionName(); got != expectedSession {
+		t.Errorf("SessionName() = %q, want %q", got, expectedSession)
+	}
+}
+
+func TestPRWorkflow_Running_Initial(t *testing.T) {
+	cfg := PRWorkflowConfig{
+		TmuxWidth:  100,
+		TmuxHeight: 50,
+	}
+	workflow := NewPRWorkflow("test", "/tmp", "main", "task", cfg)
+
+	if workflow.Running() {
+		t.Error("New PR workflow should not be running")
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1,44 +1,138 @@
 // Package tmux provides centralized configuration and helpers for tmux operations.
 //
-// Claudio uses a dedicated tmux socket to isolate its sessions from other tmux
-// clients (like iTerm2's tmux integration). This prevents crashes caused by
-// control-mode notification bugs in tmux when multiple clients share a server.
+// Claudio uses per-instance tmux sockets to isolate each instance's sessions.
+// This prevents a crash in one instance's tmux server from affecting other instances.
+// Each instance uses a socket named "claudio-{instanceID}", providing complete
+// isolation between instances.
+//
+// The default "claudio" socket is used for global operations like listing all
+// sessions or cleanup operations that need to work across multiple instances.
 package tmux
 
 import (
 	"context"
+	"os"
 	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strings"
 )
 
-// SocketName is the dedicated tmux socket name for Claudio.
-// Using a dedicated socket isolates Claudio from other tmux clients
-// that may use control mode (like iTerm2), preventing crashes from
-// tmux control-mode notification bugs.
+// SocketName is the base tmux socket name for Claudio global operations.
+// Individual instances use sockets named "claudio-{instanceID}" for isolation.
 const SocketName = "claudio"
 
-// Command creates an exec.Cmd for tmux with the Claudio socket.
-// This ensures all Claudio tmux operations use the dedicated socket.
+// SocketPrefix is the prefix used for all Claudio tmux sockets.
+// Instance sockets are named "{SocketPrefix}-{instanceID}".
+const SocketPrefix = "claudio"
+
+// Command creates an exec.Cmd for tmux with the default Claudio socket.
+// Use this for global operations like listing all sessions or cleanup.
+// For instance-specific operations, use CommandWithSocket instead.
 func Command(args ...string) *exec.Cmd {
-	fullArgs := append([]string{"-L", SocketName}, args...)
+	return CommandWithSocket(SocketName, args...)
+}
+
+// CommandContext creates a context-aware exec.Cmd for tmux with the default socket.
+// Use this for global operations. For instance-specific operations, use
+// CommandContextWithSocket instead.
+func CommandContext(ctx context.Context, args ...string) *exec.Cmd {
+	return CommandContextWithSocket(ctx, SocketName, args...)
+}
+
+// CommandWithSocket creates an exec.Cmd for tmux with a custom socket name.
+// Use this for instance-specific operations to ensure socket isolation.
+func CommandWithSocket(socket string, args ...string) *exec.Cmd {
+	fullArgs := append([]string{"-L", socket}, args...)
 	return exec.Command("tmux", fullArgs...)
 }
 
-// CommandContext creates a context-aware exec.Cmd for tmux with the Claudio socket.
-// Use this when the command should be cancellable via context.
-func CommandContext(ctx context.Context, args ...string) *exec.Cmd {
-	fullArgs := append([]string{"-L", SocketName}, args...)
+// CommandContextWithSocket creates a context-aware exec.Cmd with a custom socket.
+// Use this for instance-specific operations that need context cancellation.
+func CommandContextWithSocket(ctx context.Context, socket string, args ...string) *exec.Cmd {
+	fullArgs := append([]string{"-L", socket}, args...)
 	return exec.CommandContext(ctx, "tmux", fullArgs...)
 }
 
 // CommandArgs returns the arguments needed to run a tmux command
-// with the Claudio socket. Use this when you need to build the
+// with the default Claudio socket. Use this when you need to build the
 // command string differently (e.g., for display purposes).
 func CommandArgs(args ...string) []string {
-	return append([]string{"-L", SocketName}, args...)
+	return CommandArgsWithSocket(SocketName, args...)
+}
+
+// CommandArgsWithSocket returns tmux arguments with a custom socket name.
+func CommandArgsWithSocket(socket string, args ...string) []string {
+	return append([]string{"-L", socket}, args...)
 }
 
 // BaseArgs returns just the socket arguments [-L, claudio].
 // Use this when you need to prepend socket args to existing argument slices.
 func BaseArgs() []string {
-	return []string{"-L", SocketName}
+	return BaseArgsWithSocket(SocketName)
+}
+
+// BaseArgsWithSocket returns socket arguments for a custom socket name.
+func BaseArgsWithSocket(socket string) []string {
+	return []string{"-L", socket}
+}
+
+// InstanceSocketName returns the socket name for a specific instance.
+// Socket names follow the format "claudio-{instanceID}".
+func InstanceSocketName(instanceID string) string {
+	return SocketPrefix + "-" + instanceID
+}
+
+// ListClaudioSockets returns all tmux sockets that belong to Claudio instances.
+// It searches the tmux socket directory for sockets matching "claudio-*".
+func ListClaudioSockets() ([]string, error) {
+	socketDir, err := getSocketDir()
+	if err != nil {
+		return nil, err
+	}
+
+	pattern := filepath.Join(socketDir, SocketPrefix+"-*")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	// Also include the default socket if it exists
+	defaultSocket := filepath.Join(socketDir, SocketName)
+	if _, err := os.Stat(defaultSocket); err == nil {
+		matches = append(matches, defaultSocket)
+	}
+
+	// Extract just the socket names from full paths
+	sockets := make([]string, 0, len(matches))
+	for _, match := range matches {
+		sockets = append(sockets, filepath.Base(match))
+	}
+
+	return sockets, nil
+}
+
+// getSocketDir returns the tmux socket directory for the current user.
+func getSocketDir() (string, error) {
+	u, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	// tmux uses /tmp/tmux-{uid}/ for sockets
+	return filepath.Join("/tmp", "tmux-"+u.Uid), nil
+}
+
+// IsInstanceSocket returns true if the socket name is an instance-specific socket.
+func IsInstanceSocket(socket string) bool {
+	return strings.HasPrefix(socket, SocketPrefix+"-") && socket != SocketName
+}
+
+// ExtractInstanceID extracts the instance ID from an instance socket name.
+// Returns empty string if the socket is not an instance socket.
+func ExtractInstanceID(socket string) string {
+	prefix := SocketPrefix + "-"
+	if id, found := strings.CutPrefix(socket, prefix); found {
+		return id
+	}
+	return ""
 }

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -14,6 +14,15 @@ func TestSocketName(t *testing.T) {
 	}
 }
 
+func TestSocketPrefix(t *testing.T) {
+	if SocketPrefix == "" {
+		t.Error("SocketPrefix should not be empty")
+	}
+	if SocketPrefix != "claudio" {
+		t.Errorf("SocketPrefix = %q, want %q", SocketPrefix, "claudio")
+	}
+}
+
 func TestCommand(t *testing.T) {
 	cmd := Command("list-sessions")
 	args := cmd.Args
@@ -36,10 +45,49 @@ func TestCommand(t *testing.T) {
 	}
 }
 
+func TestCommandWithSocket(t *testing.T) {
+	customSocket := "claudio-abc123"
+	cmd := CommandWithSocket(customSocket, "list-sessions")
+	args := cmd.Args
+
+	if len(args) < 4 {
+		t.Fatalf("Expected at least 4 args, got %d: %v", len(args), args)
+	}
+
+	if args[0] != "tmux" {
+		t.Errorf("args[0] = %q, want %q", args[0], "tmux")
+	}
+	if args[1] != "-L" {
+		t.Errorf("args[1] = %q, want %q", args[1], "-L")
+	}
+	if args[2] != customSocket {
+		t.Errorf("args[2] = %q, want %q", args[2], customSocket)
+	}
+	if args[3] != "list-sessions" {
+		t.Errorf("args[3] = %q, want %q", args[3], "list-sessions")
+	}
+}
+
 func TestCommandArgs(t *testing.T) {
 	args := CommandArgs("kill-session", "-t", "test")
 
 	expected := []string{"-L", SocketName, "kill-session", "-t", "test"}
+	if len(args) != len(expected) {
+		t.Fatalf("len(args) = %d, want %d", len(args), len(expected))
+	}
+
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("args[%d] = %q, want %q", i, args[i], want)
+		}
+	}
+}
+
+func TestCommandArgsWithSocket(t *testing.T) {
+	customSocket := "claudio-def456"
+	args := CommandArgsWithSocket(customSocket, "kill-session", "-t", "test")
+
+	expected := []string{"-L", customSocket, "kill-session", "-t", "test"}
 	if len(args) != len(expected) {
 		t.Fatalf("len(args) = %d, want %d", len(args), len(expected))
 	}
@@ -65,6 +113,21 @@ func TestBaseArgs(t *testing.T) {
 	}
 }
 
+func TestBaseArgsWithSocket(t *testing.T) {
+	customSocket := "claudio-ghi789"
+	args := BaseArgsWithSocket(customSocket)
+
+	if len(args) != 2 {
+		t.Fatalf("len(args) = %d, want 2", len(args))
+	}
+	if args[0] != "-L" {
+		t.Errorf("args[0] = %q, want %q", args[0], "-L")
+	}
+	if args[1] != customSocket {
+		t.Errorf("args[1] = %q, want %q", args[1], customSocket)
+	}
+}
+
 func TestCommandContext(t *testing.T) {
 	ctx := context.Background()
 	cmd := CommandContext(ctx, "has-session", "-t", "test")
@@ -85,5 +148,95 @@ func TestCommandContext(t *testing.T) {
 	}
 	if args[3] != "has-session" {
 		t.Errorf("args[3] = %q, want %q", args[3], "has-session")
+	}
+}
+
+func TestCommandContextWithSocket(t *testing.T) {
+	ctx := context.Background()
+	customSocket := "claudio-jkl012"
+	cmd := CommandContextWithSocket(ctx, customSocket, "has-session", "-t", "test")
+	args := cmd.Args
+
+	if len(args) < 6 {
+		t.Fatalf("Expected at least 6 args, got %d: %v", len(args), args)
+	}
+
+	if args[0] != "tmux" {
+		t.Errorf("args[0] = %q, want %q", args[0], "tmux")
+	}
+	if args[1] != "-L" {
+		t.Errorf("args[1] = %q, want %q", args[1], "-L")
+	}
+	if args[2] != customSocket {
+		t.Errorf("args[2] = %q, want %q", args[2], customSocket)
+	}
+	if args[3] != "has-session" {
+		t.Errorf("args[3] = %q, want %q", args[3], "has-session")
+	}
+}
+
+func TestInstanceSocketName(t *testing.T) {
+	tests := []struct {
+		instanceID string
+		want       string
+	}{
+		{"abc123", "claudio-abc123"},
+		{"12345678", "claudio-12345678"},
+		{"", "claudio-"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.instanceID, func(t *testing.T) {
+			got := InstanceSocketName(tt.instanceID)
+			if got != tt.want {
+				t.Errorf("InstanceSocketName(%q) = %q, want %q", tt.instanceID, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsInstanceSocket(t *testing.T) {
+	tests := []struct {
+		socket string
+		want   bool
+	}{
+		{"claudio-abc123", true},
+		{"claudio-12345678", true},
+		{"claudio", false},          // Default socket is not an instance socket
+		{"other-socket", false},     // Different prefix
+		{"claudio-", true},          // Empty instance ID is still technically an instance socket format
+		{"claudiosomething", false}, // No hyphen separator
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.socket, func(t *testing.T) {
+			got := IsInstanceSocket(tt.socket)
+			if got != tt.want {
+				t.Errorf("IsInstanceSocket(%q) = %v, want %v", tt.socket, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractInstanceID(t *testing.T) {
+	tests := []struct {
+		socket string
+		want   string
+	}{
+		{"claudio-abc123", "abc123"},
+		{"claudio-12345678", "12345678"},
+		{"claudio-", ""},
+		{"claudio", ""},          // Default socket has no instance ID
+		{"other-socket", ""},     // Different prefix
+		{"claudiosomething", ""}, // No hyphen separator
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.socket, func(t *testing.T) {
+			got := ExtractInstanceID(tt.socket)
+			if got != tt.want {
+				t.Errorf("ExtractInstanceID(%q) = %q, want %q", tt.socket, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/tui/terminal/process_test.go
+++ b/internal/tui/terminal/process_test.go
@@ -1,0 +1,127 @@
+package terminal
+
+import (
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/tmux"
+)
+
+func TestNewProcess(t *testing.T) {
+	p := NewProcess("session123", "/tmp", 100, 50)
+
+	if p == nil {
+		t.Fatal("NewProcess returned nil")
+	}
+
+	// Should use the default socket
+	if got := p.SocketName(); got != tmux.SocketName {
+		t.Errorf("SocketName() = %q, want default %q", got, tmux.SocketName)
+	}
+
+	// Session name should be formatted correctly
+	expectedSession := "claudio-term-session123"
+	if got := p.SessionName(); got != expectedSession {
+		t.Errorf("SessionName() = %q, want %q", got, expectedSession)
+	}
+}
+
+func TestNewProcessWithSocket(t *testing.T) {
+	customSocket := "claudio-custom456"
+	p := NewProcessWithSocket("session123", customSocket, "/tmp", 100, 50)
+
+	if p == nil {
+		t.Fatal("NewProcessWithSocket returned nil")
+	}
+
+	// Should use the custom socket
+	if got := p.SocketName(); got != customSocket {
+		t.Errorf("SocketName() = %q, want %q", got, customSocket)
+	}
+
+	// Session name should still be formatted correctly
+	expectedSession := "claudio-term-session123"
+	if got := p.SessionName(); got != expectedSession {
+		t.Errorf("SessionName() = %q, want %q", got, expectedSession)
+	}
+}
+
+func TestProcess_SocketName(t *testing.T) {
+	tests := []struct {
+		name       string
+		socketName string
+	}{
+		{
+			name:       "default socket",
+			socketName: tmux.SocketName,
+		},
+		{
+			name:       "custom instance socket",
+			socketName: "claudio-abc123",
+		},
+		{
+			name:       "another custom socket",
+			socketName: "claudio-xyz789",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewProcessWithSocket("test-session", tt.socketName, "/tmp", 100, 50)
+			if got := p.SocketName(); got != tt.socketName {
+				t.Errorf("SocketName() = %q, want %q", got, tt.socketName)
+			}
+		})
+	}
+}
+
+func TestProcess_AttachCommand(t *testing.T) {
+	tests := []struct {
+		name        string
+		sessionID   string
+		socketName  string
+		wantCommand string
+	}{
+		{
+			name:        "default socket",
+			sessionID:   "sess1",
+			socketName:  tmux.SocketName,
+			wantCommand: "tmux -L claudio attach -t claudio-term-sess1",
+		},
+		{
+			name:        "custom socket",
+			sessionID:   "sess2",
+			socketName:  "claudio-custom",
+			wantCommand: "tmux -L claudio-custom attach -t claudio-term-sess2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewProcessWithSocket(tt.sessionID, tt.socketName, "/tmp", 100, 50)
+			if got := p.AttachCommand(); got != tt.wantCommand {
+				t.Errorf("AttachCommand() = %q, want %q", got, tt.wantCommand)
+			}
+		})
+	}
+}
+
+func TestProcess_IsRunning_Initial(t *testing.T) {
+	p := NewProcess("test", "/tmp", 100, 50)
+
+	if p.IsRunning() {
+		t.Error("New process should not be running")
+	}
+}
+
+func TestProcess_CurrentDir(t *testing.T) {
+	invocationDir := "/home/user/project"
+	p := NewProcess("test", invocationDir, 100, 50)
+
+	if got := p.CurrentDir(); got != invocationDir {
+		t.Errorf("CurrentDir() = %q, want %q", got, invocationDir)
+	}
+
+	if got := p.InvocationDir(); got != invocationDir {
+		t.Errorf("InvocationDir() = %q, want %q", got, invocationDir)
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes crash propagation bug where one instance's tmux session close could crash ALL instances
- Each instance now gets its own tmux server via unique socket name (`claudio-{instanceID}`)
- Adds socket-parameterized tmux functions for crash isolation
- Updates session cleanup to work across all claudio-* sockets

## Background

When one Claudio instance's tmux session closes, a tmux control mode bug (SIGSEGV in `control_notify_session_closed`) can crash the shared tmux server. Since all instances previously shared a single tmux server via the "claudio" socket, this would kill ALL running instances simultaneously.

**Before**: All instances → `-L claudio` → ONE tmux server (crash propagates)
**After**: Each instance → `-L claudio-{instanceID}` → ISOLATED server (crash contained)

## Changes

- **tmux package**: Added `CommandWithSocket()`, `CommandContextWithSocket()`, `InstanceSocketName()`, `ListClaudioSockets()` functions
- **instance Manager**: Uses per-instance sockets, added `TmuxSessionInfo` struct for socket-aware cleanup
- **lifecycle manager**: Added `SocketName()` to Instance interface, updated all tmux calls
- **process package**: Added `TmuxSocket` to Config, updated tmux calls
- **PR workflow**: Uses parent instance's socket for isolation
- **terminal pane**: Intentionally uses shared "claudio" socket (isolated from instance crashes)
- **CLI sessions**: Cleans up across all claudio-* sockets
- **orchestrator**: Multi-socket orphan detection and cleanup

## Test plan

- [x] Build succeeds: `go build ./...`
- [x] All tests pass: `go test ./...`
- [x] No linting issues: `go vet ./...`
- [ ] Manual test: Start tripleshot mode, verify each instance uses different socket (`ls /tmp/tmux-*/`)
- [ ] Manual test: Stop one instance via `:stop`, verify other instances continue running
- [ ] Manual test: `claudio sessions list` shows all sessions across sockets
- [ ] Manual test: `claudio sessions clean` removes orphaned sessions from all sockets