### PR TITLE
Improve triple-shot judge interaction

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1535,9 +1535,9 @@ func (m *Model) applyCommandResult(result command.Result) {
 		m.taskInputCursor = 0
 	}
 
-	// Handle triple-shot accept
-	if result.AcceptTripleShot != nil && *result.AcceptTripleShot {
-		m.handleTripleShotAccept()
+	// Handle triple-shot judge stopped - clean up the entire triple-shot session
+	if result.StoppedTripleShotJudgeID != nil {
+		m.handleTripleShotJudgeStopped(*result.StoppedTripleShotJudgeID)
 	}
 
 	// Handle inline plan mode transition

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -998,3 +998,25 @@ func (m Model) GetLogger() *logging.Logger {
 func (m Model) GetStartTime() time.Time {
 	return m.startTime
 }
+
+// IsInstanceTripleShotJudge checks if an instance is a judge in any active triple-shot session.
+func (m Model) IsInstanceTripleShotJudge(instanceID string) bool {
+	if m.tripleShot == nil {
+		return false
+	}
+	// Check all coordinators in the map
+	for _, coord := range m.tripleShot.Coordinators {
+		session := coord.Session()
+		if session != nil && session.JudgeID == instanceID {
+			return true
+		}
+	}
+	// Also check deprecated single coordinator for backward compatibility
+	if m.tripleShot.Coordinator != nil {
+		session := m.tripleShot.Coordinator.Session()
+		if session != nil && session.JudgeID == instanceID {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Remove automatic judge evaluation and the `:accept` command
- Move implementers into a sub-group when the Judge spawns for better UI hierarchy
- Allow closing the judge session to close the entire triple-shot

The judge instance is now fully interactive - users can guide it to create PRs or take other win actions directly, rather than relying on automatic evaluation.

## Changes

### Removed
- `:accept` command and `AcceptTripleShot` result field
- `handleTripleShotAccept` function
- Automatic evaluation polling and completion message prompting `:accept`

### Added  
- `IsInstanceTripleShotJudge()` method to detect when stopped instance is a judge
- `handleTripleShotJudgeStopped()` to clean up triple-shot when judge is stopped
- `StoppedTripleShotJudgeID` field in command result to signal cleanup needed
- Sub-group creation for implementers when judge spawns
- Logging when group lookup fails during judge start
- Logging when coordinator not found during cleanup

### Fixed
- `IsInstanceTripleShotJudge` now checks both `Coordinators` map and deprecated `Coordinator` field for consistency

## Test plan

- [x] Tests pass (`go test ./...`)
- [x] Lint passes (`go vet ./...`)
- [x] Format correct (`gofmt -d .`)
- [ ] Manual: Start a triple-shot, verify implementers move to sub-group when judge spawns
- [ ] Manual: Stop judge with `:x`, verify entire triple-shot is cleaned up