### PR TITLE
Expand tilde in ultraplan file paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Ultraplan File Path Tilde Expansion** - Fixed `:ultraplan --plan ~/path/to/file.yaml` failing because Go's `os.ReadFile()` doesn't expand shell shortcuts like `~`. Paths with `~/` prefix are now correctly expanded to the user's home directory.
 - **Multiplan Evaluator Not Starting** - Fixed `:multiplan` command not triggering the evaluator/assessor instance. The issue was that plan completion was only detected when planner processes exited, not when they created their plan files. Added async plan file polling (similar to `:ultraplan`) to detect plan creation and properly trigger the evaluator once all 3 planners complete.
 - **Semicolon Input** - Fixed semicolons not being sent to Claude instances when using the persistent tmux connection. Semicolons are now properly quoted in tmux control mode commands to prevent them from being interpreted as command separators.
 - **Option+Arrow and Option+Backspace Keys** - Fixed Option+Arrow (Alt+Arrow) and Option+Backspace (Alt+Backspace) keys not working in Claude instances. Bubble Tea key names are now properly mapped to tmux key names (e.g., "left" → "Left", "backspace" → "BSpace").

--- a/internal/tui/inlineplan.go
+++ b/internal/tui/inlineplan.go
@@ -61,7 +61,7 @@ func (m *Model) initInlineUltraPlanMode(result command.Result) {
 
 	// If loading from file, handle that case
 	if result.UltraPlanFromFile != nil && *result.UltraPlanFromFile != "" {
-		planPath := *result.UltraPlanFromFile
+		planPath := expandTildePath(*result.UltraPlanFromFile)
 		plan, err := orchestrator.ParsePlanFromFile(planPath, "")
 		if err != nil {
 			m.errorMessage = fmt.Sprintf("Failed to load plan: %v", err)
@@ -860,6 +860,18 @@ func truncateString(s string, maxLen int) string {
 		return s[:maxLen]
 	}
 	return s[:maxLen-3] + "..."
+}
+
+// expandTildePath expands a tilde prefix (~/) to the user's home directory.
+// Other path formats are returned unchanged.
+func expandTildePath(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			return home + path[1:]
+		}
+	}
+	return path
 }
 
 // getPlanForInlineEditor returns the plan for inline plan editing

--- a/internal/tui/inlineplan_test.go
+++ b/internal/tui/inlineplan_test.go
@@ -297,3 +297,39 @@ func TestStatFileFunction(t *testing.T) {
 		t.Error("expected error for nonexistent file")
 	}
 }
+
+func TestExpandTildePath(t *testing.T) {
+	// Test tilde expansion helper function
+	tests := []struct {
+		name     string
+		input    string
+		wantHome bool // true if result should start with home dir
+	}{
+		{"tilde prefix", "~/Desktop/plan.yaml", true},
+		{"absolute path", "/home/user/plan.yaml", false},
+		{"relative path", "plan.yaml", false},
+		{"tilde only", "~", false}, // Only ~/... gets expanded
+		{"tilde in middle", "/path/~/file", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := expandTildePath(tt.input)
+			if tt.wantHome {
+				// Should not contain tilde anymore
+				if len(result) > 0 && result[0] == '~' {
+					t.Errorf("expandTildePath(%q) = %q, still contains tilde", tt.input, result)
+				}
+				// Should be longer than input (home dir expanded)
+				if len(result) <= len(tt.input) {
+					t.Errorf("expandTildePath(%q) = %q, path not expanded", tt.input, result)
+				}
+			} else {
+				// Should be unchanged
+				if result != tt.input {
+					t.Errorf("expandTildePath(%q) = %q, want %q", tt.input, result, tt.input)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fixed `:ultraplan --plan ~/path/to/file.yaml` failing because Go's `os.ReadFile()` doesn't expand shell shortcuts like `~`
- Added `expandTildePath()` helper function that converts `~/` prefixed paths to absolute paths using `os.UserHomeDir()`
- Added comprehensive tests for the path expansion logic

## Test plan
- [x] Verify `:ultraplan --plan ~/Desktop/plan.yaml` expands the path correctly
- [x] Verify absolute paths like `/home/user/plan.yaml` remain unchanged
- [x] Verify relative paths like `plan.yaml` remain unchanged
- [x] Verify standalone `~` is not expanded (only `~/...` patterns)
- [x] All existing tests pass