### PR TITLE
Register instances with groups for sidebar display

### DIFF
--- a/internal/orchestrator/coordinator.go
+++ b/internal/orchestrator/coordinator.go
@@ -516,6 +516,11 @@ func (c *Coordinator) RunPlanning() error {
 		return fmt.Errorf("failed to create planning instance: %w", err)
 	}
 
+	// Add planning instance to the ultraplan group for sidebar display
+	if ultraGroup := c.baseSession.GetGroupBySessionType(SessionTypeUltraPlan); ultraGroup != nil {
+		ultraGroup.AddInstance(inst.ID)
+	}
+
 	session.CoordinatorID = inst.ID
 
 	// Start the instance
@@ -567,6 +572,11 @@ func (c *Coordinator) RunMultiPassPlanning() error {
 				"stage", "create_instance",
 			)
 			return fmt.Errorf("failed to create planning instance for strategy %s: %w", strategy, err)
+		}
+
+		// Add planning instance to the multi-pass group for sidebar display
+		if multiGroup := c.baseSession.GetGroupBySessionType(SessionTypePlanMulti); multiGroup != nil {
+			multiGroup.AddInstance(inst.ID)
 		}
 
 		// Store the instance ID
@@ -631,6 +641,11 @@ func (c *Coordinator) RunPlanManager() error {
 	inst, err := c.orch.AddInstance(c.baseSession, prompt)
 	if err != nil {
 		return fmt.Errorf("failed to create plan manager instance: %w", err)
+	}
+
+	// Add plan manager to the multi-pass group for sidebar display
+	if multiGroup := c.baseSession.GetGroupBySessionType(SessionTypePlanMulti); multiGroup != nil {
+		multiGroup.AddInstance(inst.ID)
 	}
 
 	session.PlanManagerID = inst.ID
@@ -923,6 +938,15 @@ func (c *Coordinator) startTask(taskID string, completionChan chan<- taskComplet
 			"stage", "create_instance",
 		)
 		return fmt.Errorf("failed to create instance for task %s: %w", taskID, err)
+	}
+
+	// Add instance to the ultraplan group for sidebar display
+	sessionType := SessionTypeUltraPlan
+	if session.Config.MultiPass {
+		sessionType = SessionTypePlanMulti
+	}
+	if ultraGroup := c.baseSession.GetGroupBySessionType(sessionType); ultraGroup != nil {
+		ultraGroup.AddInstance(inst.ID)
 	}
 
 	// Track the running task
