### PR TITLE
Add session type icons and grouped sidebar display

### DIFF
--- a/internal/orchestrator/session_type.go
+++ b/internal/orchestrator/session_type.go
@@ -1,0 +1,76 @@
+package orchestrator
+
+// SessionType identifies the type of session or group for display purposes.
+// This determines the icon shown in the sidebar and grouping behavior.
+type SessionType string
+
+const (
+	// SessionTypeStandard represents a normal task instance (default).
+	SessionTypeStandard SessionType = "standard"
+
+	// SessionTypePlan represents a :plan command instance (single-pass planning).
+	SessionTypePlan SessionType = "plan"
+
+	// SessionTypePlanMulti represents a :plan command with multi-pass enabled.
+	SessionTypePlanMulti SessionType = "plan_multi"
+
+	// SessionTypeUltraPlan represents an :ultraplan orchestrated session.
+	SessionTypeUltraPlan SessionType = "ultraplan"
+
+	// SessionTypeTripleShot represents a :tripleshot competing solutions session.
+	SessionTypeTripleShot SessionType = "tripleshot"
+)
+
+// Icon returns the display icon for this session type.
+func (t SessionType) Icon() string {
+	switch t {
+	case SessionTypePlan:
+		return "\u25c7" // ◇ diamond
+	case SessionTypePlanMulti:
+		return "\u25c8" // ◈ filled diamond
+	case SessionTypeUltraPlan:
+		return "\u26a1" // ⚡ lightning
+	case SessionTypeTripleShot:
+		return "\u25b3" // △ triangle
+	default:
+		return "\u25cf" // ● filled circle (standard)
+	}
+}
+
+// GroupingMode returns how instances of this type should be grouped.
+// Returns:
+//   - "none": no grouping (flat in Instances section)
+//   - "shared": group in shared category (e.g., "Plans")
+//   - "own": create its own named group
+func (t SessionType) GroupingMode() string {
+	switch t {
+	case SessionTypePlan:
+		return "shared"
+	case SessionTypePlanMulti, SessionTypeUltraPlan, SessionTypeTripleShot:
+		return "own"
+	default:
+		return "none"
+	}
+}
+
+// IsOrchestratedType returns true if this session type involves orchestration
+// (multiple instances coordinated together).
+func (t SessionType) IsOrchestratedType() bool {
+	switch t {
+	case SessionTypeUltraPlan, SessionTypeTripleShot, SessionTypePlanMulti:
+		return true
+	default:
+		return false
+	}
+}
+
+// SharedGroupName returns the name of the shared group for this type.
+// Only meaningful when GroupingMode() returns "shared".
+func (t SessionType) SharedGroupName() string {
+	switch t {
+	case SessionTypePlan:
+		return "Plans"
+	default:
+		return ""
+	}
+}

