### PR TITLE
Restore multiple tripleshot support and fix help panel regression

### DIFF
--- a/internal/tui/panel/help.go
+++ b/internal/tui/panel/help.go
@@ -150,18 +150,6 @@ func DefaultHelpSections() []HelpSection {
 			},
 		},
 		{
-			Title: "Group Commands (g prefix)",
-			Items: []HelpItem{
-				{Key: "gc", Description: "Collapse/expand current group"},
-				{Key: "gC", Description: "Collapse/expand all groups"},
-				{Key: "gn", Description: "Jump to next group"},
-				{Key: "gp", Description: "Jump to previous group"},
-				{Key: "gs", Description: "Skip current group (mark pending as skipped)"},
-				{Key: "gr", Description: "Retry failed tasks in current group"},
-				{Key: "gf", Description: "Force-start next group (ignore dependencies)"},
-			},
-		},
-		{
 			Title: "Instance Control",
 			Items: []HelpItem{
 				{Key: ":s  :start", Description: "Start a stopped/new instance"},
@@ -185,11 +173,12 @@ func DefaultHelpSections() []HelpSection {
 		{
 			Title: "Inline Planning (experimental)",
 			Items: []HelpItem{
-				{Key: ":plan", Description: "Start plan workflow with objective"},
-				{Key: ":ultraplan", Description: "Start ultraplan with coordinator"},
-				{Key: ":group create [name]", Description: "Create new empty group"},
-				{Key: ":group add [inst] [grp]", Description: "Add instance to group"},
-				{Key: ":group show", Description: "Toggle grouped sidebar view"},
+				{Key: ":plan", Description: "Start inline plan mode"},
+				{Key: ":ultraplan  :up", Description: "Start ultraplan mode"},
+				{Key: ":tripleshot", Description: "Run 3 parallel attempts + judge"},
+				{Key: ":accept", Description: "Accept winning triple-shot solution"},
+				{Key: ":cancel", Description: "Cancel ultraplan execution"},
+				{Key: ":group", Description: "Manage instance groups"},
 			},
 		},
 		{

--- a/internal/tui/view/dashboard.go
+++ b/internal/tui/view/dashboard.go
@@ -272,8 +272,14 @@ func (dv *DashboardView) renderExpandedInstance(
 		}
 
 		// Indent continuation lines to align under the name
+		// Pad the chunk to fill available width so background styling is consistent
+		paddedChunk := chunk
+		chunkLen := len([]rune(chunk))
+		if chunkLen < continuationAvailable {
+			paddedChunk = chunk + strings.Repeat(" ", continuationAvailable-chunkLen)
+		}
 		indent := strings.Repeat(" ", continuationIndent)
-		lines = append(lines, indent+itemStyle.Render(chunk))
+		lines = append(lines, indent+itemStyle.Render(paddedChunk))
 	}
 
 	return strings.Join(lines, "\n")


### PR DESCRIPTION
## Summary
- Fixes multiple tripleshot restoration that was functionally reverted (PR #413 regression)
- Fixes help panel duplicate "Group Commands" section and missing commands (PR #394 regression)
- Improves sidebar styling consistency for multi-line instance names

## Changes

### Multiple Tripleshot Restoration
- `NewWithTripleShot()` now properly initializes the `Coordinators` map and adds the coordinator keyed by its group ID
- Added `NewWithTripleShots()` function for restoring multiple coordinators on session resume
- Added `launchTUIWithTripleshots()` that detects active tripleshot sessions and recreates coordinators from persisted `TripleShots` slice

### Help Panel Fixes
- Removed duplicate "Group Commands (g prefix)" section in `panel/help.go`
- Added missing commands: `:tripleshot`, `:accept`, `:cancel`, `:group` to match `app.go`'s help panel

### Sidebar Styling
- Added padding to continuation line chunks in `renderExpandedInstance()` to ensure background colors extend consistently across the full available width

## Root Cause
The regressions were not true git reverts, but rather incomplete implementations:
- Data structures for multiple tripleshots were added (PR #413), but the restoration logic to recreate coordinators from persisted data was missing
- Two separate help panel implementations (`app.go:renderHelpPanel()` and `panel/help.go:DefaultHelpSections()`) existed and got out of sync

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `gofmt -d .` shows no formatting issues
- [ ] Manual testing: Start a tripleshot, exit claudio, resume session - verify tripleshot state is restored
- [ ] Manual testing: Open help panel (?) and verify no duplicate sections and all commands present