@@ -1434,6 +1458,15 @@ func (c *Coordinator) RunSynthesis() error {
 	session := c.Session()
 	session.SynthesisID = inst.ID
 
+	// Add synthesis instance to the ultraplan group for sidebar display
+	sessionType := SessionTypeUltraPlan
+	if session.Config.MultiPass {
+		sessionType = SessionTypePlanMulti
+	}
+	if ultraGroup := c.baseSession.GetGroupBySessionType(sessionType); ultraGroup != nil {
+		ultraGroup.AddInstance(inst.ID)
+	}
+
 	// Start the instance
 	if err := c.orch.StartInstance(inst); err != nil {
 		c.logger.Error("synthesis failed",
@@ -1773,6 +1806,15 @@ func (c *Coordinator) startRevisionTask(taskID string, completionChan chan<- tas
 		return fmt.Errorf("failed to create revision instance for task %s: %w", taskID, err)
 	}
 
+	// Add revision instance to the ultraplan group for sidebar display
+	sessionType := SessionTypeUltraPlan
+	if session.Config.MultiPass {
+		sessionType = SessionTypePlanMulti
+	}
+	if ultraGroup := c.baseSession.GetGroupBySessionType(sessionType); ultraGroup != nil {
+		ultraGroup.AddInstance(inst.ID)
+	}
+
 	c.mu.Lock()
 	session.RevisionID = inst.ID
 	c.mu.Unlock()
@@ -1962,6 +2004,15 @@ func (c *Coordinator) StartConsolidation() error {
 	inst, err := c.orch.AddInstance(c.baseSession, prompt)
 	if err != nil {
 		return fmt.Errorf("failed to create consolidation instance: %w", err)
+	}
+
+	// Add consolidation instance to the ultraplan group for sidebar display
+	sessionType := SessionTypeUltraPlan
+	if session.Config.MultiPass {
+		sessionType = SessionTypePlanMulti
+	}
+	if ultraGroup := c.baseSession.GetGroupBySessionType(sessionType); ultraGroup != nil {
+		ultraGroup.AddInstance(inst.ID)
 	}
 
 	// Store the consolidation instance ID for TUI visibility
@@ -3549,6 +3600,15 @@ func (c *Coordinator) startGroupConsolidatorSession(groupIndex int) error {
 	}
 	if err != nil {
 		return fmt.Errorf("failed to create group consolidator instance: %w", err)
+	}
+
+	// Add consolidator instance to the ultraplan group for sidebar display
+	sessionType := SessionTypeUltraPlan
+	if session.Config.MultiPass {
+		sessionType = SessionTypePlanMulti
+	}
+	if ultraGroup := c.baseSession.GetGroupBySessionType(sessionType); ultraGroup != nil {
+		ultraGroup.AddInstance(inst.ID)
 	}
 
 	// Store the consolidator instance ID

--- a/internal/orchestrator/tripleshot_coordinator.go
+++ b/internal/orchestrator/tripleshot_coordinator.go
@@ -227,6 +227,9 @@ func (c *TripleShotCoordinator) StartAttempts() error {
 	now := time.Now()
 	session.StartedAt = &now
 
+	// Find the triple-shot group to add instances to
+	tripleGroup := c.baseSession.GetGroupBySessionType(SessionTypeTripleShot)
+
 	// Create and start all three attempts
 	for i := range 3 {
 		prompt := fmt.Sprintf(TripleShotAttemptPromptTemplate, task, i)
@@ -235,6 +238,11 @@ func (c *TripleShotCoordinator) StartAttempts() error {
 		inst, err := c.orch.AddInstance(c.baseSession, prompt)
 		if err != nil {
 			return fmt.Errorf("failed to create attempt %d instance: %w", i, err)
+		}
+
+		// Add instance to the triple-shot group for sidebar display
+		if tripleGroup != nil {
+			tripleGroup.AddInstance(inst.ID)
 		}
 
 		// Record attempt info
@@ -302,6 +310,11 @@ func (c *TripleShotCoordinator) StartJudge() error {
 	inst, err := c.orch.AddInstance(c.baseSession, prompt)
 	if err != nil {
 		return fmt.Errorf("failed to create judge instance: %w", err)
+	}
+
+	// Add judge to the triple-shot group for sidebar display
+	if tripleGroup := c.baseSession.GetGroupBySessionType(SessionTypeTripleShot); tripleGroup != nil {
+		tripleGroup.AddInstance(inst.ID)
 	}
 
 	session.JudgeID = inst.ID

--- a/internal/tui/inlineplan.go
+++ b/internal/tui/inlineplan.go
@@ -203,6 +203,8 @@ func (m *Model) handleInlinePlanObjectiveSubmit(objective string) {
 		if orchGroup := m.session.GetGroup(planGroup.ID); orchGroup != nil {
 			orchGroup.SessionType = orchestrator.SessionTypePlan
 			orchGroup.Objective = objective
+			// Add the planning instance to the group for sidebar display
+			orchGroup.AddInstance(inst.ID)
 		}
 
 		// If in tripleshot mode, register this group for sidebar display


### PR DESCRIPTION
## Summary

- Fixes bug where instances weren't appearing in the grouped sidebar view
- Groups were created correctly but instances were never added to `group.Instances`
- The sidebar rendered group headers with `[0/0]` progress and no visible instances
- Navigation (h/l/tab) still worked because it used a different code path

## Changes

Adds `group.AddInstance(inst.ID)` calls after each instance creation:

**tripleshot_coordinator.go:**
- `StartAttempts()` - register attempt instances
- `StartJudge()` - register judge instance

**coordinator.go:**
- `RunPlanning()` - planning instance for single-pass
- `RunMultiPassPlanning()` - planning instances for multi-pass
- `RunPlanManager()` - plan manager instance
- `startTask()` - task execution instances
- `RunSynthesis()` - synthesis instance
- `startRevisionTask()` - revision instances
- `StartConsolidation()` - consolidation instance
- `startGroupConsolidatorSession()` - group consolidator instances

**inlineplan.go:**
- `handleInlinePlanObjectiveSubmit()` - planning instance for inline plan

## Test plan

- [ ] Start a triple-shot session - verify 3 attempt instances appear under the group header
- [ ] Start an ultraplan session - verify planning instance appears, then task instances
- [ ] Verify group progress shows correct counts (e.g., `[1/3]` instead of `[0/0]`)
- [ ] Verify navigation (j/k) and group collapse (Space) still work correctly
- [ ] Run `go test ./internal/orchestrator/... ./internal/tui/...` - all tests pass