### PR TITLE
Add guided divergence for tripleshot mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Guided Divergence for Tripleshot** - Specify different approaches for each of the three instances in a tripleshot session. In CLI: `claudio tripleshot --approach "use X" --approach "use Y" --approach "use Z"`. In TUI: `:tripleshot --approach "approach 1" --approach "approach 2" --approach "approach 3"`. This enables exploring specific solution strategies rather than letting each instance choose freely.
 - **Enhanced Task Decomposition** - Comprehensive `decomposition` package provides intelligent task breakdown for UltraPlan with multiple analysis strategies:
   - **Code Structure Analysis**: Parses Go source files to build package dependency graphs with centrality calculations
   - **Risk-Based Prioritization**: Multi-factor risk scoring (complexity, file count, centrality, shared files, cross-package scope) with blocking scores for execution ordering

--- a/internal/orchestrator/tripleshot_coordinator.go
+++ b/internal/orchestrator/tripleshot_coordinator.go
@@ -239,7 +239,9 @@ func (c *TripleShotCoordinator) StartAttempts() error {
 
 	// Create and start all three attempts
 	for i := range 3 {
-		prompt := fmt.Sprintf(TripleShotAttemptPromptTemplate, task, i)
+		// Get approach for this attempt if guided divergence is configured
+		approach := session.Config.GetApproach(i)
+		prompt := BuildAttemptPrompt(task, i, approach)
 
 		// Create instance for this attempt
 		inst, err := c.orch.AddInstance(c.baseSession, prompt)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -158,7 +158,8 @@ type Model struct {
 	dependentOnInstanceID string // The instance ID that the new task will depend on
 
 	// Triple-shot task state (for :tripleshot command)
-	startingTripleShot bool // When true, taskInput will start a triple-shot session
+	startingTripleShot   bool     // When true, taskInput will start a triple-shot session
+	tripleShotApproaches []string // Guided divergence approaches for the pending tripleshot
 
 	errorMessage string
 	infoMessage  string // Non-error status message


### PR DESCRIPTION
## Summary
- Add the ability to specify different approaches for each of the three tripleshot instances
- Users can now guide each instance with a specific approach (e.g., "use quicksort", "use mergesort", "use heapsort")
- Supports both CLI (`--approach` flag, up to 3 times) and TUI (`:tripleshot --approach "..." --approach "..."`)

## Changes
- **TripleShotConfig**: Added `Approaches []string` field with `GetApproach()` helper method
- **Prompt Templates**: Created `TripleShotGuidedAttemptPromptTemplate` for guided attempts
- **BuildAttemptPrompt()**: New helper that selects guided vs unguided template per-attempt
- **CLI**: Added `--approach` flag to `claudio tripleshot` command
- **TUI**: Added `--approach`/`-a` flag parsing to `:tripleshot` command
- **Bug fixes**: Fixed grammar ("1 approach" not "1 approaches"), fixed `-a` flag parsing to not match mid-word

## Test plan
- [x] Added `TestTripleShotConfig_GetApproach` with 9 edge cases (nil, empty, bounds, partial)
- [x] Added `TestBuildAttemptPrompt` testing guided/unguided selection
- [x] Added `TestTripleShotGuidedAttemptPromptTemplate` validating template structure
- [x] Added `TestTripleShotCommandWithApproaches` with 6 TUI command test cases
- [x] Added `TestParseTripleShotApproaches` with 9 parsing test cases including edge cases
- [x] All existing tests pass
- [x] `go vet ./...` passes
- [x] `gofmt` reports no issues

## Usage Examples

**CLI:**
```bash
# Specify all three approaches
claudio tripleshot "Implement sorting" \
  --approach "Use quicksort algorithm" \
  --approach "Use merge sort algorithm" \
  --approach "Use heap sort algorithm"

# Partial specification (third instance chooses freely)
claudio tripleshot "Build a cache" \
  --approach "Use in-memory LRU cache" \
  --approach "Use Redis-based distributed cache"
```

**TUI:**
```
:tripleshot --approach "optimize for performance" --approach "optimize for readability" -a "minimize changes"
```