### PR TITLE
Add CI check requiring changelog entries on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,3 +104,51 @@ jobs:
 
       - name: Build CLI
         run: go build -v -o claudio ./cmd/claudio
+
+  changelog:
+    name: Changelog
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for skip label
+        id: skip
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          has_skip=$(gh pr view "$PR_NUMBER" --json labels -q '[.labels[].name] | any(. == "skip-changelog")')
+          if [ "$has_skip" = "true" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Skipping changelog check (skip-changelog label found)"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for changelog entry
+        if: steps.skip.outputs.skip != 'true'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # Get the list of changed files in this PR
+          changed_files=$(git diff --name-only "origin/${BASE_REF}...HEAD")
+
+          if echo "$changed_files" | grep -q "^CHANGELOG.md$"; then
+            echo "Changelog entry found"
+          else
+            echo "::error::No CHANGELOG.md entry found. Please add an entry to the Unreleased section."
+            echo ""
+            echo "If this change doesn't need a changelog entry (test-only, internal refactor,"
+            echo "docs-only, or dependency update), add the 'skip-changelog' label to this PR."
+            echo ""
+            echo "See CLAUDE.md for changelog guidelines."
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Changelog CI Check** - PRs now require a CHANGELOG.md entry. Add the `skip-changelog` label to bypass for trivial changes (test-only, internal refactors, docs-only, dependency updates).
+
 ## [0.6.1] - 2026-01-14
 
 ### Added


### PR DESCRIPTION
## Summary

- Adds a new `changelog` job to the CI workflow that enforces CHANGELOG.md updates on all PRs
- Creates a `skip-changelog` label for bypassing the check on trivial changes (test-only, internal refactors, docs-only, dependency updates)
- Provides clear error messages explaining what to do when the check fails

## Implementation

The check:
1. Runs only on pull requests (not pushes to main)
2. First checks if the PR has the `skip-changelog` label using jq exact matching
3. If no skip label, verifies CHANGELOG.md was modified via git diff against the base branch
4. Fails with a helpful error message pointing to CLAUDE.md guidelines

Security considerations addressed:
- Uses environment variables instead of direct GitHub context interpolation in shell commands
- Explicitly declares `pull-requests: read` permission
- Uses exact string matching for label detection

## Test plan

- [ ] Create a PR without a CHANGELOG.md entry → should fail
- [ ] Add the `skip-changelog` label → should pass
- [ ] Create a PR with a CHANGELOG.md entry → should pass