### PR TITLE
Fix instance numbering calculation in sidebar

### DIFF
--- a/internal/tui/view/dashboard.go
+++ b/internal/tui/view/dashboard.go
@@ -15,10 +15,9 @@ import (
 
 // Layout constants for dashboard rendering
 const (
-	SidebarWidth               = 30 // Fixed sidebar width
-	SidebarMinWidth            = 20 // Minimum sidebar width for narrow terminals
-	ExpandedNameMaxLen         = 50 // Maximum length for expanded instance names
-	ExpandedNameContinuationIn = 4  // Indentation for continuation lines
+	SidebarWidth       = 30 // Fixed sidebar width
+	SidebarMinWidth    = 20 // Minimum sidebar width for narrow terminals
+	ExpandedNameMaxLen = 50 // Maximum length for expanded instance names
 )
 
 // DashboardState provides the minimal state needed for dashboard rendering.
@@ -256,7 +255,9 @@ func (dv *DashboardView) renderExpandedInstance(
 	for len(remaining) > 0 && remaining[0] == ' ' {
 		remaining = remaining[1:]
 	}
-	continuationAvailable := max(width-ExpandedNameContinuationIn-2, 10) // indent + padding
+	// Use firstLineOverhead as indent to align continuation text with the name start position
+	continuationIndent := firstLineOverhead
+	continuationAvailable := max(width-continuationIndent-2, 10) // indent + padding
 
 	for len(remaining) > 0 {
 		chunk := wrapAtWordBoundary(remaining, continuationAvailable)
@@ -271,7 +272,7 @@ func (dv *DashboardView) renderExpandedInstance(
 		}
 
 		// Indent continuation lines to align under the name
-		indent := strings.Repeat(" ", ExpandedNameContinuationIn)
+		indent := strings.Repeat(" ", continuationIndent)
 		lines = append(lines, indent+itemStyle.Render(chunk))
 	}
 


### PR DESCRIPTION
## Summary

- **Grouped view instance numbering**: Instance numbers now remain stable when groups are collapsed/expanded. Previously, numbers shifted because they counted only visible instances.
- **Continuation line alignment**: Expanded instance names now have properly aligned continuation lines regardless of instance number width (single vs double digit).
- **Defensive error handling**: Added fallback when instance index lookup fails, and nil session handling.

## Changes

### `internal/tui/view/group.go`
- Added `AbsoluteIdx` field to `GroupedInstance` struct to track stable position in `session.Instances`
- Added `findInstanceIndex()` helper to look up instance position by ID
- Updated `RenderGroupedInstance` to use `AbsoluteIdx` with fallback to `GlobalIdx` if invalid
- Added nil session check to `findInstanceIndex`

### `internal/tui/view/dashboard.go`
- Fixed continuation line indent to use dynamic `firstLineOverhead` instead of static constant
- Removed unused `ExpandedNameContinuationIn` constant

### Tests
- Added `TestFindInstanceIndex` covering normal cases and nil session
- Added `TestGroupedInstance_AbsoluteIdx` verifying stable numbering across collapse state changes
- Added `TestGroupedInstance_AbsoluteIdx_OutOfOrder` verifying correct behavior with non-sequential group ordering
- Added `TestRenderSidebar_ContinuationLineAlignment` for alignment verification

## Test plan

- [x] All existing tests pass
- [x] New tests cover the fixed behaviors
- [x] Manual verification: instance numbers stay stable when collapsing groups
- [x] Manual verification: continuation lines align properly for single and double digit instance numbers