### PR TITLE
Graduate :plan command from experimental to always available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Changelog CI Check** - PRs now require a CHANGELOG.md entry. Add the `skip-changelog` label to bypass for trivial changes (test-only, internal refactors, docs-only, dependency updates).
 - **Multi-Pass Plan Mode** (Experimental) - New `:multiplan` (or `:mp`) command launches competitive multi-pass planning with 3 parallel planners using different strategies (maximize-parallelism, minimize-complexity, balanced-approach) plus a plan manager/assessor that evaluates and merges the best plan. This provides the same competitive planning approach as `:ultraplan --multi-pass` but within the simpler inline plan workflow.
 
+### Changed
+
+- **Plan Mode Graduated from Experimental** - The `:plan` command is now always available without any configuration. The `experimental.inline_plan` setting now only controls the `:multiplan` command, which remains experimental.
+
 ### Fixed
 
 - **Multiplan Evaluator Not Starting** - Fixed `:multiplan` command not triggering the evaluator/assessor instance. The issue was that plan completion was only detected when planner processes exited, not when they created their plan files. Added async plan file polling (similar to `:ultraplan`) to detect plan creation and properly trigger the evaluator once all 3 planners complete.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -276,7 +276,7 @@ Controls experimental features that may change or be removed. These features are
 |-----|------|---------|-------------|
 | `experimental.intelligent_naming` | bool | `false` | Use Claude to generate short, descriptive instance names |
 | `experimental.triple_shot` | bool | `false` | Spawn three parallel instances and select the best solution |
-| `experimental.inline_plan` | bool | `false` | Enable `:plan` command in the TUI |
+| `experimental.inline_plan` | bool | `false` | Enable `:multiplan` command in the TUI (`:plan` is always available) |
 | `experimental.inline_ultraplan` | bool | `false` | Enable `:ultraplan` command in the TUI |
 | `experimental.grouped_instance_view` | bool | `false` | Enable visual group organization in the sidebar |
 
@@ -286,7 +286,7 @@ Controls experimental features that may change or be removed. These features are
 |---------|-------------|
 | `intelligent_naming` | Uses Claude to generate short, descriptive instance names for the sidebar based on the task and Claude's initial output. Requires `ANTHROPIC_API_KEY`. |
 | `triple_shot` | Spawns three parallel instances working on the same problem, then uses a judge instance to evaluate and select the best solution. |
-| `inline_plan` | Enables the `:plan` command in the standard TUI, allowing you to start a Plan workflow directly from the main interface. |
+| `inline_plan` | Enables the `:multiplan` command in the standard TUI for multi-pass planning with 3 planners + assessor. The `:plan` command is always available without this setting. |
 | `inline_ultraplan` | Enables the `:ultraplan` command in the standard TUI, allowing you to start an UltraPlan workflow with parallel task execution. |
 | `grouped_instance_view` | Organizes instances visually by execution group in the TUI sidebar. Related tasks are grouped together, with sub-groups for dependency chains. |
 
@@ -294,9 +294,9 @@ Controls experimental features that may change or be removed. These features are
 experimental:
   intelligent_naming: false
   triple_shot: false
