### PR TITLE
Fix :multiplan evaluator not starting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Changelog CI Check** - PRs now require a CHANGELOG.md entry. Add the `skip-changelog` label to bypass for trivial changes (test-only, internal refactors, docs-only, dependency updates).
 - **Multi-Pass Plan Mode** (Experimental) - New `:multiplan` (or `:mp`) command launches competitive multi-pass planning with 3 parallel planners using different strategies (maximize-parallelism, minimize-complexity, balanced-approach) plus a plan manager/assessor that evaluates and merges the best plan. This provides the same competitive planning approach as `:ultraplan --multi-pass` but within the simpler inline plan workflow.
 
+### Fixed
+
+- **Multiplan Evaluator Not Starting** - Fixed `:multiplan` command not triggering the evaluator/assessor instance. The issue was that plan completion was only detected when planner processes exited, not when they created their plan files. Added async plan file polling (similar to `:ultraplan`) to detect plan creation and properly trigger the evaluator once all 3 planners complete.
+
 ## [0.6.1] - 2026-01-14
 
 ### Added

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -453,6 +453,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// This avoids blocking the UI with file I/O during planning phases
 		cmds = append(cmds, m.dispatchUltraPlanFileChecks()...)
 
+		// Dispatch async commands to check inline multiplan files
+		// This polls for plan file creation during :multiplan command
+		cmds = append(cmds, m.dispatchInlineMultiPlanFileChecks()...)
+
 		// Check if ultraplan needs user notification
 		if m.ultraPlan != nil && m.ultraPlan.NeedsNotification {
 			m.ultraPlan.NeedsNotification = false
@@ -651,6 +655,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case planManagerFileCheckResultMsg:
 		// Handle async plan manager file check result
 		return m.handlePlanManagerFileCheckResult(msg)
+
+	case inlineMultiPlanFileCheckResultMsg:
+		// Handle async inline multiplan file check result
+		return m.handleInlineMultiPlanFileCheckResult(msg)
 	}
 
 	return m, nil
@@ -3473,6 +3481,14 @@ type planManagerFileCheckResultMsg struct {
 	Plan     *orchestrator.PlanSpec
 	Decision *orchestrator.PlanDecision
 	Err      error
+}
+
+// inlineMultiPlanFileCheckResultMsg contains the result of async inline multiplan file checking.
+// Used by the :multiplan command to detect when planners create their plan files.
+type inlineMultiPlanFileCheckResultMsg struct {
+	Index        int
+	Plan         *orchestrator.PlanSpec
+	StrategyName string
 }
 
 // checkPlanFileAsync returns a command that checks for a plan file asynchronously.

