### PR TITLE
Add searchable branch selector with scrolling support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Searchable Branch Selector** - Branch selection when adding a new instance now supports real-time search filtering and scrolling. Type to filter branches, use arrow keys to navigate, Page Up/Down for faster scrolling, and scroll indicators show when more branches exist above or below the visible viewport.
+
 ## [0.6.0] - 2026-01-14
 
 This release introduces **Intelligent Task Decomposition** - a comprehensive analysis system that makes UltraPlan significantly smarter about breaking down complex projects into well-ordered, risk-aware execution plans.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1882,10 +1882,26 @@ func (m Model) openBranchSelector() (tea.Model, tea.Cmd) {
 		m.branchList[i] = b.Name
 	}
 
+	// Initialize filter state - start with all branches visible
+	m.branchSearchInput = ""
+	m.branchFiltered = m.branchList
+	m.branchScrollOffset = 0
+
+	// Calculate visible height for branch selector (reserve space for UI elements)
+	dims := m.terminalManager.GetPaneDimensions(m.calculateExtraFooterLines())
+	// Reserve: search line, scroll indicators, count line, padding
+	m.branchSelectorHeight = dims.MainAreaHeight - 10
+	if m.branchSelectorHeight < 5 {
+		m.branchSelectorHeight = 5
+	}
+	if m.branchSelectorHeight > 15 {
+		m.branchSelectorHeight = 15 // Cap at reasonable max
+	}
+
 	// Find the index of the currently selected branch (if any)
 	selectedIdx := 0
 	if m.selectedBaseBranch != "" {
-		for i, name := range m.branchList {
+		for i, name := range m.branchFiltered {
 			if name == m.selectedBaseBranch {
 				selectedIdx = i
 				break
@@ -1895,39 +1911,155 @@ func (m Model) openBranchSelector() (tea.Model, tea.Cmd) {
 
 	m.showBranchSelector = true
 	m.branchSelected = selectedIdx
+	m = m.adjustBranchScroll()
+
 	return m, nil
+}
+
+// closeBranchSelector resets the branch selector state.
+func (m Model) closeBranchSelector() Model {
+	m.showBranchSelector = false
+	m.branchSearchInput = ""
+	m.branchFiltered = nil
+	m.branchScrollOffset = 0
+	return m
 }
 
 // handleBranchSelector handles keyboard input when the branch selector is visible.
 func (m Model) handleBranchSelector(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.Type {
 	case tea.KeyEsc:
-		// Close dropdown without changing selection
-		m.showBranchSelector = false
-		return m, nil
+		return m.closeBranchSelector(), nil
 
 	case tea.KeyEnter, tea.KeyTab:
-		// Select the highlighted branch
-		if len(m.branchList) > 0 && m.branchSelected < len(m.branchList) {
-			m.selectedBaseBranch = m.branchList[m.branchSelected]
+		// Select the highlighted branch from the filtered list
+		if len(m.branchFiltered) > 0 && m.branchSelected < len(m.branchFiltered) {
+			m.selectedBaseBranch = m.branchFiltered[m.branchSelected]
 		}
-		m.showBranchSelector = false
-		return m, nil
+		return m.closeBranchSelector(), nil
 
 	case tea.KeyUp:
 		if m.branchSelected > 0 {
 			m.branchSelected--
+			m = m.adjustBranchScroll()
 		}
 		return m, nil
 
 	case tea.KeyDown:
-		if m.branchSelected < len(m.branchList)-1 {
+		if m.branchSelected < len(m.branchFiltered)-1 {
 			m.branchSelected++
+			m = m.adjustBranchScroll()
 		}
+		return m, nil
+
+	case tea.KeyPgUp, tea.KeyCtrlU:
+		// Page up
+		m.branchSelected -= m.branchSelectorHeight
+		if m.branchSelected < 0 {
+			m.branchSelected = 0
+		}
+		m = m.adjustBranchScroll()
+		return m, nil
+
+	case tea.KeyPgDown, tea.KeyCtrlD:
+		// Page down
+		m.branchSelected += m.branchSelectorHeight
+		if m.branchSelected >= len(m.branchFiltered) {
+			m.branchSelected = len(m.branchFiltered) - 1
+		}
+		if m.branchSelected < 0 {
+			m.branchSelected = 0
+		}
+		m = m.adjustBranchScroll()
+		return m, nil
+
+	case tea.KeyBackspace:
+		// Remove last character from search
+		if len(m.branchSearchInput) > 0 {
+			runes := []rune(m.branchSearchInput)
+			m.branchSearchInput = string(runes[:len(runes)-1])
+			m = m.applyBranchFilter()
+		}
+		return m, nil
+
+	case tea.KeyRunes:
+		// Add typed characters to search
+		m.branchSearchInput += string(msg.Runes)
+		m = m.applyBranchFilter()
+		return m, nil
+
+	case tea.KeySpace:
+		// Add space to search
+		m.branchSearchInput += " "
+		m = m.applyBranchFilter()
 		return m, nil
 	}
 
 	return m, nil
+}
+
+// applyBranchFilter filters the branch list based on search input.
+// Returns a new Model with the filter applied.
+func (m Model) applyBranchFilter() Model {
+	if m.branchSearchInput == "" {
+		m.branchFiltered = m.branchList
+	} else {
+		searchLower := strings.ToLower(m.branchSearchInput)
+		m.branchFiltered = nil
+		for _, name := range m.branchList {
+			if strings.Contains(strings.ToLower(name), searchLower) {
+				m.branchFiltered = append(m.branchFiltered, name)
+			}
+		}
+	}
+
+	// Reset selection to first item when filter changes
+	m.branchSelected = 0
+	m.branchScrollOffset = 0
+
+	// Try to keep previously selected branch selected if it's still visible
+	if m.selectedBaseBranch != "" {
+		for i, name := range m.branchFiltered {
+			if name == m.selectedBaseBranch {
+				m.branchSelected = i
+				break
+			}
+		}
+	}
+
+	return m.adjustBranchScroll()
+}
+
+// adjustBranchScroll adjusts scroll offset to keep selection visible.
+// Returns a new Model with the scroll adjusted.
+func (m Model) adjustBranchScroll() Model {
+	if m.branchSelectorHeight <= 0 {
+		return m
+	}
+
+	// If selection is above viewport, scroll up
+	if m.branchSelected < m.branchScrollOffset {
+		m.branchScrollOffset = m.branchSelected
+	}
+
+	// If selection is below viewport, scroll down
+	if m.branchSelected >= m.branchScrollOffset+m.branchSelectorHeight {
+		m.branchScrollOffset = m.branchSelected - m.branchSelectorHeight + 1
+	}
+
+	// Clamp scroll offset
+	maxScroll := len(m.branchFiltered) - m.branchSelectorHeight
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if m.branchScrollOffset > maxScroll {
+		m.branchScrollOffset = maxScroll
+	}
+	if m.branchScrollOffset < 0 {
+		m.branchScrollOffset = 0
+	}
+
+	return m
 }
 
 // handleSearchInput handles keyboard input when in search mode
@@ -2570,15 +2702,18 @@ func (m Model) renderFilterPanel(width int) string {
 // renderAddTask renders the add task input
 func (m Model) renderAddTask(width int) string {
 	inputState := &view.InputState{
-		Text:               m.taskInput,
-		Cursor:             m.taskInputCursor,
-		ShowTemplates:      m.showTemplates,
-		Templates:          m.buildTemplateItems(),
-		TemplateSelected:   m.templateSelected,
-		ShowBranchSelector: m.showBranchSelector,
-		Branches:           m.buildBranchItems(),
-		BranchSelected:     m.branchSelected,
-		SelectedBranch:     m.selectedBaseBranch,
+		Text:                 m.taskInput,
+		Cursor:               m.taskInputCursor,
+		ShowTemplates:        m.showTemplates,
+		Templates:            m.buildTemplateItems(),
+		TemplateSelected:     m.templateSelected,
+		ShowBranchSelector:   m.showBranchSelector,
+		Branches:             m.buildBranchItems(),
+		BranchSelected:       m.branchSelected,
+		BranchScrollOffset:   m.branchScrollOffset,
+		BranchSearchInput:    m.branchSearchInput,
+		SelectedBranch:       m.selectedBaseBranch,
+		BranchSelectorHeight: m.branchSelectorHeight,
 	}
 
 	// Customize title/subtitle for dependent task mode
@@ -2615,17 +2750,22 @@ func (m Model) buildTemplateItems() []view.TemplateItem {
 	return items
 }
 
-// buildBranchItems converts the cached branch list to view branch items
+// buildBranchItems converts the filtered branch list to view branch items
 func (m Model) buildBranchItems() []view.BranchItem {
-	if len(m.branchList) == 0 {
+	// Use filtered list if available, otherwise full list
+	branchList := m.branchFiltered
+	if len(branchList) == 0 && len(m.branchList) > 0 && m.branchSearchInput == "" {
+		branchList = m.branchList
+	}
+	if len(branchList) == 0 {
 		return nil
 	}
 
 	// Get main branch name from orchestrator
 	mainBranch := m.orchestrator.GetMainBranch()
 
-	items := make([]view.BranchItem, len(m.branchList))
-	for i, name := range m.branchList {
+	items := make([]view.BranchItem, len(branchList))
+	for i, name := range branchList {
 		items[i] = view.BranchItem{
 			Name:   name,
 			IsMain: name == mainBranch,

--- a/internal/tui/branch_selector_test.go
+++ b/internal/tui/branch_selector_test.go
@@ -1,0 +1,360 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestHandleBranchSelector(t *testing.T) {
+	t.Run("escape closes selector and clears search", func(t *testing.T) {
+		m := testModel()
+		m.showBranchSelector = true
+		m.branchSearchInput = "test"
+		m.branchFiltered = []string{"test-branch"}
+		m.branchScrollOffset = 5
+
+		msg := tea.KeyMsg{Type: tea.KeyEsc}
+		result, _ := m.handleBranchSelector(msg)
+		model := result.(Model)
+
+		if model.showBranchSelector {
+			t.Error("expected showBranchSelector to be false")
+		}
+		if model.branchSearchInput != "" {
+			t.Error("expected branchSearchInput to be cleared")
+		}
+		if model.branchFiltered != nil {
+			t.Error("expected branchFiltered to be nil")
+		}
+		if model.branchScrollOffset != 0 {
+			t.Error("expected branchScrollOffset to be 0")
+		}
+	})
+
+	t.Run("enter selects highlighted branch", func(t *testing.T) {
+		m := testModel()
+		m.showBranchSelector = true
+		m.branchFiltered = []string{"main", "feature-1", "feature-2"}
+		m.branchSelected = 1
+
+		msg := tea.KeyMsg{Type: tea.KeyEnter}
+		result, _ := m.handleBranchSelector(msg)
+		model := result.(Model)
+
+		if model.selectedBaseBranch != "feature-1" {
+			t.Errorf("expected selectedBaseBranch to be %q, got %q", "feature-1", model.selectedBaseBranch)
+		}
+		if model.showBranchSelector {
+			t.Error("expected showBranchSelector to be false after selection")
+		}
+	})
+
+	t.Run("tab selects highlighted branch", func(t *testing.T) {
+		m := testModel()
+		m.showBranchSelector = true
+		m.branchFiltered = []string{"main", "feature-1"}
+		m.branchSelected = 0
+
+		msg := tea.KeyMsg{Type: tea.KeyTab}
+		result, _ := m.handleBranchSelector(msg)
+		model := result.(Model)
+
+		if model.selectedBaseBranch != "main" {
+			t.Errorf("expected selectedBaseBranch to be %q, got %q", "main", model.selectedBaseBranch)
+		}
+	})
+
+	t.Run("up arrow moves selection up", func(t *testing.T) {
+		m := testModel()
+		m.showBranchSelector = true
+		m.branchFiltered = []string{"main", "feature-1", "feature-2"}
+		m.branchSelected = 2
+		m.branchSelectorHeight = 10
+
+		msg := tea.KeyMsg{Type: tea.KeyUp}
+		result, _ := m.handleBranchSelector(msg)
+		model := result.(Model)
+
+		if model.branchSelected != 1 {
+			t.Errorf("expected branchSelected to be 1, got %d", model.branchSelected)
+		}
+	})
+
+	t.Run("down arrow moves selection down", func(t *testing.T) {
+		m := testModel()
+		m.showBranchSelector = true
+		m.branchFiltered = []string{"main", "feature-1", "feature-2"}
+		m.branchSelected = 0
+		m.branchSelectorHeight = 10
+
+		msg := tea.KeyMsg{Type: tea.KeyDown}
+		result, _ := m.handleBranchSelector(msg)
+		model := result.(Model)
+
+		if model.branchSelected != 1 {
+			t.Errorf("expected branchSelected to be 1, got %d", model.branchSelected)
+		}
+	})
+
+	t.Run("up at top stays at top", func(t *testing.T) {
+		m := testModel()
+		m.showBranchSelector = true
+		m.branchFiltered = []string{"main", "feature-1"}
+		m.branchSelected = 0
+		m.branchSelectorHeight = 10
+
+		msg := tea.KeyMsg{Type: tea.KeyUp}
+		result, _ := m.handleBranchSelector(msg)
+		model := result.(Model)
+
+		if model.branchSelected != 0 {
+			t.Errorf("expected branchSelected to stay at 0, got %d", model.branchSelected)
+		}
+	})
+
+	t.Run("down at bottom stays at bottom", func(t *testing.T) {
+		m := testModel()
+		m.showBranchSelector = true
+		m.branchFiltered = []string{"main", "feature-1"}
+		m.branchSelected = 1
+		m.branchSelectorHeight = 10
+
+		msg := tea.KeyMsg{Type: tea.KeyDown}
+		result, _ := m.handleBranchSelector(msg)
+		model := result.(Model)
+
+		if model.branchSelected != 1 {
+			t.Errorf("expected branchSelected to stay at 1, got %d", model.branchSelected)
+		}
+	})
+
+	t.Run("typing adds to search and filters branches", func(t *testing.T) {
+		m := testModel()
+		m.showBranchSelector = true
+		m.branchList = []string{"main", "feature-1", "feature-2", "bugfix-1"}
+		m.branchFiltered = m.branchList
+		m.branchSelectorHeight = 10
+
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("feat")}
+		result, _ := m.handleBranchSelector(msg)
+		model := result.(Model)
+
+		if model.branchSearchInput != "feat" {
+			t.Errorf("expected branchSearchInput to be %q, got %q", "feat", model.branchSearchInput)
+		}
+		if len(model.branchFiltered) != 2 {
+			t.Errorf("expected 2 filtered branches, got %d", len(model.branchFiltered))
+		}
+	})
+
+	t.Run("backspace removes from search", func(t *testing.T) {
+		m := testModel()
+		m.showBranchSelector = true
+		m.branchSearchInput = "feat"
+		m.branchList = []string{"main", "feature-1"}
+		m.branchFiltered = []string{"feature-1"}
+		m.branchSelectorHeight = 10
+
+		msg := tea.KeyMsg{Type: tea.KeyBackspace}
+		result, _ := m.handleBranchSelector(msg)
+		model := result.(Model)
+
+		if model.branchSearchInput != "fea" {
+			t.Errorf("expected branchSearchInput to be %q, got %q", "fea", model.branchSearchInput)
+		}
+	})
+
+	t.Run("space adds to search", func(t *testing.T) {
+		m := testModel()
+		m.showBranchSelector = true
+		m.branchSearchInput = "my"
+		m.branchList = []string{"my branch", "other"}
+		m.branchFiltered = []string{"my branch"}
+		m.branchSelectorHeight = 10
+
+		msg := tea.KeyMsg{Type: tea.KeySpace}
+		result, _ := m.handleBranchSelector(msg)
+		model := result.(Model)
+
+		if model.branchSearchInput != "my " {
+			t.Errorf("expected branchSearchInput to be %q, got %q", "my ", model.branchSearchInput)
+		}
+	})
+
+	t.Run("page down moves by viewport height", func(t *testing.T) {
+		m := testModel()
+		m.showBranchSelector = true
+		m.branchFiltered = make([]string, 50)
+		for i := range m.branchFiltered {
+			m.branchFiltered[i] = "branch"
+		}
+		m.branchSelected = 0
+		m.branchSelectorHeight = 10
+
+		msg := tea.KeyMsg{Type: tea.KeyPgDown}
+		result, _ := m.handleBranchSelector(msg)
+		model := result.(Model)
+
+		if model.branchSelected != 10 {
+			t.Errorf("expected branchSelected to be 10, got %d", model.branchSelected)
+		}
+	})
+
+	t.Run("page up moves by viewport height", func(t *testing.T) {
+		m := testModel()
+		m.showBranchSelector = true
+		m.branchFiltered = make([]string, 50)
+		for i := range m.branchFiltered {
+			m.branchFiltered[i] = "branch"
+		}
+		m.branchSelected = 20
+		m.branchSelectorHeight = 10
+
+		msg := tea.KeyMsg{Type: tea.KeyPgUp}
+		result, _ := m.handleBranchSelector(msg)
+		model := result.(Model)
+
+		if model.branchSelected != 10 {
+			t.Errorf("expected branchSelected to be 10, got %d", model.branchSelected)
+		}
+	})
+}
+
+func TestApplyBranchFilter(t *testing.T) {
+	t.Run("empty search shows all branches", func(t *testing.T) {
+		m := testModel()
+		m.branchList = []string{"main", "feature-1", "bugfix-1"}
+		m.branchSearchInput = ""
+		m.branchSelectorHeight = 10
+
+		result := m.applyBranchFilter()
+
+		if len(result.branchFiltered) != 3 {
+			t.Errorf("expected 3 branches, got %d", len(result.branchFiltered))
+		}
+	})
+
+	t.Run("filter is case insensitive", func(t *testing.T) {
+		m := testModel()
+		m.branchList = []string{"main", "Feature-1", "BUGFIX-1"}
+		m.branchSearchInput = "feature"
+		m.branchSelectorHeight = 10
+
+		result := m.applyBranchFilter()
+
+		if len(result.branchFiltered) != 1 {
+			t.Errorf("expected 1 branch, got %d", len(result.branchFiltered))
+		}
+		if result.branchFiltered[0] != "Feature-1" {
+			t.Errorf("expected %q, got %q", "Feature-1", result.branchFiltered[0])
+		}
+	})
+
+	t.Run("filter resets selection to first item", func(t *testing.T) {
+		m := testModel()
+		m.branchList = []string{"main", "feature-1", "feature-2"}
+		m.branchSearchInput = "feat"
+		m.branchSelected = 5
+		m.branchScrollOffset = 10
+		m.branchSelectorHeight = 10
+
+		result := m.applyBranchFilter()
+
+		if result.branchSelected != 0 {
+			t.Errorf("expected branchSelected to be 0, got %d", result.branchSelected)
+		}
+		if result.branchScrollOffset != 0 {
+			t.Errorf("expected branchScrollOffset to be 0, got %d", result.branchScrollOffset)
+		}
+	})
+
+	t.Run("preserves previously selected branch if still visible", func(t *testing.T) {
+		m := testModel()
+		m.branchList = []string{"main", "feature-1", "feature-2", "bugfix-1"}
+		m.branchSearchInput = "feature"
+		m.selectedBaseBranch = "feature-2"
+		m.branchSelectorHeight = 10
+
+		result := m.applyBranchFilter()
+
+		// feature-2 is the second match (index 1)
+		if result.branchSelected != 1 {
+			t.Errorf("expected branchSelected to be 1, got %d", result.branchSelected)
+		}
+	})
+}
+
+func TestAdjustBranchScroll(t *testing.T) {
+	t.Run("scrolls up when selection above viewport", func(t *testing.T) {
+		m := testModel()
+		m.branchFiltered = make([]string, 50)
+		m.branchSelected = 2
+		m.branchScrollOffset = 10
+		m.branchSelectorHeight = 5
+
+		result := m.adjustBranchScroll()
+
+		if result.branchScrollOffset != 2 {
+			t.Errorf("expected branchScrollOffset to be 2, got %d", result.branchScrollOffset)
+		}
+	})
+
+	t.Run("scrolls down when selection below viewport", func(t *testing.T) {
+		m := testModel()
+		m.branchFiltered = make([]string, 50)
+		m.branchSelected = 15
+		m.branchScrollOffset = 5
+		m.branchSelectorHeight = 5
+
+		result := m.adjustBranchScroll()
+
+		// Selection at 15 with height 5 means scroll should be 11 (15-5+1)
+		if result.branchScrollOffset != 11 {
+			t.Errorf("expected branchScrollOffset to be 11, got %d", result.branchScrollOffset)
+		}
+	})
+
+	t.Run("clamps scroll offset to max", func(t *testing.T) {
+		m := testModel()
+		m.branchFiltered = make([]string, 10)
+		m.branchSelected = 9
+		m.branchScrollOffset = 100 // Way too high
+		m.branchSelectorHeight = 5
+
+		result := m.adjustBranchScroll()
+
+		// Max scroll is 10-5=5
+		if result.branchScrollOffset != 5 {
+			t.Errorf("expected branchScrollOffset to be 5, got %d", result.branchScrollOffset)
+		}
+	})
+
+	t.Run("clamps scroll offset to zero minimum", func(t *testing.T) {
+		m := testModel()
+		m.branchFiltered = make([]string, 10)
+		m.branchSelected = 0
+		m.branchScrollOffset = -5
+		m.branchSelectorHeight = 5
+
+		result := m.adjustBranchScroll()
+
+		if result.branchScrollOffset != 0 {
+			t.Errorf("expected branchScrollOffset to be 0, got %d", result.branchScrollOffset)
+		}
+	})
+
+	t.Run("handles zero height gracefully", func(t *testing.T) {
+		m := testModel()
+		m.branchFiltered = make([]string, 10)
+		m.branchScrollOffset = 5
+		m.branchSelectorHeight = 0
+
+		result := m.adjustBranchScroll()
+
+		// Should return unchanged when height is 0
+		if result.branchScrollOffset != 5 {
+			t.Errorf("expected branchScrollOffset to remain 5, got %d", result.branchScrollOffset)
+		}
+	})
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -175,10 +175,14 @@ type Model struct {
 	templateSuffix   string // Suffix to append on submission (from selected template)
 
 	// Branch selection state (for selecting base branch when adding task)
-	showBranchSelector bool     // Whether the branch selector is visible
-	branchList         []string // Cached list of branch names
-	branchSelected     int      // Currently highlighted branch index (0 = main branch)
-	selectedBaseBranch string   // The selected base branch for the new instance
+	showBranchSelector   bool     // Whether the branch selector is visible
+	branchList           []string // Cached list of branch names (unfiltered)
+	branchFiltered       []string // Filtered list of branch names based on search
+	branchSelected       int      // Currently highlighted branch index in filtered list
+	branchScrollOffset   int      // Scroll offset for branch list viewport
+	branchSearchInput    string   // Current search/filter text
+	selectedBaseBranch   string   // The selected base branch for the new instance
+	branchSelectorHeight int      // Visible height for branch list (calculated from terminal)
 
 	// File conflict tracking
 	conflicts []conflict.FileConflict

--- a/internal/tui/view/input_test.go
+++ b/internal/tui/view/input_test.go
@@ -1,0 +1,163 @@
+package view
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInputView_RenderBranchSelector(t *testing.T) {
+	iv := NewInputView()
+
+	t.Run("renders search input with cursor", func(t *testing.T) {
+		state := &InputState{
+			ShowBranchSelector:   true,
+			BranchSearchInput:    "feat",
+			Branches:             []BranchItem{{Name: "feature-branch"}},
+			BranchSelected:       0,
+			BranchSelectorHeight: 10,
+		}
+
+		result := iv.Render(state, 80)
+
+		if !strings.Contains(result, "Search:") {
+			t.Error("should show search label")
+		}
+		if !strings.Contains(result, "feat") {
+			t.Error("should show search input text")
+		}
+	})
+
+	t.Run("shows no matching branches message when filter yields no results", func(t *testing.T) {
+		state := &InputState{
+			ShowBranchSelector:   true,
+			BranchSearchInput:    "nonexistent",
+			Branches:             []BranchItem{},
+			BranchSelectorHeight: 10,
+		}
+
+		result := iv.Render(state, 80)
+
+		if !strings.Contains(result, "No matching branches") {
+			t.Error("should show 'no matching branches' when search yields no results")
+		}
+	})
+
+	t.Run("shows no branches available when no branches exist", func(t *testing.T) {
+		state := &InputState{
+			ShowBranchSelector:   true,
+			BranchSearchInput:    "",
+			Branches:             []BranchItem{},
+			BranchSelectorHeight: 10,
+		}
+
+		result := iv.Render(state, 80)
+
+		if !strings.Contains(result, "No branches available") {
+			t.Error("should show 'no branches available' when list is empty")
+		}
+	})
+
+	t.Run("renders branch list with scroll indicators", func(t *testing.T) {
+		branches := make([]BranchItem, 20)
+		for i := 0; i < 20; i++ {
+			branches[i] = BranchItem{Name: "branch-" + string(rune('a'+i))}
+		}
+
+		state := &InputState{
+			ShowBranchSelector:   true,
+			Branches:             branches,
+			BranchSelected:       10,
+			BranchScrollOffset:   5,
+			BranchSelectorHeight: 5,
+		}
+
+		result := iv.Render(state, 80)
+
+		if !strings.Contains(result, "more above") {
+			t.Error("should show 'more above' indicator when scrolled down")
+		}
+		if !strings.Contains(result, "more below") {
+			t.Error("should show 'more below' indicator when more items exist")
+		}
+	})
+
+	t.Run("marks main branch with default suffix", func(t *testing.T) {
+		state := &InputState{
+			ShowBranchSelector: true,
+			Branches: []BranchItem{
+				{Name: "main", IsMain: true},
+				{Name: "feature-branch"},
+			},
+			BranchSelected:       0,
+			BranchSelectorHeight: 10,
+		}
+
+		result := iv.Render(state, 80)
+
+		if !strings.Contains(result, "(default)") {
+			t.Error("should mark main branch with (default) suffix")
+		}
+	})
+
+	t.Run("shows branch count", func(t *testing.T) {
+		state := &InputState{
+			ShowBranchSelector: true,
+			Branches: []BranchItem{
+				{Name: "branch-1"},
+				{Name: "branch-2"},
+				{Name: "branch-3"},
+			},
+			BranchSelected:       0,
+			BranchSelectorHeight: 10,
+		}
+
+		result := iv.Render(state, 80)
+
+		if !strings.Contains(result, "3 branches") {
+			t.Error("should show branch count")
+		}
+	})
+}
+
+func TestInputView_RenderHints_BranchSelector(t *testing.T) {
+	iv := NewInputView()
+
+	t.Run("shows filter hint for branch selector", func(t *testing.T) {
+		state := &InputState{
+			ShowBranchSelector:   true,
+			BranchSelectorHeight: 10,
+		}
+
+		result := iv.Render(state, 80)
+
+		if !strings.Contains(result, "filter") {
+			t.Error("should show filter hint in branch selector mode")
+		}
+		if !strings.Contains(result, "navigate") {
+			t.Error("should show navigate hint in branch selector mode")
+		}
+		if !strings.Contains(result, "select") {
+			t.Error("should show select hint in branch selector mode")
+		}
+	})
+}
+
+func TestFormatCount(t *testing.T) {
+	tests := []struct {
+		input    int
+		expected string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{10, "10"},
+		{100, "100"},
+		{999, "999"},
+	}
+
+	for _, tt := range tests {
+		result := formatCount(tt.input)
+		if result != tt.expected {
+			t.Errorf("formatCount(%d) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds real-time search filtering to the branch selector (type to filter, case-insensitive matching)
- Implements scrollable list with viewport for repositories with many branches
- Adds scroll indicators showing items above/below the visible viewport
- Displays total matching branch count
- Supports Page Up/Down and Ctrl+U/D for faster navigation

## Motivation

Users with repositories containing many branches (potentially hundreds) previously had to arrow through the entire list to find their target branch. This was tedious and the selection could scroll off-screen, making it impossible to see which branch was highlighted.

## Changes

- **internal/tui/model.go**: Added state fields for filtering (`branchFiltered`, `branchSearchInput`) and scrolling (`branchScrollOffset`, `branchSelectorHeight`)
- **internal/tui/app.go**: Added keyboard handling for search input, filtering logic, and scroll adjustment
- **internal/tui/view/input.go**: Updated view to render search input field, scrollable list with indicators, and branch count
- **CHANGELOG.md**: Added entry under Unreleased

## Test plan

- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [x] Linting passes (`go vet ./...`)
- [x] Formatting correct (`gofmt -d .`)
- [ ] Manual testing: Open branch selector with Tab, type to filter, verify scroll indicators appear with many branches