### PR TITLE
Remove redundant status badge from instance header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Instance Header Simplified** - Removed redundant status badge from instance detail header since task state is already displayed in the sidebar with 4-character abbreviations (WAIT, WORK, DONE, etc.)
+
 ### Added
 
 - **Changelog CI Check** - PRs now require a CHANGELOG.md entry. Add the `skip-changelog` label to bypass for trivial changes (test-only, internal refactors, docs-only, dependency updates).

--- a/internal/tui/view/instance.go
+++ b/internal/tui/view/instance.go
@@ -92,7 +92,7 @@ func (v *InstanceView) Render(inst *orchestrator.Instance, state RenderState) st
 func (v *InstanceView) RenderWithSession(inst *orchestrator.Instance, state RenderState, session *orchestrator.Session) string {
 	var b strings.Builder
 
-	// Render header (status badge + branch info)
+	// Render header (branch info)
 	b.WriteString(v.RenderHeader(inst))
 	b.WriteString("\n")
 
@@ -143,11 +143,10 @@ func (v *InstanceView) RenderWithSession(inst *orchestrator.Instance, state Rend
 	return b.String()
 }
 
-// RenderHeader renders the instance header with status badge and branch info.
+// RenderHeader renders the instance header with branch info.
+// Status is displayed in the sidebar, so we only show branch here.
 func (v *InstanceView) RenderHeader(inst *orchestrator.Instance) string {
-	statusColor := styles.StatusColor(string(inst.Status))
-	statusBadge := styles.StatusBadge.Background(statusColor).Render(string(inst.Status))
-	info := fmt.Sprintf("%s  Branch: %s", statusBadge, inst.Branch)
+	info := fmt.Sprintf("Branch: %s", inst.Branch)
 	return styles.InstanceInfo.Render(info)
 }
 


### PR DESCRIPTION
## Summary
- Remove the status badge from the instance detail header since task state is already displayed in the sidebar
- The sidebar shows 4-character status abbreviations (WAIT, WORK, DONE, etc.) making the header badge redundant
- The header now only displays branch information, reducing visual noise

## Test plan
- [ ] Verify the instance detail view shows only branch info in the header
- [ ] Confirm task status is still visible in the sidebar with colored abbreviations
- [ ] Check that all existing tests pass