--- a/internal/tui/inlineplan_test.go
+++ b/internal/tui/inlineplan_test.go
@@ -1,0 +1,299 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+)
+
+func TestDispatchInlineMultiPlanFileChecks_NilInlinePlan(t *testing.T) {
+	m := Model{
+		inlinePlan: nil,
+	}
+
+	cmds := m.dispatchInlineMultiPlanFileChecks()
+	if cmds != nil {
+		t.Errorf("expected nil when inlinePlan is nil, got %v", cmds)
+	}
+}
+
+func TestDispatchInlineMultiPlanFileChecks_NotMultiPass(t *testing.T) {
+	m := Model{
+		inlinePlan: &InlinePlanState{
+			MultiPass:            false,
+			AwaitingPlanCreation: true,
+		},
+	}
+
+	cmds := m.dispatchInlineMultiPlanFileChecks()
+	if cmds != nil {
+		t.Errorf("expected nil when not in multipass mode, got %v", cmds)
+	}
+}
+
+func TestDispatchInlineMultiPlanFileChecks_NotAwaitingPlanCreation(t *testing.T) {
+	m := Model{
+		inlinePlan: &InlinePlanState{
+			MultiPass:            true,
+			AwaitingPlanCreation: false,
+		},
+	}
+
+	cmds := m.dispatchInlineMultiPlanFileChecks()
+	if cmds != nil {
+		t.Errorf("expected nil when not awaiting plan creation, got %v", cmds)
+	}
+}
+
+func TestDispatchInlineMultiPlanFileChecks_NoPlannerIDs(t *testing.T) {
+	m := Model{
+		inlinePlan: &InlinePlanState{
+			MultiPass:            true,
+			AwaitingPlanCreation: true,
+			PlanningInstanceIDs:  []string{},
+		},
+	}
+
+	cmds := m.dispatchInlineMultiPlanFileChecks()
+	if cmds != nil {
+		t.Errorf("expected nil when no planner IDs, got %v", cmds)
+	}
+}
+
+func TestDispatchInlineMultiPlanFileChecks_SkipsProcessedPlanners(t *testing.T) {
+	m := Model{
+		inlinePlan: &InlinePlanState{
+			MultiPass:            true,
+			AwaitingPlanCreation: true,
+			PlanningInstanceIDs:  []string{"planner-1", "planner-2", "planner-3"},
+			ProcessedPlanners: map[int]bool{
+				0: true, // planner-1 already processed
+				1: true, // planner-2 already processed
+				2: true, // planner-3 already processed
+			},
+			Objective: "test objective",
+		},
+		orchestrator: nil, // Will cause GetInstance to return nil
+	}
+
+	cmds := m.dispatchInlineMultiPlanFileChecks()
+	// All planners are processed, so no commands should be returned
+	if len(cmds) != 0 {
+		t.Errorf("expected 0 commands when all planners processed, got %d", len(cmds))
+	}
+}
+
+func TestDispatchInlineMultiPlanFileChecks_CreatesCommandsForUnprocessedPlanners(t *testing.T) {
+	m := Model{
+		inlinePlan: &InlinePlanState{
+			MultiPass:            true,
+			AwaitingPlanCreation: true,
+			PlanningInstanceIDs:  []string{"planner-1", "planner-2", "planner-3"},
+			ProcessedPlanners: map[int]bool{
+				0: true, // Only planner-1 is processed
+			},
+			Objective: "test objective",
+		},
+		orchestrator: nil, // Commands will return nil when GetInstance fails
+	}
+
+	cmds := m.dispatchInlineMultiPlanFileChecks()
+	// Should create commands for planner-2 and planner-3
+	if len(cmds) != 2 {
+		t.Errorf("expected 2 commands for unprocessed planners, got %d", len(cmds))
+	}
+}
+
+func TestHandleInlineMultiPlanFileCheckResult_NilInlinePlan(t *testing.T) {
+	m := &Model{
+		inlinePlan: nil,
+	}
+
+	msg := inlineMultiPlanFileCheckResultMsg{
+		Index:        0,
+		Plan:         &orchestrator.PlanSpec{},
+		StrategyName: "test",
+	}
+
+	result, cmd := m.handleInlineMultiPlanFileCheckResult(msg)
+	if cmd != nil {
+		t.Error("expected nil command when inlinePlan is nil")
+	}
+	resultModel := result.(*Model)
+	if resultModel.inlinePlan != nil {
+		t.Error("expected inlinePlan to remain nil")
+	}
+}
+
+func TestHandleInlineMultiPlanFileCheckResult_NotMultiPass(t *testing.T) {
+	m := &Model{
+		inlinePlan: &InlinePlanState{
+			MultiPass:            false,
+			AwaitingPlanCreation: true,
+		},
+	}
+
+	msg := inlineMultiPlanFileCheckResultMsg{
+		Index:        0,
+		Plan:         &orchestrator.PlanSpec{},
+		StrategyName: "test",
+	}
+
+	_, cmd := m.handleInlineMultiPlanFileCheckResult(msg)
+	if cmd != nil {
+		t.Error("expected nil command when not in multipass mode")
+	}
+}
+
+func TestHandleInlineMultiPlanFileCheckResult_InvalidIndex(t *testing.T) {
+	tests := []struct {
+		name  string
+		index int
+	}{
+		{"negative index", -1},
+		{"index out of bounds", 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Model{
+				inlinePlan: &InlinePlanState{
+					MultiPass:            true,
+					AwaitingPlanCreation: true,
+					PlanningInstanceIDs:  []string{"planner-1"},
+					ProcessedPlanners:    make(map[int]bool),
+					CandidatePlans:       make([]*orchestrator.PlanSpec, 1),
+				},
+			}
+
+			msg := inlineMultiPlanFileCheckResultMsg{
+				Index:        tt.index,
+				Plan:         &orchestrator.PlanSpec{},
+				StrategyName: "test",
+			}
+
+			_, cmd := m.handleInlineMultiPlanFileCheckResult(msg)
+			if cmd != nil {
+				t.Error("expected nil command for invalid index")
+			}
+		})
+	}
+}
+
+func TestHandleInlineMultiPlanFileCheckResult_SkipsAlreadyProcessed(t *testing.T) {
+	m := &Model{
+		inlinePlan: &InlinePlanState{
+			MultiPass:            true,
+			AwaitingPlanCreation: true,
+			PlanningInstanceIDs:  []string{"planner-1"},
+			ProcessedPlanners: map[int]bool{
+				0: true, // Already processed
+			},
+			CandidatePlans: make([]*orchestrator.PlanSpec, 1),
+		},
+	}
+
+	msg := inlineMultiPlanFileCheckResultMsg{
+		Index:        0,
+		Plan:         &orchestrator.PlanSpec{Tasks: []orchestrator.PlannedTask{{ID: "new"}}},
+		StrategyName: "test",
+	}
+
+	_, cmd := m.handleInlineMultiPlanFileCheckResult(msg)
+	if cmd != nil {
+		t.Error("expected nil command for already processed planner")
+	}
+	// Plan should not be updated
+	if m.inlinePlan.CandidatePlans[0] != nil {
+		t.Error("plan should not be updated for already processed planner")
+	}
+}
+
+func TestHandleInlineMultiPlanFileCheckResult_StoresPlan(t *testing.T) {
+	m := &Model{
+		inlinePlan: &InlinePlanState{
+			MultiPass:            true,
+			AwaitingPlanCreation: true,
+			PlanningInstanceIDs:  []string{"planner-1", "planner-2", "planner-3"},
+			ProcessedPlanners:    make(map[int]bool),
+			CandidatePlans:       make([]*orchestrator.PlanSpec, 3),
+			Objective:            "test",
+		},
+	}
+
+	testPlan := &orchestrator.PlanSpec{
+		Summary: "test plan",
+		Tasks:   []orchestrator.PlannedTask{{ID: "task-1", Title: "Test Task"}},
+	}
+
+	msg := inlineMultiPlanFileCheckResultMsg{
+		Index:        1,
+		Plan:         testPlan,
+		StrategyName: "minimize-complexity",
+	}
+
+	result, _ := m.handleInlineMultiPlanFileCheckResult(msg)
+	resultModel := result.(*Model)
+
+	// Check planner was marked as processed
+	if !resultModel.inlinePlan.ProcessedPlanners[1] {
+		t.Error("planner should be marked as processed")
+	}
+
+	// Check plan was stored
+	if resultModel.inlinePlan.CandidatePlans[1] != testPlan {
+		t.Error("plan should be stored in CandidatePlans")
+	}
+
+	// Check info message was updated
+	if resultModel.infoMessage == "" {
+		t.Error("info message should be updated")
+	}
+}
+
+func TestHandleInlineMultiPlanFileCheckResult_AllPlansCollectedWithNoValidPlans(t *testing.T) {
+	m := &Model{
+		inlinePlan: &InlinePlanState{
+			MultiPass:            true,
+			AwaitingPlanCreation: true,
+			PlanningInstanceIDs:  []string{"planner-1"},
+			ProcessedPlanners:    make(map[int]bool),
+			CandidatePlans:       make([]*orchestrator.PlanSpec, 1),
+			Objective:            "test",
+		},
+	}
+
+	// Send a nil plan (simulating parse failure)
+	msg := inlineMultiPlanFileCheckResultMsg{
+		Index:        0,
+		Plan:         nil,
+		StrategyName: "test",
+	}
+
+	result, _ := m.handleInlineMultiPlanFileCheckResult(msg)
+	resultModel := result.(*Model)
+
+	// inlinePlan should be nil because all planners failed
+	if resultModel.inlinePlan != nil {
+		t.Error("inlinePlan should be nil when all planners fail")
+	}
+
+	// Error message should be set
+	if resultModel.errorMessage == "" {
+		t.Error("error message should be set when all planners fail")
+	}
+}
+
+// Coverage: checkInlineMultiPlanFileAsync is not directly tested because:
+// 1. It requires a full orchestrator setup with instances
+// 2. It's an internal async function that's tested indirectly through integration
+// 3. The dispatch function already tests the command creation
+
+func TestStatFileFunction(t *testing.T) {
+	// Test that statFile is a function that wraps os.Stat
+	// This is the hook for testing file operations
+	_, err := statFile("/nonexistent/path/that/should/not/exist")
+	if err == nil {
+		t.Error("expected error for nonexistent file")
+	}
+}


### PR DESCRIPTION
## Summary

- Fixed `:multiplan` command not triggering the evaluator/assessor instance after planners complete
- Root cause: plan completion was only detected when planner tmux sessions exited, not when they created their plan files
- Added async plan file polling (same pattern as `:ultraplan`) to detect plan creation

## Changes

- Add `inlineMultiPlanFileCheckResultMsg` type for async plan file check results
- Add `dispatchInlineMultiPlanFileChecks()` - runs on every tick to poll for plan files
- Add `checkInlineMultiPlanFileAsync()` - async function to check individual plan files
- Add `handleInlineMultiPlanFileCheckResult()` - processes detected plans and triggers evaluator
- Add comprehensive test coverage for new functions
- Fix nil plan handling in info message (defensive programming)

## Test plan

- [x] All existing tests pass
- [x] New unit tests for plan file polling functions
- [x] Manual testing: run `:multiplan` and verify evaluator starts after planners create plan files