### PR TITLE
Fix semicolon and Option key input to tmux instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Multiplan Evaluator Not Starting** - Fixed `:multiplan` command not triggering the evaluator/assessor instance. The issue was that plan completion was only detected when planner processes exited, not when they created their plan files. Added async plan file polling (similar to `:ultraplan`) to detect plan creation and properly trigger the evaluator once all 3 planners complete.
+- **Semicolon Input** - Fixed semicolons not being sent to Claude instances when using the persistent tmux connection. Semicolons are now properly quoted in tmux control mode commands to prevent them from being interpreted as command separators.
+- **Option+Arrow and Option+Backspace Keys** - Fixed Option+Arrow (Alt+Arrow) and Option+Backspace (Alt+Backspace) keys not working in Claude instances. Bubble Tea key names are now properly mapped to tmux key names (e.g., "left" → "Left", "backspace" → "BSpace").
 
 ## [0.6.1] - 2026-01-14
 

--- a/internal/instance/input/persistent_sender.go
+++ b/internal/instance/input/persistent_sender.go
@@ -406,7 +406,8 @@ func escapeForControlMode(s string) string {
 	// if it contains special characters. We use single quotes and escape
 	// any existing single quotes by ending the quote, adding escaped quote,
 	// and restarting the quote: ' -> '\''
-	if strings.ContainsAny(s, " \t\n\r'\"\\") {
+	// Note: semicolon (;) is a tmux command separator and must be quoted.
+	if strings.ContainsAny(s, " \t\n\r'\"\\;") {
 		escaped := strings.ReplaceAll(s, "'", "'\\''")
 		return "'" + escaped + "'"
 	}

--- a/internal/instance/input/persistent_sender_test.go
+++ b/internal/instance/input/persistent_sender_test.go
@@ -221,6 +221,21 @@ func TestEscapeForControlMode(t *testing.T) {
 			input:    "echo 'hello' | grep 'world'",
 			expected: "'echo '\\''hello'\\'' | grep '\\''world'\\'''",
 		},
+		{
+			name:     "string with semicolon",
+			input:    "foo;bar",
+			expected: "'foo;bar'",
+		},
+		{
+			name:     "javascript with semicolons",
+			input:    "const x = 1; const y = 2;",
+			expected: "'const x = 1; const y = 2;'",
+		},
+		{
+			name:     "semicolon only",
+			input:    ";",
+			expected: "';'",
+		},
 	}
 
 	for _, tt := range tests {
@@ -304,6 +319,18 @@ func TestPersistentTmuxSender_BuildCommand(t *testing.T) {
 			keys:     "hello world",
 			literal:  true,
 			expected: "send-keys -t my-session -l 'hello world'\n",
+		},
+		{
+			name:     "literal text with semicolon",
+			keys:     "foo;bar",
+			literal:  true,
+			expected: "send-keys -t my-session -l 'foo;bar'\n",
+		},
+		{
+			name:     "literal text with semicolon and spaces",
+			keys:     "console.log('hello'); return;",
+			literal:  true,
+			expected: "send-keys -t my-session -l 'console.log('\\''hello'\\''); return;'\n",
 		},
 	}
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -136,3 +136,41 @@ func ExtractInstanceID(socket string) string {
 	}
 	return ""
 }
+
+// MapKeyToTmux converts Bubble Tea key names to tmux key names.
+// Bubble Tea uses lowercase names like "left", "backspace" while
+// tmux expects capitalized names like "Left", "BSpace".
+func MapKeyToTmux(key string) string {
+	switch key {
+	case "up":
+		return "Up"
+	case "down":
+		return "Down"
+	case "left":
+		return "Left"
+	case "right":
+		return "Right"
+	case "home":
+		return "Home"
+	case "end":
+		return "End"
+	case "backspace":
+		return "BSpace"
+	case "delete":
+		return "DC"
+	case "insert":
+		return "IC"
+	case "pgup":
+		return "PageUp"
+	case "pgdown":
+		return "PageDown"
+	case "tab":
+		return "Tab"
+	case "enter":
+		return "Enter"
+	case "esc", "escape":
+		return "Escape"
+	default:
+		return key
+	}
+}

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -240,3 +240,42 @@ func TestExtractInstanceID(t *testing.T) {
 		})
 	}
 }
