### PR TITLE
Fix first line highlighting for wrapped ultraplan tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Ultraplan Sidebar First Line Highlighting** - Fixed selected task highlighting not being applied to the first line of wrapped task names in ultraplan sidebar. When a task title wrapped to multiple lines, only continuation lines were highlighted because pre-applying `statusStyle.Render(icon)` embedded ANSI reset codes that broke the background color.
 - **Inline Ultraplan Group Linkage** - Fixed inline ultraplan (`:ultraplan` command) not properly linking the ultraplan session to its group. The `ultraSession.GroupID` was not being set when creating groups, which could cause coexistence issues with standard instances. Now all three inline ultraplan creation paths (from file, immediate objective, and interactive objective) correctly set the GroupID.
 - **Inline Ultraplan Consolidation Failure** - Fixed `:ultraplan --plan <file>` failing with "no task branches with verified commits found" after Group 1 completed. The inline ultraplan config was missing `RequireVerifiedCommits: true`, causing commit counts to never be recorded. Now uses `DefaultUltraPlanConfig()` to ensure proper defaults.
 - **CLI-Started Ultraplan/Tripleshot Grouping** - Fixed `claudio ultraplan` and `claudio tripleshot` commands not displaying as grouped entries in the TUI sidebar. CLI-started sessions now create instance groups and enable grouped sidebar mode, matching the behavior of inline commands (`:ultraplan`, `:tripleshot`).


### PR DESCRIPTION
## Summary
- Fixes highlighting not being applied to the first line of wrapped task names in ultraplan sidebar
- When a selected task's title wrapped to multiple lines, only continuation lines were highlighted
- Root cause: Pre-applying `statusStyle.Render(icon)` embedded ANSI reset codes that broke the background color

## Test plan
- [ ] Select a task in ultraplan sidebar with a long enough title to wrap
- [ ] Verify the first line (including the icon) is now highlighted with the purple background
- [ ] Verify continuation lines remain highlighted as before