### PR TITLE
Show ungrouped instances in grouped sidebar mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Triple-Shot Accept Command** - Implement missing `:accept` command that was referenced in UI message but never implemented. Users can now accept winning triple-shot solutions after evaluation completes.
+- **Grouped Sidebar Shows All Instances** - Fixed bug where instances not belonging to a group (e.g., pre-existing instances) would disappear from the sidebar when a tripleshot or other grouped session was active. Ungrouped instances now appear at the top of the sidebar in grouped mode.
 
 ### Changed
 

--- a/internal/tui/view/sidebar.go
+++ b/internal/tui/view/sidebar.go
@@ -115,6 +115,7 @@ func (sv *SidebarView) RenderGroupedSidebar(state SidebarState, width, height in
 		endIdx := min(scrollOffset+availableSlots, len(items))
 
 		// Render visible items
+		// ActiveTab returns the index in session.Instances, so compare with AbsoluteIdx
 		activeInstanceIdx := state.ActiveTab()
 		for i := startIdx; i < endIdx; i++ {
 			item := items[i]
@@ -128,8 +129,8 @@ func (sv *SidebarView) RenderGroupedSidebar(state SidebarState, width, height in
 				b.WriteString("\n")
 
 			case GroupedInstance:
-				// Render instance
-				isActive := v.GlobalIdx == activeInstanceIdx
+				// Render instance - use AbsoluteIdx to match against activeInstanceIdx
+				isActive := v.AbsoluteIdx == activeInstanceIdx
 				hasConflict := conflictingInstances[v.Instance.ID]
 				line := RenderGroupedInstance(v, isActive, hasConflict, width)
 				b.WriteString(line)


### PR DESCRIPTION
## Summary

- Fixed bug where instances not belonging to a group (e.g., pre-existing instances) would disappear from the sidebar when a tripleshot or other grouped session was active
- Ungrouped instances now appear at the top of the sidebar in grouped mode, rendered without tree connectors
- Fixed active tab highlighting to correctly identify the selected instance

## Root Cause

When tripleshot mode was activated, the sidebar switched to grouped mode. However, `FlattenGroupsForDisplay` only iterated through `session.Groups`, completely ignoring any instances that weren't explicitly added to a group.

## Changes

- `FlattenGroupsForDisplay` now includes ungrouped instances first (with `Depth=-1`)
- `RenderGroupedInstance` handles ungrouped instances without tree connectors
- `GetVisibleInstanceCount` includes ungrouped instances in the count
- `FindInstanceByGlobalIndex` searches ungrouped instances first
- `RenderGroupedSidebar` uses `AbsoluteIdx` instead of `GlobalIdx` for active tab highlighting

## Test plan

- [x] All existing tests pass
- [x] Added `TestFlattenGroupsForDisplay_UngroupedInstances` - verifies ungrouped instances appear first
- [x] Added `TestFlattenGroupsForDisplay_OnlyUngroupedInstances` - verifies behavior with no groups
- [x] Added `TestGetVisibleInstanceCount_WithUngroupedInstances` - verifies count includes ungrouped
- [x] Added `TestFindInstanceByGlobalIndex_WithUngroupedInstances` - verifies navigation works
- [x] Added `TestSidebarView_GroupedModeShowsUngroupedInstances` - end-to-end test for the fix
- [x] Added `TestRenderGroupedInstance_UngroupedInstance` - verifies rendering without tree connectors
- [x] Added `TestRenderGroupedInstance_GroupedInstance` - verifies grouped rendering