+
+func TestMapKeyToTmux(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// Arrow keys
+		{"up", "Up"},
+		{"down", "Down"},
+		{"left", "Left"},
+		{"right", "Right"},
+		// Navigation keys
+		{"home", "Home"},
+		{"end", "End"},
+		{"backspace", "BSpace"},
+		{"delete", "DC"},
+		{"insert", "IC"},
+		{"pgup", "PageUp"},
+		{"pgdown", "PageDown"},
+		// Other special keys
+		{"tab", "Tab"},
+		{"enter", "Enter"},
+		{"esc", "Escape"},
+		{"escape", "Escape"},
+		// Unknown keys should pass through unchanged
+		{"f1", "f1"},
+		{"unknown", "unknown"},
+		{"x", "x"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := MapKeyToTmux(tt.input)
+			if got != tt.expected {
+				t.Errorf("MapKeyToTmux(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -18,6 +18,7 @@ import (
 	instmetrics "github.com/Iron-Ham/claudio/internal/instance/metrics"
 	"github.com/Iron-Ham/claudio/internal/logging"
 	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/tmux"
 	"github.com/Iron-Ham/claudio/internal/tui/command"
 	"github.com/Iron-Ham/claudio/internal/tui/input"
 	"github.com/Iron-Ham/claudio/internal/tui/output"
@@ -1769,7 +1770,9 @@ func (m Model) sendKeyToTmux(mgr *instance.Manager, msg tea.KeyMsg) {
 			if len(baseKey) == 1 {
 				mgr.SendLiteral(baseKey)
 			} else {
-				mgr.SendKey(baseKey)
+				// Map Bubble Tea key names to tmux key names
+				tmuxKey := tmux.MapKeyToTmux(baseKey)
+				mgr.SendKey(tmuxKey)
 			}
 			return
 		case strings.HasPrefix(keyStr, "ctrl+"):

--- a/internal/tui/terminal/manager.go
+++ b/internal/tui/terminal/manager.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/Iron-Ham/claudio/internal/logging"
+	"github.com/Iron-Ham/claudio/internal/tmux"
 	"github.com/Iron-Ham/claudio/internal/tui/styles"
 )
 
@@ -649,7 +650,9 @@ func (m *Manager) SendKey(msg tea.KeyMsg) {
 			if len(baseKey) == 1 {
 				logKeyErr("SendLiteral", baseKey, m.process.SendLiteral(baseKey))
 			} else {
-				logKeyErr("SendKey", baseKey, m.process.SendKey(baseKey))
+				// Map Bubble Tea key names to tmux key names
+				tmuxKey := tmux.MapKeyToTmux(baseKey)
+				logKeyErr("SendKey", tmuxKey, m.process.SendKey(tmuxKey))
 			}
 			return
 		case strings.HasPrefix(keyStr, "ctrl+"):


### PR DESCRIPTION
## Summary

- **Semicolon fix**: Semicolons were not being sent to Claude instances when using the persistent tmux connection. The `escapeForControlMode()` function now includes `;` in the list of characters that need quoting to prevent tmux from interpreting them as command separators.

- **Option+Arrow/Backspace fix**: Option+Arrow (Alt+Arrow on macOS) and Option+Backspace keys were not working because Bubble Tea uses lowercase key names (e.g., `"left"`, `"backspace"`) while tmux expects capitalized names (e.g., `"Left"`, `"BSpace"`). Added a `MapKeyToTmux()` function to handle this translation.

## Test plan

- [x] Added test cases for semicolon escaping in `escapeForControlMode`
- [x] Added test cases for `MapKeyToTmux` key name mapping
- [x] All existing tests pass
- [x] Code formatting and linting pass