### PR TITLE
Add progress persistence for interrupted sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **Triple-Shot Accept Command** - Implement missing `:accept` command that was referenced in UI message but never implemented. Users can now accept winning triple-shot solutions after evaluation completes.
-
 ### Added
 
+- **Progress Persistence & Session Recovery** - Claude instances now persist their session IDs, enabling automatic recovery when Claudio is interrupted. If Claudio exits unexpectedly while instances are running, reattaching to the session will automatically resume Claude conversations using `--resume`, picking up exactly where they left off. Sessions track clean shutdown state and can detect interruptions on restart.
 - **Plan Mode in Triple-Shot** - The `:plan` command can now be used while in triple-shot mode. Plan groups appear as separate sections in the sidebar below the tripleshot attempts and judge, allowing parallel planning workflows alongside tripleshot execution.
 - **Inline Plan Mode** (Experimental) - New `:plan` command enables structured task planning directly within the TUI. Create task groups, define dependencies, and execute plans without leaving Claudio. Enable via `experimental.inline_plan` in config.
 - **Inline UltraPlan Mode** (Experimental) - New `:ultraplan` command for parallel task execution with automatic coordination. Supports multi-pass planning (`--multi-pass`) and loading existing plans (`--plan <file>`). Enable via `experimental.inline_ultraplan` in config.
@@ -21,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Group Management Commands** - New commands for organizing instances: `:group create`, `:group add`, `:group remove`, `:group move`, `:group order`, `:group delete`.
 - **Group-aware PR Workflow** - Create PRs for task groups with `:pr --group` (stacked PRs), `:pr --group=all` (consolidated), or `:pr --group=single` (single group).
 - **Session Resume for Consolidation** - Resume paused consolidation after manually resolving merge conflicts using the `r` key in UltraPlan mode. The system validates conflicts are resolved before continuing.
+
+### Fixed
+
+- **Triple-Shot Accept Command** - Implement missing `:accept` command that was referenced in UI message but never implemented. Users can now accept winning triple-shot solutions after evaluation completes.
 
 ### Changed
 

