### PR TITLE
Fix dual highlighting when adding task in grouped sidebar

### DIFF
--- a/internal/tui/view/sidebar.go
+++ b/internal/tui/view/sidebar.go
@@ -116,7 +116,11 @@ func (sv *SidebarView) RenderGroupedSidebar(state SidebarState, width, height in
 
 		// Render visible items
 		// ActiveTab returns the index in session.Instances, so compare with AbsoluteIdx
-		activeInstanceIdx := state.ActiveTab()
+		// When adding a task, no instance should be highlighted (use -1 to match nothing)
+		activeInstanceIdx := -1
+		if !isAddingTask {
+			activeInstanceIdx = state.ActiveTab()
+		}
 		for i := startIdx; i < endIdx; i++ {
 			item := items[i]
 			switch v := item.(type) {


### PR DESCRIPTION
## Summary
- Fixed a bug where the most recently selected instance was highlighted in addition to the "New Task" entry when adding a new task in grouped sidebar mode
- The grouped sidebar view was missing a conditional check that the flat sidebar view had

## Root Cause
In `RenderGroupedSidebar`, `activeInstanceIdx` was unconditionally set to `state.ActiveTab()`. When adding a task, the flat view correctly uses `-1` to prevent any instance from being highlighted, but the grouped view was missing this logic.

## Changes
- Added conditional logic in `sidebar.go` to set `activeInstanceIdx = -1` when `isAddingTask` is true
- Added regression test to verify no instance is highlighted when adding a task in grouped mode

## Test plan
- [x] Run `go test ./internal/tui/view/...` - all tests pass
- [x] Run full test suite `go test ./...` - all tests pass
- [x] Manually verify in grouped mode: when pressing `:a` to add task, only "New Task" is highlighted, not the previously selected instance