-  inline_plan: true
-  inline_ultraplan: true
-  grouped_instance_view: true
+  inline_plan: false  # enables :multiplan; :plan is always available
+  inline_ultraplan: false
+  grouped_instance_view: false
 ```
 
 See the [Inline Planning Guide](../guide/inline-planning.md) for detailed usage of inline planning features.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -342,7 +342,7 @@ func Default() *Config {
 			IntelligentNaming:   false, // Disabled by default until stable
 			TripleShot:          false, // Disabled by default until stable
 			TerminalSupport:     false, // Disabled by default until stable
-			InlinePlan:          false, // Disabled by default until stable
+			InlinePlan:          false, // Controls :multiplan only; :plan is always available
 			InlineUltraPlan:     false, // Disabled by default until stable
 			GroupedInstanceView: false, // Disabled by default until stable
 		},

--- a/internal/tui/command/handler.go
+++ b/internal/tui/command/handler.go
@@ -987,11 +987,6 @@ func cmdTripleShot(deps Dependencies) Result {
 }
 
 func cmdPlan(deps Dependencies) Result {
-	// Check if inline plan is enabled in config
-	if !viper.GetBool("experimental.inline_plan") {
-		return Result{ErrorMessage: "Plan mode is disabled. Enable it in :config under Experimental"}
-	}
-
 	// Don't allow starting plan mode if already in ultraplan mode
 	if deps.IsUltraPlanMode() {
 		return Result{ErrorMessage: "Cannot start plan mode while in ultraplan mode"}
@@ -1009,9 +1004,9 @@ func cmdPlan(deps Dependencies) Result {
 }
 
 func cmdMultiPlan(deps Dependencies) Result {
-	// Check if inline plan is enabled in config
+	// Check if inline plan is enabled in config (multiplan remains experimental)
 	if !viper.GetBool("experimental.inline_plan") {
-		return Result{ErrorMessage: "Plan mode is disabled. Enable it in :config under Experimental"}
+		return Result{ErrorMessage: "MultiPlan mode is disabled. Enable it in :config under Experimental"}
 	}
 
 	// Don't allow starting multiplan mode if already in ultraplan mode

--- a/internal/tui/command/handler_test.go
+++ b/internal/tui/command/handler_test.go
@@ -1092,32 +1092,11 @@ func TestTripleShotCommand(t *testing.T) {
 	})
 }
 
-// TestPlanCommand tests the plan command with config check
+// TestPlanCommand tests the plan command
 func TestPlanCommand(t *testing.T) {
-	t.Run("disabled by default", func(t *testing.T) {
+	t.Run("enabled by default", func(t *testing.T) {
 		// Reset viper to ensure clean state
 		viper.Reset()
-
-		h := New()
-		deps := newMockDeps()
-
-		result := h.Execute("plan", deps)
-
-		if result.ErrorMessage == "" {
-			t.Error("expected error when plan mode is disabled")
-		}
-		if result.ErrorMessage != "Plan mode is disabled. Enable it in :config under Experimental" {
-			t.Errorf("unexpected error message: %q", result.ErrorMessage)
-		}
-		if result.StartPlanMode != nil {
-			t.Error("StartPlanMode should be nil when disabled")
-		}
-	})
-
-	t.Run("enabled via config", func(t *testing.T) {
-		// Reset and enable plan mode
-		viper.Reset()
-		viper.Set("experimental.inline_plan", true)
 
 		h := New()
 		deps := newMockDeps()
@@ -1140,7 +1119,6 @@ func TestPlanCommand(t *testing.T) {
 
 	t.Run("blocked in ultraplan mode", func(t *testing.T) {
 		viper.Reset()
-		viper.Set("experimental.inline_plan", true)
 
 		h := New()
 		deps := newMockDeps()
@@ -1160,7 +1138,6 @@ func TestPlanCommand(t *testing.T) {
 
 	t.Run("allowed when in triple-shot mode", func(t *testing.T) {
 		viper.Reset()
-		viper.Set("experimental.inline_plan", true)
 
 		h := New()
 		deps := newMockDeps()
@@ -1180,7 +1157,7 @@ func TestPlanCommand(t *testing.T) {
 	})
 }
 
-// TestMultiPlanCommand tests the multiplan command with config check
+// TestMultiPlanCommand tests the multiplan command with config check (remains experimental)
 func TestMultiPlanCommand(t *testing.T) {
 	t.Run("disabled by default", func(t *testing.T) {
 		// Reset viper to ensure clean state
@@ -1192,9 +1169,9 @@ func TestMultiPlanCommand(t *testing.T) {
 		result := h.Execute("multiplan", deps)
 
 		if result.ErrorMessage == "" {
-			t.Error("expected error when plan mode is disabled")
+			t.Error("expected error when multiplan mode is disabled")
 		}
-		if result.ErrorMessage != "Plan mode is disabled. Enable it in :config under Experimental" {
+		if result.ErrorMessage != "MultiPlan mode is disabled. Enable it in :config under Experimental" {
 			t.Errorf("unexpected error message: %q", result.ErrorMessage)
 		}
 		if result.StartMultiPlanMode != nil {

--- a/internal/tui/config/config.go
+++ b/internal/tui/config/config.go
@@ -462,8 +462,8 @@ func New() Model {
 				},
 				{
 					Key:         "experimental.inline_plan",
-					Label:       "Inline Plan",
-					Description: "Enable :plan command in standard TUI to start Plan workflows",
+					Label:       "Inline MultiPlan",
+					Description: "Enable :multiplan command for multi-pass planning with 3 planners + assessor",
 					Type:        "bool",
 					Category:    "experimental",
 				},


### PR DESCRIPTION
## Summary

- The `:plan` command is now always available without any configuration
- The `:multiplan` command remains experimental and requires `experimental.inline_plan: true`
- Updated config UI to clarify the setting only controls `:multiplan`

## Test plan

- [x] Verify `go build ./...` succeeds
- [x] Verify `go vet ./...` passes
- [x] Verify `go test ./...` all tests pass
- [x] Verify `gofmt -d .` shows no formatting issues
- [ ] Manual test: Run `:plan` command - should work without any config
- [ ] Manual test: Run `:multiplan` command - should show error until enabled
- [ ] Manual test: Enable `experimental.inline_plan` and verify `:multiplan` works