### PR TITLE
Remove redundant status-based task text coloring

### DIFF
--- a/internal/tui/styles/styles.go
+++ b/internal/tui/styles/styles.go
@@ -131,13 +131,6 @@ var (
 				Padding(0, 1).
 				MarginBottom(0)
 
-	SidebarItemInputNeeded = lipgloss.NewStyle().
-				Bold(true).
-				Foreground(TextColor).
-				Background(WarningColor).
-				Padding(0, 1).
-				MarginBottom(0)
-
 	SidebarTitle = lipgloss.NewStyle().
 			Bold(true).
 			Foreground(PrimaryColor)

--- a/internal/tui/view/dashboard.go
+++ b/internal/tui/view/dashboard.go
@@ -174,27 +174,13 @@ func (dv *DashboardView) renderSidebarInstance(
 		prefixLen += 2
 	}
 
-	// Choose style based on active state and status
+	// Choose style - only differentiate active (selected) vs inactive
+	// Status is already shown via the colored status indicator
 	var itemStyle lipgloss.Style
 	if i == activeTab {
-		if conflictingInstances[inst.ID] {
-			// Active item with conflict - use warning background
-			itemStyle = styles.SidebarItemInputNeeded
-		} else if inst.Status == orchestrator.StatusWaitingInput {
-			itemStyle = styles.SidebarItemInputNeeded
-		} else {
-			itemStyle = styles.SidebarItemActive
-		}
+		itemStyle = styles.SidebarItemActive
 	} else {
-		itemStyle = styles.SidebarItem
-		if conflictingInstances[inst.ID] {
-			// Inactive but has conflict - use warning color
-			itemStyle = itemStyle.Foreground(styles.WarningColor)
-		} else if inst.Status == orchestrator.StatusWaitingInput {
-			itemStyle = itemStyle.Foreground(styles.WarningColor)
-		} else {
-			itemStyle = itemStyle.Foreground(styles.MutedColor)
-		}
+		itemStyle = styles.SidebarItem.Foreground(styles.MutedColor)
 	}
 
 	// Calculate maximum task length based on context

--- a/internal/tui/view/group.go
+++ b/internal/tui/view/group.go
@@ -332,21 +332,13 @@ func RenderGroupedInstance(gi GroupedInstance, isActiveInstance bool, hasConflic
 
 	displayName := truncate(inst.EffectiveName(), maxNameLen)
 
-	// Choose style
+	// Choose style - only differentiate active (selected) vs inactive
+	// Status is already shown via the colored status abbreviation
 	var nameStyle lipgloss.Style
 	if isActiveInstance {
-		if hasConflict || inst.Status == orchestrator.StatusWaitingInput {
-			nameStyle = styles.SidebarItemInputNeeded
-		} else {
-			nameStyle = styles.SidebarItemActive
-		}
+		nameStyle = styles.SidebarItemActive
 	} else {
-		nameStyle = styles.SidebarItem
-		if hasConflict || inst.Status == orchestrator.StatusWaitingInput {
-			nameStyle = nameStyle.Foreground(styles.WarningColor)
-		} else {
-			nameStyle = nameStyle.Foreground(styles.MutedColor)
-		}
+		nameStyle = styles.SidebarItem.Foreground(styles.MutedColor)
 	}
 
 	statusStyle := lipgloss.NewStyle().Foreground(statusColor)


### PR DESCRIPTION
## Summary

- Removes status-based text coloring from task names in the sidebar
- Status is now shown via colored badges (WORK, WAIT, etc.) beneath each session, making colored task text redundant
- Simplifies visual hierarchy: selection state = background highlight, task status = colored abbreviation

## Changes

- **dashboard.go**: Simplified `renderSidebarInstance()` to only differentiate active vs inactive states
- **group.go**: Simplified `RenderGroupedInstance()` with the same approach  
- **styles.go**: Removed unused `SidebarItemInputNeeded` style

Task names now use consistent styling:
- **Selected**: Bold white text on primary background
- **Unselected**: Muted gray text

Conflict indicators (⚠) and status dots remain for visual feedback.

## Test plan

- [x] Build passes: `go build ./...`
- [x] All tests pass: `go test ./...`
- [x] Code formatted: `gofmt -d .` shows no output
- [ ] Visual verification: Sidebar displays correctly with selection highlight and status badges