### PR TITLE
Auto-dismiss TUI status messages after 5 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Multiplan Evaluator Not Starting** - Fixed `:multiplan` command not triggering the evaluator/assessor instance. The issue was that plan completion was only detected when planner processes exited, not when they created their plan files. Added async plan file polling (similar to `:ultraplan`) to detect plan creation and properly trigger the evaluator once all 3 planners complete.
 - **Semicolon Input** - Fixed semicolons not being sent to Claude instances when using the persistent tmux connection. Semicolons are now properly quoted in tmux control mode commands to prevent them from being interpreted as command separators.
 - **Option+Arrow and Option+Backspace Keys** - Fixed Option+Arrow (Alt+Arrow) and Option+Backspace (Alt+Backspace) keys not working in Claude instances. Bubble Tea key names are now properly mapped to tmux key names (e.g., "left" → "Left", "backspace" → "BSpace").
+- **Status Messages Auto-Dismiss** - Info and error messages in the TUI status bar now automatically clear after 5 seconds. Previously, messages like conflict watcher warnings would persist indefinitely until manually cleared or replaced.
 
 ## [0.6.1] - 2026-01-14
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -182,9 +182,11 @@ type Model struct {
 	// Triple-shot task state (for :tripleshot command)
 	startingTripleShot bool // When true, taskInput will start a triple-shot session
 
-	errorMessage string
-	infoMessage  string // Non-error status message
-	inputMode    bool   // When true, all keys are forwarded to the active instance's tmux session
+	errorMessage   string
+	infoMessage    string    // Non-error status message
+	messageSetAt   time.Time // When the current message was set (for auto-dismiss)
+	lastMessageKey string    // Used to detect message changes (concatenation of both messages)
+	inputMode      bool      // When true, all keys are forwarded to the active instance's tmux session
 
 	// Command mode state (vim-style ex commands with ':' prefix)
 	commandMode   bool   // When true, we're typing a command after ':'


### PR DESCRIPTION
## Summary
- Info and error messages in the TUI status bar now automatically clear after 5 seconds
- Prevents messages like conflict watcher warnings from persisting indefinitely until manually cleared
- Timer resets when a new message appears

## Test plan
- [x] Run existing tests: `go test ./internal/tui/... -run AutoDismiss -v`
- [ ] Manual test: Trigger a warning/error message and verify it disappears after ~5 seconds
- [ ] Manual test: Trigger a message, then trigger another before 5s, verify the timer resets