### PR TITLE
Fix TUI freeze from synchronous file I/O in tripleshot and ultraplan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Triple-Shot Accept Command** - Implement missing `:accept` command that was referenced in UI message but never implemented. Users can now accept winning triple-shot solutions after evaluation completes.
 - **Grouped Sidebar Shows All Instances** - Fixed bug where instances not belonging to a group (e.g., pre-existing instances) would disappear from the sidebar when a tripleshot or other grouped session was active. Ungrouped instances now appear at the top of the sidebar in grouped mode.
+- **TUI Freeze from File I/O** - Fixed UI freeze that could occur during triple-shot and ultraplan modes when checking for completion files or plan files. All file I/O operations in the tick handler are now performed asynchronously, keeping the UI responsive.
 
 ### Changed
 


### PR DESCRIPTION
## Summary

- Fix TUI freeze when tripleshot attempts/judge complete or ultraplan plan files are detected
- All file I/O operations in the tick handler were called synchronously in the Bubble Tea Update handler, blocking the entire TUI when disk I/O was slow
- Completes the async refactoring started in #414

## Changes

### Tripleshot Async Processing
- Add `tripleShotAttemptProcessedMsg` and `tripleShotJudgeProcessedMsg` message types for async results
- Add `processAttemptCompletionAsync()` and `processJudgeCompletionAsync()` to run file I/O in goroutines
- Update `processAttemptCheckResults()` and `processJudgeCheckResult()` to dispatch async commands

### Ultraplan Async Processing
- Add `planFileCheckResultMsg`, `multiPassPlanFileCheckResultMsg`, and `planManagerFileCheckResultMsg` message types
- Add `checkPlanFileAsync()`, `checkMultiPassPlanFilesAsync()`, and `checkPlanManagerFileAsync()` functions
- Add `dispatchUltraPlanFileChecks()` to dispatch all ultraplan file checks asynchronously
- Remove synchronous `checkForPlanFile()`, `checkForMultiPassPlanFiles()`, and `checkForPlanManagerPlanFile()` functions
- Add handlers `handlePlanFileCheckResult()`, `handleMultiPassPlanFileCheckResult()`, and `handlePlanManagerFileCheckResult()`

### Tick Handler Changes
- Remove synchronous plan file check calls from tick handler
- Add `cmds = append(cmds, m.dispatchUltraPlanFileChecks()...)` to tick handler

## Test plan

- [x] Build passes (`go build ./...`)
- [x] TUI tests pass (`go test ./internal/tui/...`)
- [x] Code formatted with gofmt
- [x] go vet passes
- [ ] Manual testing: Run tripleshot/ultraplan with slow disk I/O and verify TUI remains responsive