### PR TITLE
Fix sidebar line-wrapping width calculations

### DIFF
--- a/internal/tui/view/dashboard.go
+++ b/internal/tui/view/dashboard.go
@@ -218,8 +218,12 @@ func (dv *DashboardView) renderExpandedInstance(
 
 	// Calculate how much fits on the first line
 	// Format: "● N prefix<name>" where N is the instance number
+	// Width deductions:
+	// - 2 chars: sidebar Padding(1, 1) horizontal
+	// - 2 chars: itemStyle Padding(0, 1) horizontal (from SidebarItemActive)
+	// - 2 chars: safety buffer for border/edge alignment
 	firstLineOverhead := 2 + len(fmt.Sprintf("%d ", i+1)) + prefixLen // "● " + "N " + prefix
-	firstLineAvailable := max(width-firstLineOverhead-2, 10)          // -2 for padding
+	firstLineAvailable := max(width-firstLineOverhead-6, 10)
 
 	if len(nameRunes) <= firstLineAvailable {
 		// Fits on one line even when expanded
@@ -243,7 +247,8 @@ func (dv *DashboardView) renderExpandedInstance(
 	}
 	// Use firstLineOverhead as indent to align continuation text with the name start position
 	continuationIndent := firstLineOverhead
-	continuationAvailable := max(width-continuationIndent-2, 10) // indent + padding
+	// Same width deductions as first line: sidebar padding (2) + item padding (2) + buffer (2)
+	continuationAvailable := max(width-continuationIndent-6, 10)
 
 	for len(remaining) > 0 {
 		chunk := wrapAtWordBoundary(remaining, continuationAvailable)

--- a/internal/tui/view/group.go
+++ b/internal/tui/view/group.go
@@ -144,12 +144,15 @@ func RenderGroupHeaderWrapped(group *orchestrator.InstanceGroup, progress GroupP
 
 	// Calculate how much space we have for the name on the first line
 	// Format: "V I <name> [x/y] P" where V=collapse, I=session icon, P=phase indicator
-	// Suffix: " [x/y] P"
-	suffixLen := 1 + len(progressStr) + 1 + 1                // space + progress + space + indicator
-	maxFirstLineNameLen := width - prefixLen - suffixLen - 2 // some padding
+	// Width deductions:
+	// - 2 chars: sidebar Padding(1, 1) horizontal
+	// - 2 chars: safety buffer for border/edge alignment
+	suffixLen := 1 + len(progressStr) + 1 + 1 // space + progress + space + indicator
+	maxFirstLineNameLen := width - prefixLen - suffixLen - 4
 
 	// Calculate max name length for continuation lines (full width minus indent)
-	maxContinuationNameLen := width - prefixLen - 2
+	// Same deductions: sidebar padding (2) + buffer (2)
+	maxContinuationNameLen := width - prefixLen - 4
 
 	// Wrap the group name with different widths for first line vs continuation
 	nameLines := wrapGroupNameWithWidths(group.Name, maxFirstLineNameLen, maxContinuationNameLen)


### PR DESCRIPTION
## Summary

- Fixed line-wrapping in the sidebar that was injecting extra newlines between wrapped lines
- The width calculations in `renderExpandedInstance` and `RenderGroupHeaderWrapped` did not account for all padding layers
- When lipgloss received content wider than the actual inner box width, it would re-wrap the content, causing unexpected line breaks

**Root cause**: The calculations used the raw `width` parameter without deducting:
- Sidebar `Padding(1, 1)`: 2 chars horizontal
- `SidebarItemActive` `Padding(0, 1)`: 2 chars horizontal (for expanded instances)
- Safety buffer for border/edge alignment: 2 chars

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` passes
- [x] `gofmt -d .` shows no formatting issues
- [x] Visual testing confirms wrapped text fits within sidebar boundaries