--- a/internal/tui/keypress_test.go
+++ b/internal/tui/keypress_test.go
@@ -292,6 +292,7 @@ func TestIsFailedStatus(t *testing.T) {
 		{orchestrator.StatusWorking, false},
 		{orchestrator.StatusCompleted, false},
 		{orchestrator.StatusPaused, false},
+		{orchestrator.StatusInterrupted, false},
 	}
 
 	for _, tt := range tests {
@@ -299,6 +300,32 @@ func TestIsFailedStatus(t *testing.T) {
 			got := isFailedStatus(tt.status)
 			if got != tt.expected {
 				t.Errorf("isFailedStatus(%s) = %v, want %v", tt.status, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsRestartableStatus(t *testing.T) {
+	tests := []struct {
+		status   orchestrator.InstanceStatus
+		expected bool
+	}{
+		{orchestrator.StatusInterrupted, true},
+		{orchestrator.StatusPaused, true},
+		{orchestrator.StatusStuck, true},
+		{orchestrator.StatusTimeout, true},
+		{orchestrator.StatusError, true},
+		{orchestrator.StatusPending, false},
+		{orchestrator.StatusWorking, false},
+		{orchestrator.StatusCompleted, false},
+		{orchestrator.StatusWaitingInput, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			got := isRestartableStatus(tt.status)
+			if got != tt.expected {
+				t.Errorf("isRestartableStatus(%s) = %v, want %v", tt.status, got, tt.expected)
 			}
 		})
 	}

--- a/internal/tui/styles/styles.go
+++ b/internal/tui/styles/styles.go
@@ -30,15 +30,16 @@ var (
 	Text      = lipgloss.NewStyle().Foreground(TextColor)
 
 	// Status colors - all meet WCAG AA contrast (4.5:1) on both black and dark surfaces
-	StatusWorking    = lipgloss.Color("#10B981") // Green
-	StatusPending    = lipgloss.Color("#9CA3AF") // Gray (brighter for readability)
-	StatusInput      = lipgloss.Color("#F59E0B") // Amber
-	StatusPaused     = lipgloss.Color("#60A5FA") // Blue (brighter for readability)
-	StatusComplete   = lipgloss.Color("#A78BFA") // Purple (brighter for readability)
-	StatusError      = lipgloss.Color("#F87171") // Red (red-400, was #EF4444 - improved contrast)
-	StatusCreatingPR = lipgloss.Color("#F472B6") // Pink (brighter for readability)
-	StatusStuck      = lipgloss.Color("#FB923C") // Orange - for stuck/no activity
-	StatusTimeout    = lipgloss.Color("#F87171") // Red (red-400, was #DC2626 - improved contrast)
+	StatusWorking     = lipgloss.Color("#10B981") // Green
+	StatusPending     = lipgloss.Color("#9CA3AF") // Gray (brighter for readability)
+	StatusInput       = lipgloss.Color("#F59E0B") // Amber
+	StatusPaused      = lipgloss.Color("#60A5FA") // Blue (brighter for readability)
+	StatusComplete    = lipgloss.Color("#A78BFA") // Purple (brighter for readability)
+	StatusError       = lipgloss.Color("#F87171") // Red (red-400, was #EF4444 - improved contrast)
+	StatusCreatingPR  = lipgloss.Color("#F472B6") // Pink (brighter for readability)
+	StatusStuck       = lipgloss.Color("#FB923C") // Orange - for stuck/no activity
+	StatusTimeout     = lipgloss.Color("#F87171") // Red (red-400, was #DC2626 - improved contrast)
+	StatusInterrupted = lipgloss.Color("#FBBF24") // Yellow/Amber - for interrupted sessions
 
 	// Base styles
 	Title = lipgloss.NewStyle().
@@ -304,6 +305,8 @@ func StatusColor(status string) lipgloss.Color {
 		return StatusStuck
 	case "timeout":
 		return StatusTimeout
+	case "interrupted":
+		return StatusInterrupted
 	default:
 		return MutedColor
 	}
@@ -330,6 +333,8 @@ func StatusIcon(status string) string {
 		return "⏱" // Timer icon for stuck/no activity
 	case "timeout":
 		return "⏰" // Alarm icon for timeout exceeded
+	case "interrupted":
+		return "⚡" // Lightning bolt for interrupted (needs resume)
 	default:
 		return "●"
 	}

--- a/internal/tui/styles/styles_test.go
+++ b/internal/tui/styles/styles_test.go
@@ -1,0 +1,69 @@
+package styles
+
+import "testing"
+
+func TestStatusColor(t *testing.T) {
+	tests := []struct {
+		status   string
+		expected string // Expected color hex value
+	}{
+		{"working", "#10B981"},
+		{"pending", "#9CA3AF"},
+		{"waiting_input", "#F59E0B"},
+		{"paused", "#60A5FA"},
+		{"completed", "#A78BFA"},
+		{"error", "#F87171"},
+		{"creating_pr", "#F472B6"},
+		{"stuck", "#FB923C"},
+		{"timeout", "#F87171"},
+		{"interrupted", "#FBBF24"},
+		{"unknown", "#9CA3AF"}, // Should fall back to MutedColor
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			got := StatusColor(tt.status)
+			if string(got) != tt.expected {
+				t.Errorf("StatusColor(%q) = %q, want %q", tt.status, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStatusIcon(t *testing.T) {
+	tests := []struct {
+		status   string
+		expected string
+	}{
+		{"working", "●"},
+		{"pending", "○"},
+		{"waiting_input", "?"},
+		{"paused", "⏸"},
+		{"completed", "✓"},
+		{"error", "✗"},
+		{"creating_pr", "↗"},
+		{"stuck", "⏱"},
+		{"timeout", "⏰"},
+		{"interrupted", "⚡"},
+		{"unknown", "●"}, // Should fall back to default
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			got := StatusIcon(tt.status)
+			if got != tt.expected {
+				t.Errorf("StatusIcon(%q) = %q, want %q", tt.status, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStatusInterruptedConstant(t *testing.T) {
+	// Verify the interrupted status color is defined
+	if StatusInterrupted == "" {
+		t.Error("StatusInterrupted color should be defined")
+	}
+	if string(StatusInterrupted) != "#FBBF24" {
+		t.Errorf("StatusInterrupted = %q, want %q", StatusInterrupted, "#FBBF24")
+	}
+}

--- a/internal/tui/view/group.go
+++ b/internal/tui/view/group.go
@@ -354,6 +354,8 @@ func instanceStatusAbbrev(status orchestrator.InstanceStatus) string {
 		return "STUK"
 	case orchestrator.StatusTimeout:
 		return "TIME"
+	case orchestrator.StatusInterrupted:
+		return "INT!"
 	default:
 		return "????"
 	}

--- a/internal/tui/view/instance.go
+++ b/internal/tui/view/instance.go
@@ -728,6 +728,8 @@ func (v *InstanceView) RenderWaitingState(status orchestrator.InstanceStatus) st
 		return styles.Error.Render("⏰ Instance timed out")
 	case orchestrator.StatusPaused:
 		return styles.Muted.Render("⏸ Instance paused")
+	case orchestrator.StatusInterrupted:
+		return styles.Warning.Render("⚡ Session interrupted - press 'r' to resume")
 	default:
 		return ""
 	}


### PR DESCRIPTION
## Summary

Enable Claude conversations to resume after Claudio exits by storing and using Claude session IDs. This allows long-running sessions to survive Claudio restarts and be resumed later.

### Key Changes

- **Session Recovery State**: Added `RecoveryState` enum (`None`, `Interrupted`, `Recovered`) and `CleanShutdown` flag to detect abnormal exits
- **Instance Persistence**: Added `ClaudeSessionID` field to instances for conversation resumption using `--resume` flag
- **Visual Feedback**: Added `StatusInterrupted` with amber/yellow color and lightning bolt icon for interrupted instances
- **Recovery Methods**: Added `StartWithResume()`, `ResumeInstance()`, `NeedsRecovery()`, `GetResumableInstances()`, `MarkInstancesInterrupted()`, `MarkRecovered()`

### Recovery Flow

When Claudio restarts after an interruption:
1. Detects non-clean shutdown via `CleanShutdown` flag
2. Marks running instances as `StatusInterrupted`
3. Attempts to resume Claude conversations using `--resume <session-id>`
4. Falls back to fresh start if resume fails (with warning logged)

## Test Plan

- [x] All tests pass (`go test ./...`)
- [x] Code formatted (`gofmt -d .`)
- [x] Linting passes (`go vet ./...`)
- [ ] Manual test: Start instance, exit Claudio, restart and verify resume
- [ ] Manual test: Verify interrupted instances show amber lightning bolt icon
- [ ] Manual test: Press 'r' on interrupted instance to restart