--- a/internal/orchestrator/session_type_test.go
+++ b/internal/orchestrator/session_type_test.go
@@ -1,0 +1,196 @@
+package orchestrator
+
+import "testing"
+
+func TestSessionType_Icon(t *testing.T) {
+	tests := []struct {
+		sessionType SessionType
+		wantIcon    string
+	}{
+		{SessionTypeStandard, "\u25cf"},   // ● filled circle
+		{SessionTypePlan, "\u25c7"},       // ◇ diamond
+		{SessionTypePlanMulti, "\u25c8"},  // ◈ filled diamond
+		{SessionTypeUltraPlan, "\u26a1"},  // ⚡ lightning
+		{SessionTypeTripleShot, "\u25b3"}, // △ triangle
+		{"unknown", "\u25cf"},             // Default to filled circle
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.sessionType), func(t *testing.T) {
+			got := tt.sessionType.Icon()
+			if got != tt.wantIcon {
+				t.Errorf("Icon() = %q, want %q", got, tt.wantIcon)
+			}
+		})
+	}
+}
+
+func TestSessionType_GroupingMode(t *testing.T) {
+	tests := []struct {
+		sessionType SessionType
+		wantMode    string
+	}{
+		{SessionTypeStandard, "none"},
+		{SessionTypePlan, "shared"},
+		{SessionTypePlanMulti, "own"},
+		{SessionTypeUltraPlan, "own"},
+		{SessionTypeTripleShot, "own"},
+		{"unknown", "none"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.sessionType), func(t *testing.T) {
+			got := tt.sessionType.GroupingMode()
+			if got != tt.wantMode {
+				t.Errorf("GroupingMode() = %q, want %q", got, tt.wantMode)
+			}
+		})
+	}
+}
+
+func TestSessionType_IsOrchestratedType(t *testing.T) {
+	tests := []struct {
+		sessionType SessionType
+		want        bool
+	}{
+		{SessionTypeStandard, false},
+		{SessionTypePlan, false},
+		{SessionTypePlanMulti, true},
+		{SessionTypeUltraPlan, true},
+		{SessionTypeTripleShot, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.sessionType), func(t *testing.T) {
+			got := tt.sessionType.IsOrchestratedType()
+			if got != tt.want {
+				t.Errorf("IsOrchestratedType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSessionType_SharedGroupName(t *testing.T) {
+	tests := []struct {
+		sessionType SessionType
+		want        string
+	}{
+		{SessionTypePlan, "Plans"},
+		{SessionTypeStandard, ""},
+		{SessionTypeUltraPlan, ""},
+		{SessionTypeTripleShot, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.sessionType), func(t *testing.T) {
+			got := tt.sessionType.SharedGroupName()
+			if got != tt.want {
+				t.Errorf("SharedGroupName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewInstanceGroupWithType(t *testing.T) {
+	group := NewInstanceGroupWithType("Test Group", SessionTypeUltraPlan, "Test objective")
+
+	if group.ID == "" {
+		t.Error("Expected group ID to be generated")
+	}
+	if group.Name != "Test Group" {
+		t.Errorf("Name = %q, want %q", group.Name, "Test Group")
+	}
+	if group.SessionType != SessionTypeUltraPlan {
+		t.Errorf("SessionType = %q, want %q", group.SessionType, SessionTypeUltraPlan)
+	}
+	if group.Objective != "Test objective" {
+		t.Errorf("Objective = %q, want %q", group.Objective, "Test objective")
+	}
+	if group.Phase != GroupPhasePending {
+		t.Errorf("Phase = %q, want %q", group.Phase, GroupPhasePending)
+	}
+}
+
+func TestSession_GetOrCreateSharedGroup(t *testing.T) {
+	t.Run("creates new shared group", func(t *testing.T) {
+		session := &Session{
+			ID:     "test-session",
+			Groups: make([]*InstanceGroup, 0),
+		}
+
+		group := session.GetOrCreateSharedGroup(SessionTypePlan)
+
+		if group == nil {
+			t.Fatal("Expected group to be created")
+		}
+		if group.SessionType != SessionTypePlan {
+			t.Errorf("SessionType = %q, want %q", group.SessionType, SessionTypePlan)
+		}
+		if group.Name != "Plans" {
+			t.Errorf("Name = %q, want %q", group.Name, "Plans")
+		}
+		if len(session.Groups) != 1 {
+			t.Errorf("Expected 1 group, got %d", len(session.Groups))
+		}
+	})
+
+	t.Run("returns existing shared group", func(t *testing.T) {
+		existingGroup := NewInstanceGroupWithType("Plans", SessionTypePlan, "")
+		session := &Session{
+			ID:     "test-session",
+			Groups: []*InstanceGroup{existingGroup},
+		}
+
+		group := session.GetOrCreateSharedGroup(SessionTypePlan)
+
+		if group != existingGroup {
+			t.Error("Expected to get existing group")
+		}
+		if len(session.Groups) != 1 {
+			t.Errorf("Expected 1 group, got %d", len(session.Groups))
+		}
+	})
+
+	t.Run("returns nil for non-shared types", func(t *testing.T) {
+		session := &Session{
+			ID:     "test-session",
+			Groups: make([]*InstanceGroup, 0),
+		}
+
+		group := session.GetOrCreateSharedGroup(SessionTypeUltraPlan)
+
+		if group != nil {
+			t.Error("Expected nil for non-shared type")
+		}
+	})
+}
+
+func TestSession_GetGroupBySessionType(t *testing.T) {
+	planGroup := NewInstanceGroupWithType("Plans", SessionTypePlan, "")
+	ultraGroup := NewInstanceGroupWithType("Ultra Task", SessionTypeUltraPlan, "objective")
+
+	session := &Session{
+		ID:     "test-session",
+		Groups: []*InstanceGroup{planGroup, ultraGroup},
+	}
+
+	tests := []struct {
+		name        string
+		sessionType SessionType
+		expected    *InstanceGroup
+	}{
+		{"find plan group", SessionTypePlan, planGroup},
+		{"find ultraplan group", SessionTypeUltraPlan, ultraGroup},
+		{"not found tripleshot", SessionTypeTripleShot, nil},
+		{"not found standard", SessionTypeStandard, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := session.GetGroupBySessionType(tt.sessionType)
+			if got != tt.expected {
+				t.Errorf("GetGroupBySessionType(%q) = %v, want %v", tt.sessionType, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3112,6 +3112,17 @@ func (m Model) initiateTripleShotMode(task string) (Model, tea.Cmd) {
 	// Create coordinator
 	coordinator := orchestrator.NewTripleShotCoordinator(m.orchestrator, m.session, tripleSession, m.logger)
 
+	// Create a group for this triple-shot session
+	tripleGroup := orchestrator.NewInstanceGroupWithType(
+		truncateString(task, 30),
+		orchestrator.SessionTypeTripleShot,
+		task,
+	)
+	m.session.AddGroup(tripleGroup)
+
+	// Auto-enable grouped sidebar mode
+	m.autoEnableGroupedMode()
+
 	// Set triple-shot state
 	m.tripleShot = &TripleShotState{
 		Coordinator: coordinator,

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -245,6 +245,17 @@ func (m Model) SidebarMode() view.SidebarMode {
 	return m.sidebarMode
 }
 
+// autoEnableGroupedMode switches to grouped sidebar mode when groups exist.
+// Call this after creating a new group to automatically show the grouped view.
+func (m *Model) autoEnableGroupedMode() {
+	if m.session != nil && len(m.session.Groups) > 0 && m.sidebarMode == view.SidebarModeFlat {
+		m.sidebarMode = view.SidebarModeGrouped
+		if m.groupViewState == nil {
+			m.groupViewState = view.NewGroupViewState()
+		}
+	}
+}
+
 // enterPlanEditor initializes the plan editor state when entering edit mode
 func (m *Model) enterPlanEditor() {
 	m.planEditor = &PlanEditorState{

--- a/internal/tui/styles/styles.go
+++ b/internal/tui/styles/styles.go
@@ -334,3 +334,35 @@ func StatusIcon(status string) string {
 		return "●"
 	}
 }
+
+// Session type icons for the grouped sidebar
+const (
+	IconStandard      = "●" // Filled circle for standard instances
+	IconPlan          = "◇" // Diamond for :plan instances
+	IconPlanMulti     = "◈" // Filled diamond for multi-pass plan
+	IconUltraPlan     = "⚡" // Lightning for :ultraplan orchestration
+	IconTripleShot    = "△" // Triangle for :tripleshot (three competing)
+	IconGroupExpand   = "▾" // Down-pointing triangle (expanded)
+	IconGroupCollapse = "▸" // Right-pointing triangle (collapsed)
+)
+
+// Session type colors
+var (
+	SessionTypePlanColor       = PurpleColor // Purple for planning
+	SessionTypeUltraPlanColor  = YellowColor // Yellow for orchestration
+	SessionTypeTripleShotColor = BlueColor   // Blue for competition
+)
+
+// SessionTypeColor returns the color for a session type string
+func SessionTypeColor(sessionType string) lipgloss.Color {
+	switch sessionType {
+	case "plan", "plan_multi":
+		return SessionTypePlanColor
+	case "ultraplan":
+		return SessionTypeUltraPlanColor
+	case "tripleshot":
+		return SessionTypeTripleShotColor
+	default:
+		return MutedColor
+	}
+}

--- a/internal/tui/view/group_builder.go
+++ b/internal/tui/view/group_builder.go
@@ -1,0 +1,142 @@
+package view
+
+import (
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+)
+
+// GroupedSidebarData holds the structured data for rendering the grouped sidebar.
+// It separates instances into ungrouped (flat) and grouped sections.
+type GroupedSidebarData struct {
+	// UngroupedInstances are instances not belonging to any group (shown in "Instances" section)
+	UngroupedInstances []*orchestrator.Instance
+
+	// Groups are session-specific groups (ultraplan, tripleshot, multi-pass plan)
+	// Each creates its own collapsible section
+	Groups []*orchestrator.InstanceGroup
+
+	// SharedGroups are groups that collect instances of the same type (e.g., "Plans")
+	SharedGroups []*orchestrator.InstanceGroup
+}
+
+// BuildGroupedSidebarData analyzes a session and builds the structured data
+// for rendering a grouped sidebar. It categorizes instances based on their
+// group membership and session types.
+func BuildGroupedSidebarData(session *orchestrator.Session) *GroupedSidebarData {
+	if session == nil {
+		return &GroupedSidebarData{}
+	}
+
+	data := &GroupedSidebarData{
+		UngroupedInstances: make([]*orchestrator.Instance, 0),
+		Groups:             make([]*orchestrator.InstanceGroup, 0),
+		SharedGroups:       make([]*orchestrator.InstanceGroup, 0),
+	}
+
+	// Build a set of instance IDs that belong to groups
+	groupedInstanceIDs := make(map[string]bool)
+	for _, group := range session.Groups {
+		for _, instID := range group.AllInstanceIDs() {
+			groupedInstanceIDs[instID] = true
+		}
+	}
+
+	// Categorize instances
+	for _, inst := range session.Instances {
+		if !groupedInstanceIDs[inst.ID] {
+			data.UngroupedInstances = append(data.UngroupedInstances, inst)
+		}
+	}
+
+	// Categorize groups by type
+	for _, group := range session.Groups {
+		if group.SessionType.GroupingMode() == "shared" {
+			data.SharedGroups = append(data.SharedGroups, group)
+		} else {
+			data.Groups = append(data.Groups, group)
+		}
+	}
+
+	return data
+}
+
+// HasGroups returns true if there are any groups to display
+func (d *GroupedSidebarData) HasGroups() bool {
+	return len(d.Groups) > 0 || len(d.SharedGroups) > 0
+}
+
+// TotalGroupCount returns the total number of groups (both regular and shared)
+func (d *GroupedSidebarData) TotalGroupCount() int {
+	return len(d.Groups) + len(d.SharedGroups)
+}
+
+// SidebarSection represents a section in the grouped sidebar
+type SidebarSection struct {
+	Type      SidebarSectionType
+	Title     string                      // Section header (e.g., "INSTANCES", "Plans")
+	Icon      string                      // Icon for this section
+	Instances []*orchestrator.Instance    // For ungrouped sections
+	Group     *orchestrator.InstanceGroup // For group sections
+}
+
+// SidebarSectionType identifies the type of sidebar section
+type SidebarSectionType int
+
+const (
+	// SectionTypeUngrouped is the flat "Instances" section
+	SectionTypeUngrouped SidebarSectionType = iota
+	// SectionTypeGroup is a session-specific group (ultraplan, tripleshot)
+	SectionTypeGroup
+	// SectionTypeSharedGroup is a shared category group (e.g., "Plans")
+	SectionTypeSharedGroup
+)
+
+// BuildSidebarSections creates an ordered list of sections for sidebar rendering.
+// The order is:
+// 1. Ungrouped instances (if any)
+// 2. Session-specific groups (ultraplan, tripleshot, etc.)
+// 3. Shared groups (Plans, etc.)
+func BuildSidebarSections(session *orchestrator.Session) []SidebarSection {
+	data := BuildGroupedSidebarData(session)
+	sections := make([]SidebarSection, 0)
+
+	// Add ungrouped instances section if any exist
+	if len(data.UngroupedInstances) > 0 {
+		sections = append(sections, SidebarSection{
+			Type:      SectionTypeUngrouped,
+			Title:     "INSTANCES",
+			Icon:      "",
+			Instances: data.UngroupedInstances,
+		})
+	}
+
+	// Add session-specific groups
+	for _, group := range data.Groups {
+		sections = append(sections, SidebarSection{
+			Type:  SectionTypeGroup,
+			Title: group.Name,
+			Icon:  group.SessionType.Icon(),
+			Group: group,
+		})
+	}
+
+	// Add shared groups
+	for _, group := range data.SharedGroups {
+		sections = append(sections, SidebarSection{
+			Type:  SectionTypeSharedGroup,
+			Title: group.Name,
+			Icon:  group.SessionType.Icon(),
+			Group: group,
+		})
+	}
+
+	return sections
+}
+
+// ShouldUseGroupedMode determines if the sidebar should switch to grouped mode.
+// Returns true if there are any groups defined in the session.
+func ShouldUseGroupedMode(session *orchestrator.Session) bool {
+	if session == nil {
+		return false
+	}
+	return len(session.Groups) > 0
+}

--- a/internal/tui/view/group_builder_test.go
+++ b/internal/tui/view/group_builder_test.go
@@ -1,0 +1,270 @@
+package view
+
+import (
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+)
+
+func TestBuildGroupedSidebarData_NilSession(t *testing.T) {
+	data := BuildGroupedSidebarData(nil)
+
+	if data == nil {
+		t.Fatal("Expected non-nil data")
+	}
+	if len(data.UngroupedInstances) != 0 {
+		t.Errorf("Expected 0 ungrouped instances, got %d", len(data.UngroupedInstances))
+	}
+	if len(data.Groups) != 0 {
+		t.Errorf("Expected 0 groups, got %d", len(data.Groups))
+	}
+}
+
+func TestBuildGroupedSidebarData_UngroupedInstances(t *testing.T) {
+	session := &orchestrator.Session{
+		ID: "test-session",
+		Instances: []*orchestrator.Instance{
+			{ID: "inst-1", Task: "Task 1"},
+			{ID: "inst-2", Task: "Task 2"},
+		},
+		Groups: nil,
+	}
+
+	data := BuildGroupedSidebarData(session)
+
+	if len(data.UngroupedInstances) != 2 {
+		t.Errorf("Expected 2 ungrouped instances, got %d", len(data.UngroupedInstances))
+	}
+	if len(data.Groups) != 0 {
+		t.Errorf("Expected 0 groups, got %d", len(data.Groups))
+	}
+}
+
+func TestBuildGroupedSidebarData_WithGroups(t *testing.T) {
+	ultraGroup := orchestrator.NewInstanceGroupWithType("Ultraplan Task", orchestrator.SessionTypeUltraPlan, "Do something")
+	ultraGroup.Instances = []string{"inst-1", "inst-2"}
+
+	planGroup := orchestrator.NewInstanceGroupWithType("Plans", orchestrator.SessionTypePlan, "")
+	planGroup.Instances = []string{"inst-3"}
+
+	session := &orchestrator.Session{
+		ID: "test-session",
+		Instances: []*orchestrator.Instance{
+			{ID: "inst-1", Task: "Task 1"},
+			{ID: "inst-2", Task: "Task 2"},
+			{ID: "inst-3", Task: "Task 3"},
+			{ID: "inst-4", Task: "Ungrouped Task"},
+		},
+		Groups: []*orchestrator.InstanceGroup{ultraGroup, planGroup},
+	}
+
+	data := BuildGroupedSidebarData(session)
+
+	// inst-4 should be ungrouped
+	if len(data.UngroupedInstances) != 1 {
+		t.Errorf("Expected 1 ungrouped instance, got %d", len(data.UngroupedInstances))
+	}
+	if data.UngroupedInstances[0].ID != "inst-4" {
+		t.Errorf("Expected ungrouped instance inst-4, got %s", data.UngroupedInstances[0].ID)
+	}
+
+	// ultraplan should be in Groups (own type)
+	if len(data.Groups) != 1 {
+		t.Errorf("Expected 1 own group, got %d", len(data.Groups))
+	}
+	if data.Groups[0].SessionType != orchestrator.SessionTypeUltraPlan {
+		t.Errorf("Expected SessionTypeUltraPlan, got %s", data.Groups[0].SessionType)
+	}
+
+	// plan should be in SharedGroups (shared type)
+	if len(data.SharedGroups) != 1 {
+		t.Errorf("Expected 1 shared group, got %d", len(data.SharedGroups))
+	}
+	if data.SharedGroups[0].SessionType != orchestrator.SessionTypePlan {
+		t.Errorf("Expected SessionTypePlan, got %s", data.SharedGroups[0].SessionType)
+	}
+}
+
+func TestGroupedSidebarData_HasGroups(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     *GroupedSidebarData
+		expected bool
+	}{
+		{
+			name:     "no groups",
+			data:     &GroupedSidebarData{},
+			expected: false,
+		},
+		{
+			name: "with regular groups",
+			data: &GroupedSidebarData{
+				Groups: []*orchestrator.InstanceGroup{
+					orchestrator.NewInstanceGroup("Test"),
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "with shared groups",
+			data: &GroupedSidebarData{
+				SharedGroups: []*orchestrator.InstanceGroup{
+					orchestrator.NewInstanceGroup("Plans"),
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.data.HasGroups()
+			if got != tt.expected {
+				t.Errorf("HasGroups() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGroupedSidebarData_TotalGroupCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     *GroupedSidebarData
+		expected int
+	}{
+		{
+			name:     "no groups",
+			data:     &GroupedSidebarData{},
+			expected: 0,
+		},
+		{
+			name: "only regular groups",
+			data: &GroupedSidebarData{
+				Groups: []*orchestrator.InstanceGroup{
+					orchestrator.NewInstanceGroup("Test"),
+				},
+			},
+			expected: 1,
+		},
+		{
+			name: "only shared groups",
+			data: &GroupedSidebarData{
+				SharedGroups: []*orchestrator.InstanceGroup{
+					orchestrator.NewInstanceGroup("Plans"),
+				},
+			},
+			expected: 1,
+		},
+		{
+			name: "both types",
+			data: &GroupedSidebarData{
+				Groups: []*orchestrator.InstanceGroup{
+					orchestrator.NewInstanceGroup("Ultra"),
+					orchestrator.NewInstanceGroup("Triple"),
+				},
+				SharedGroups: []*orchestrator.InstanceGroup{
+					orchestrator.NewInstanceGroup("Plans"),
+				},
+			},
+			expected: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.data.TotalGroupCount()
+			if got != tt.expected {
+				t.Errorf("TotalGroupCount() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildSidebarSections(t *testing.T) {
+	ultraGroup := orchestrator.NewInstanceGroupWithType("Auth Task", orchestrator.SessionTypeUltraPlan, "Add auth")
+	ultraGroup.Instances = []string{"inst-1"}
+
+	session := &orchestrator.Session{
+		ID: "test-session",
+		Instances: []*orchestrator.Instance{
+			{ID: "inst-1", Task: "Task 1"},
+			{ID: "inst-2", Task: "Ungrouped"},
+		},
+		Groups: []*orchestrator.InstanceGroup{ultraGroup},
+	}
+
+	sections := BuildSidebarSections(session)
+
+	// Should have 2 sections: ungrouped instances and ultraplan group
+	if len(sections) != 2 {
+		t.Fatalf("Expected 2 sections, got %d", len(sections))
+	}
+
+	// First section should be ungrouped instances
+	if sections[0].Type != SectionTypeUngrouped {
+		t.Errorf("First section type = %v, want SectionTypeUngrouped", sections[0].Type)
+	}
+	if sections[0].Title != "INSTANCES" {
+		t.Errorf("First section title = %q, want INSTANCES", sections[0].Title)
+	}
+	if len(sections[0].Instances) != 1 {
+		t.Errorf("Expected 1 ungrouped instance, got %d", len(sections[0].Instances))
+	}
+
+	// Second section should be ultraplan group
+	if sections[1].Type != SectionTypeGroup {
+		t.Errorf("Second section type = %v, want SectionTypeGroup", sections[1].Type)
+	}
+	if sections[1].Icon != orchestrator.SessionTypeUltraPlan.Icon() {
+		t.Errorf("Second section icon = %q, want %q", sections[1].Icon, orchestrator.SessionTypeUltraPlan.Icon())
+	}
+}
+
+func TestShouldUseGroupedMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		session  *orchestrator.Session
+		expected bool
+	}{
+		{
+			name:     "nil session",
+			session:  nil,
+			expected: false,
+		},
+		{
+			name: "no groups",
+			session: &orchestrator.Session{
+				ID:     "test",
+				Groups: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "empty groups",
+			session: &orchestrator.Session{
+				ID:     "test",
+				Groups: []*orchestrator.InstanceGroup{},
+			},
+			expected: false,
+		},
+		{
+			name: "with groups",
+			session: &orchestrator.Session{
+				ID: "test",
+				Groups: []*orchestrator.InstanceGroup{
+					orchestrator.NewInstanceGroup("Test"),
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ShouldUseGroupedMode(tt.session)
+			if got != tt.expected {
+				t.Errorf("ShouldUseGroupedMode() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/tui/view/sidebar_test.go
+++ b/internal/tui/view/sidebar_test.go
@@ -736,14 +736,14 @@ func TestRenderGroupHeader(t *testing.T) {
 		t.Errorf("should contain progress [2/5], got: %s", result)
 	}
 	// Should have expanded indicator (down triangle)
-	if !strings.Contains(result, "\u25bc") {
+	if !strings.Contains(result, styles.IconGroupExpand) {
 		t.Errorf("expanded group should have down triangle, got: %s", result)
 	}
 
 	// Test collapsed
 	result = RenderGroupHeader(group, progress, true, false, 40)
 	// Should have collapsed indicator (right triangle)
-	if !strings.Contains(result, "\u25b6") {
+	if !strings.Contains(result, styles.IconGroupCollapse) {
 		t.Errorf("collapsed group should have right triangle, got: %s", result)
 	}
 }


### PR DESCRIPTION
## Summary

- Add distinct icons for each session type in the sidebar (●, ◇, ◈, ⚡, △)
- Implement auto-grouping behavior: ultraplan/tripleshot create their own groups, single-pass plans go to shared "Plans" group
- Auto-enable grouped sidebar mode when groups exist
- Add LLM-based group renaming support in namer package

## Changes

### New Files
- `internal/orchestrator/session_type.go` - SessionType enum with Icon(), GroupingMode(), IsOrchestratedType(), SharedGroupName() methods
- `internal/tui/view/group_builder.go` - Auto-grouping logic for sidebar data organization
- Tests for all new functionality

### Modified Files
- Extended `InstanceGroup` with SessionType and Objective fields
- Updated group header rendering to show session type icons
- Added group renaming callbacks to namer package
- Auto-enable grouped mode in model.go when groups are created

## Test plan

- [x] `go build ./...` succeeds
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [ ] Manual test: Start Claudio, verify standard instances in "Instances" section
- [ ] Manual test: Run `:ultraplan test`, verify creates group with ⚡ icon
- [ ] Manual test: Run `:tripleshot test`, verify creates group with △ icon
- [ ] Manual test: Verify collapse/expand and navigation work