### PR TITLE
Automatically close empty groups when last instance is removed

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1084,6 +1084,9 @@ func (o *Orchestrator) RemoveInstance(session *Session, instanceID string, force
 	// Remove from session
 	session.Instances = append(session.Instances[:instIndex], session.Instances[instIndex+1:]...)
 
+	// Remove from any groups and clean up empty groups
+	session.RemoveInstanceFromGroups(instanceID)
+
 	// Update context
 	if err := o.updateContext(); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to update context: %v\n", err)

--- a/internal/tui/command/group_commands.go
+++ b/internal/tui/command/group_commands.go
@@ -190,15 +190,12 @@ func cmdGroupRemove(args string, deps GroupDependencies) Result {
 		return Result{InfoMessage: fmt.Sprintf("Instance %q is not in any group", inst.EffectiveName())}
 	}
 
-	// Remove instance by moving to no group
-	// The group manager doesn't have a direct "ungroup" method,
-	// so we use the orchestrator's InstanceGroup method directly
-	sessionGroup := session.GetGroupForInstance(inst.ID)
-	if sessionGroup != nil {
-		sessionGroup.RemoveInstance(inst.ID)
-	}
+	groupName := currentGroup.Name
 
-	return Result{InfoMessage: fmt.Sprintf("Removed instance %q from group %q", inst.EffectiveName(), currentGroup.Name)}
+	// Remove instance from group (this also cleans up empty groups automatically)
+	mgr.RemoveInstanceFromGroup(inst.ID)
+
+	return Result{InfoMessage: fmt.Sprintf("Removed instance %q from group %q", inst.EffectiveName(), groupName)}
 }
 
 // cmdGroupMove handles ":group move [instance] [group]"


### PR DESCRIPTION
## Summary

- When an instance is removed from a group, the group is now automatically cleaned up if it becomes empty
- This applies recursively to sub-groups as well - if removing an instance causes a sub-group to become empty, that sub-group is removed, and if the parent then becomes empty, it's removed too
- Works for both `:group remove` command and when deleting instances entirely

## Changes

- Added `IsEmpty()` method to `InstanceGroup` for checking emptiness (uses `InstanceCount() == 0`)
- Added `RemoveInstanceFromGroup()` to `group.Manager` with automatic cleanup of empty groups
- Added `RemoveInstanceFromGroups()` and `CleanupEmptyGroups()` methods to `Session`
- Updated `orchestrator.RemoveInstance()` to call cleanup after removing an instance
- Updated `:group remove` command to use the new `RemoveInstanceFromGroup` method

## Test plan

- [x] Added comprehensive tests for `IsEmpty()` method
- [x] Added tests for `RemoveInstanceFromGroups()` covering:
  - Removing last instance cleans up empty group
  - Removing one instance keeps group with remaining instances
  - Removing from sub-group cleans up empty hierarchy
  - Sibling sub-groups with instances are preserved
  - Non-existent instances handled gracefully
- [x] Added tests for `CleanupEmptyGroups()` covering:
  - Empty top-level groups removed
  - Empty sub-groups removed
  - Deeply nested empty groups handled
  - No-op when all groups non-empty
- [x] Added tests for `group.Manager.RemoveInstanceFromGroup()` with similar coverage
- [x] All existing tests pass
- [x] `go vet` passes
- [x] `gofmt` shows no issues