### PR TITLE
Fix frozen output panel after instance removal

### DIFF
--- a/internal/tui/inlineplan.go
+++ b/internal/tui/inlineplan.go
@@ -221,8 +221,14 @@ func (m *Model) handleInlinePlanObjectiveSubmit(objective string) {
 		}
 		m.infoMessage = "Planning started (group view unavailable)..."
 	}
+	// Pause the old active instance before switching
+	if oldInst := m.activeInstance(); oldInst != nil {
+		m.pauseInstance(oldInst.ID)
+	}
 	m.activeTab = m.findInstanceIndex(inst.ID)
 	m.ensureActiveVisible()
+	// Resume the new active instance's capture
+	m.resumeActiveInstance()
 }
 
 // handleUltraPlanObjectiveSubmit handles submission of an ultraplan objective.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -539,6 +539,22 @@ func (m *Model) pauseInstance(instanceID string) {
 	}
 }
 
+// resumeActiveInstance resumes the capture loop for the currently active instance.
+// This should be called after any direct modification of activeTab (e.g., after
+// instance removal) to ensure the new active instance's output is being captured.
+// Without this, removed instances can leave the remaining instance in a paused state.
+func (m *Model) resumeActiveInstance() {
+	if m.orchestrator == nil {
+		return
+	}
+	if inst := m.activeInstance(); inst != nil {
+		if mgr := m.orchestrator.GetInstanceManager(inst.ID); mgr != nil {
+			// Note: Resume() currently always returns nil, so error is safely discarded
+			_ = mgr.Resume()
+		}
+	}
+}
+
 // instanceCount returns the number of instances
 func (m Model) instanceCount() int {
 	if m.session == nil {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Iron-Ham/claudio/internal/conflict"
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
 	"github.com/spf13/viper"
 )
 
@@ -633,4 +634,41 @@ func TestCalculateExtraFooterLines(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResumeActiveInstance_NilSession(t *testing.T) {
+	// Test that resumeActiveInstance doesn't panic with nil session
+	m := Model{
+		session: nil,
+	}
+
+	// Should not panic
+	m.resumeActiveInstance()
+}
+
+func TestResumeActiveInstance_NoActiveInstance(t *testing.T) {
+	// Test that resumeActiveInstance doesn't panic with empty instances
+	m := Model{
+		session:   &orchestrator.Session{},
+		activeTab: 0,
+	}
+
+	// Should not panic even with no instances
+	m.resumeActiveInstance()
+}
+
+func TestResumeActiveInstance_NilOrchestrator(t *testing.T) {
+	// Test that resumeActiveInstance doesn't panic with nil orchestrator
+	m := Model{
+		session: &orchestrator.Session{
+			Instances: []*orchestrator.Instance{
+				{ID: "test-1"},
+			},
+		},
+		orchestrator: nil,
+		activeTab:    0,
+	}
+
+	// Should not panic when orchestrator is nil
+	m.resumeActiveInstance()
 }

--- a/internal/tui/ultraplan.go
+++ b/internal/tui/ultraplan.go
@@ -273,9 +273,15 @@ func (m *Model) navigateToNextInstance(direction int) bool {
 	targetInstID := instances[nextIdx]
 	for i, inst := range m.session.Instances {
 		if inst.ID == targetInstID {
+			// Pause the old active instance before switching
+			if oldInst := m.activeInstance(); oldInst != nil {
+				m.pauseInstance(oldInst.ID)
+			}
 			m.activeTab = i
 			m.ultraPlan.SelectedNavIdx = nextIdx
 			m.ensureActiveVisible()
+			// Resume the new active instance's capture
+			m.resumeActiveInstance()
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

- Fixes a bug where the output panel would freeze and show stale content after removing instances
- The root cause was that when instances were removed, `activeTab` was adjusted without calling `Resume()` on the new active instance
- Added `resumeActiveInstance()` helper function that ensures the capture loop is running for the active instance
- Applied consistent pause/resume handling across all tab switching operations

## Problem

When a user had multiple Claudio instances running and removed some of them (via Ctrl+K or commands), the remaining instance's output panel would appear "frozen" - showing old/stale content while the rest of the TUI remained responsive.

This happened because:
1. Claudio pauses output capture for non-active instances as an optimization
2. When switching tabs, `switchToInstance()` properly pauses the old and resumes the new
3. However, when instances were removed, `activeTab` was directly modified without calling `Resume()`
4. The remaining instance stayed in a permanently paused state

## Solution

Added a `resumeActiveInstance()` helper that ensures the active instance's capture loop is running. This is now called after all direct modifications of `activeTab`:
- After instance removal via `Ctrl+K` (app.go)
- After command-based removal via `ActiveTabAdjustment` (app.go)
- After ultraplan navigation (ultraplan.go)
- After inline plan creation (inlineplan.go)
- After ultraplan initialization (app.go)

## Test plan

- [x] Added unit tests for `resumeActiveInstance()` covering nil safety
- [x] All existing tests pass
- [x] Build passes with no vet warnings
- [ ] Manual testing: Create 3 instances, remove 2, verify remaining instance output continues updating