### PR TITLE
Render ultraplan as collapsible group in standard sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Ultraplan Sidebar Coexistence** - Fixed ultraplan mode taking over the entire TUI sidebar, preventing navigation to standard instances. Ultraplans now render as collapsible groups within the standard grouped sidebar, allowing standard instances to run alongside ultraplans with proper navigation support.
 - **Ultraplan Sidebar First Line Highlighting** - Fixed selected task highlighting not being applied to the first line of wrapped task names in ultraplan sidebar. When a task title wrapped to multiple lines, only continuation lines were highlighted because pre-applying `statusStyle.Render(icon)` embedded ANSI reset codes that broke the background color.
 - **Inline Ultraplan Group Linkage** - Fixed inline ultraplan (`:ultraplan` command) not properly linking the ultraplan session to its group. The `ultraSession.GroupID` was not being set when creating groups, which could cause coexistence issues with standard instances. Now all three inline ultraplan creation paths (from file, immediate objective, and interactive objective) correctly set the GroupID.
 - **Inline Ultraplan Consolidation Failure** - Fixed `:ultraplan --plan <file>` failing with "no task branches with verified commits found" after Group 1 completed. The inline ultraplan config was missing `RequireVerifiedCommits: true`, causing commit counts to never be recorded. Now uses `DefaultUltraPlanConfig()` to ensure proper defaults.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -856,20 +856,22 @@ func (m Model) View() string {
 	mainAreaHeight := dims.MainAreaHeight
 
 	// Sidebar + Content area (horizontal layout)
-	// Use mode-specific rendering if applicable
+	// Use view component for sidebar rendering - handles all modes including ultraplan
+	// The SidebarView automatically handles flat, grouped, and ultraplan modes by
+	// rendering ultraplan content inline within its group when expanded
 	var sidebar, content string
-	if m.IsUltraPlanMode() {
-		sidebar = m.renderUltraPlanSidebar(effectiveSidebarWidth, mainAreaHeight)
-		content = m.renderUltraPlanContent(mainContentWidth)
-	} else if m.IsTripleShotMode() {
+	if m.IsTripleShotMode() {
 		sidebar = m.renderTripleShotSidebar(effectiveSidebarWidth, mainAreaHeight)
 		content = m.renderContent(mainContentWidth) // Reuse normal content for now
 	} else {
-		// Use view component for sidebar rendering
-		// SidebarView automatically handles both flat and grouped modes
 		sidebarView := view.NewSidebarView()
 		sidebar = sidebarView.RenderSidebar(m, effectiveSidebarWidth, mainAreaHeight)
-		content = m.renderContent(mainContentWidth)
+		// Use ultraplan content renderer when in ultraplan mode
+		if m.IsUltraPlanMode() {
+			content = m.renderUltraPlanContent(mainContentWidth)
+		} else {
+			content = m.renderContent(mainContentWidth)
+		}
 	}
 
 	// Apply height constraints to both panels and join horizontally

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -280,6 +280,30 @@ func (m Model) SidebarMode() view.SidebarMode {
 	return m.sidebarMode
 }
 
+// UltraPlanState returns the ultraplan state if in ultraplan mode.
+// Implements view.SidebarState interface.
+func (m Model) UltraPlanState() *view.UltraPlanState {
+	return m.ultraPlan
+}
+
+// Orchestrator returns the orchestrator for instance lookups.
+// Implements view.SidebarState interface.
+func (m Model) Orchestrator() *orchestrator.Orchestrator {
+	return m.orchestrator
+}
+
+// IsInstanceSelected returns true if the given instance ID is currently selected.
+// Implements view.SidebarState interface.
+func (m Model) IsInstanceSelected(instanceID string) bool {
+	if instanceID == "" {
+		return false
+	}
+	if m.activeTab >= 0 && m.activeTab < len(m.session.Instances) {
+		return m.session.Instances[m.activeTab].ID == instanceID
+	}
+	return false
+}
+
 // autoEnableGroupedMode switches to grouped sidebar mode when groups exist.
 // Call this after creating a new group to automatically show the grouped view.
 func (m *Model) autoEnableGroupedMode() {

--- a/internal/tui/view/group.go
+++ b/internal/tui/view/group.go
@@ -296,6 +296,15 @@ type GroupedInstance struct {
 	AbsoluteIdx int  // Absolute index in session.Instances for stable display numbering
 }
 
+// UltraPlanContentItem represents ultraplan phase content to be rendered inline within a group.
+// When an ultraplan group is expanded, this item replaces the individual instance items,
+// allowing the phase-based ultraplan sidebar to be rendered within the group.
+type UltraPlanContentItem struct {
+	UltraPlan *UltraPlanState
+	GroupID   string
+	Depth     int
+}
+
 // FlattenGroupsForDisplay flattens groups into a list of renderable items.
 // This respects collapsed state - collapsed groups won't have their instances expanded.
 // Returns both the group headers and the instances in display order.
@@ -340,6 +349,103 @@ type GroupHeaderItem struct {
 	Collapsed  bool
 	IsSelected bool
 	Depth      int
+}
+
+// FlattenGroupsForDisplayWithUltraPlan is like FlattenGroupsForDisplay but handles
+// ultraplan groups specially. When an ultraplan group is expanded, instead of showing
+// individual instances, it returns a single UltraPlanContentItem that will render
+// the phase-based ultraplan content.
+func FlattenGroupsForDisplayWithUltraPlan(session *orchestrator.Session, state *GroupViewState, ultraPlanGroupID string, ultraPlan *UltraPlanState) []any {
+	if session == nil {
+		return nil
+	}
+
+	var items []any
+	globalIdx := 0
+
+	// Build grouped sidebar data to identify ungrouped instances
+	data := BuildGroupedSidebarData(session)
+
+	// Add ungrouped instances first (they don't have a group header)
+	for i, inst := range data.UngroupedInstances {
+		isLast := i == len(data.UngroupedInstances)-1 && len(session.Groups) == 0
+		items = append(items, GroupedInstance{
+			Instance:    inst,
+			GroupID:     "", // No group
+			Depth:       -1, // Special depth to indicate ungrouped (no tree connector)
+			IsLast:      isLast,
+			GlobalIdx:   globalIdx,
+			AbsoluteIdx: findInstanceIndex(session, inst.ID),
+		})
+		globalIdx++
+	}
+
+	// Add groups
+	for _, group := range session.Groups {
+		items = append(items, flattenGroupRecursiveWithUltraPlan(group, session, state, 0, &globalIdx, ultraPlanGroupID, ultraPlan)...)
+	}
+
+	return items
+}
+
+// flattenGroupRecursiveWithUltraPlan is like flattenGroupRecursive but handles
+// ultraplan groups specially by returning UltraPlanContentItem instead of instances.
+func flattenGroupRecursiveWithUltraPlan(group *orchestrator.InstanceGroup, session *orchestrator.Session, state *GroupViewState, depth int, globalIdx *int, ultraPlanGroupID string, ultraPlan *UltraPlanState) []any {
+	var items []any
+
+	// Add group header
+	progress := CalculateGroupProgress(group, session)
+	collapsed := state.IsCollapsed(group.ID)
+	isSelected := state.SelectedGroupID == group.ID
+
+	items = append(items, GroupHeaderItem{
+		Group:      group,
+		Progress:   progress,
+		Collapsed:  collapsed,
+		IsSelected: isSelected,
+		Depth:      depth,
+	})
+
+	// If collapsed, don't add instances or sub-groups
+	if collapsed {
+		return items
+	}
+
+	// Check if this is the ultraplan group
+	if group.ID == ultraPlanGroupID && ultraPlan != nil {
+		// Instead of showing individual instances, show the ultraplan content
+		items = append(items, UltraPlanContentItem{
+			UltraPlan: ultraPlan,
+			GroupID:   group.ID,
+			Depth:     depth,
+		})
+		return items
+	}
+
+	// Add instances from this group (normal path)
+	for i, instID := range group.Instances {
+		inst := session.GetInstance(instID)
+		if inst == nil {
+			continue
+		}
+		isLast := i == len(group.Instances)-1 && len(group.SubGroups) == 0
+		items = append(items, GroupedInstance{
+			Instance:    inst,
+			GroupID:     group.ID,
+			Depth:       depth,
+			IsLast:      isLast,
+			GlobalIdx:   *globalIdx,
+			AbsoluteIdx: findInstanceIndex(session, instID),
+		})
+		*globalIdx++
+	}
+
+	// Add sub-groups
+	for _, subGroup := range group.SubGroups {
+		items = append(items, flattenGroupRecursiveWithUltraPlan(subGroup, session, state, depth+1, globalIdx, ultraPlanGroupID, ultraPlan)...)
+	}
+
+	return items
 }
 
 func flattenGroupRecursive(group *orchestrator.InstanceGroup, session *orchestrator.Session, state *GroupViewState, depth int, globalIdx *int) []any {

--- a/internal/tui/view/sidebar.go
+++ b/internal/tui/view/sidebar.go
@@ -31,6 +31,16 @@ type SidebarState interface {
 
 	// SidebarMode returns the current display mode.
 	SidebarMode() SidebarMode
+
+	// UltraPlanState returns the ultraplan state if in ultraplan mode.
+	// Returns nil if not in ultraplan mode.
+	UltraPlanState() *UltraPlanState
+
+	// Orchestrator returns the orchestrator for instance lookups.
+	Orchestrator() *orchestrator.Orchestrator
+
+	// IsInstanceSelected returns true if the given instance ID is currently selected.
+	IsInstanceSelected(instanceID string) bool
 }
 
 // SidebarView handles rendering of the sidebar in both flat and grouped modes.
@@ -91,8 +101,17 @@ func (sv *SidebarView) RenderGroupedSidebar(state SidebarState, width, height in
 	}
 	availableSlots := max(height-reservedLines, 5)
 
-	// Get flattened items for display
-	items := FlattenGroupsForDisplay(session, groupState)
+	// Get ultraplan state and group ID for special rendering
+	ultraPlanState := state.UltraPlanState()
+	var ultraPlanGroupID string
+	if ultraPlanState != nil && ultraPlanState.Coordinator != nil {
+		if upSession := ultraPlanState.Coordinator.Session(); upSession != nil {
+			ultraPlanGroupID = upSession.GroupID
+		}
+	}
+
+	// Get flattened items for display (with ultraplan-aware flattening)
+	items := FlattenGroupsForDisplayWithUltraPlan(session, groupState, ultraPlanGroupID, ultraPlanState)
 	if len(items) == 0 && !isAddingTask {
 		b.WriteString(styles.Muted.Render("No instances"))
 		b.WriteString("\n")
@@ -139,6 +158,11 @@ func (sv *SidebarView) RenderGroupedSidebar(state SidebarState, width, height in
 				line := RenderGroupedInstance(v, isActive, hasConflict, width)
 				b.WriteString(line)
 				b.WriteString("\n")
+
+			case UltraPlanContentItem:
+				// Render ultraplan phase content within the group
+				content := sv.renderUltraPlanContent(v, state, width-4, availableSlots-(i-startIdx))
+				b.WriteString(content)
 			}
 		}
 
@@ -175,6 +199,40 @@ func (sv *SidebarView) RenderGroupedSidebar(state SidebarState, width, height in
 
 	// Wrap in sidebar box
 	return styles.Sidebar.Width(width - 2).Render(b.String())
+}
+
+// renderUltraPlanContent renders the ultraplan phase content inline within a group.
+func (sv *SidebarView) renderUltraPlanContent(item UltraPlanContentItem, state SidebarState, width, maxLines int) string {
+	if item.UltraPlan == nil || item.UltraPlan.Coordinator == nil {
+		return ""
+	}
+
+	upSession := item.UltraPlan.Coordinator.Session()
+	if upSession == nil {
+		return ""
+	}
+
+	// Create a render context for the ultraplan view
+	ctx := &RenderContext{
+		Orchestrator: state.Orchestrator(),
+		Session:      state.Session(),
+		UltraPlan:    item.UltraPlan,
+		ActiveTab:    state.ActiveTab(),
+		Width:        width,
+		Height:       maxLines,
+		GetInstance: func(id string) *orchestrator.Instance {
+			if orch := state.Orchestrator(); orch != nil {
+				return orch.GetInstance(id)
+			}
+			return nil
+		},
+		IsSelected: func(instanceID string) bool {
+			return state.IsInstanceSelected(instanceID)
+		},
+	}
+
+	v := NewUltraplanView(ctx)
+	return v.RenderInlineContent(width, maxLines)
 }
 
 // buildConflictMap creates a map of instance IDs that have conflicts.

--- a/internal/tui/view/sidebar_test.go
+++ b/internal/tui/view/sidebar_test.go
@@ -33,6 +33,16 @@ func (m *mockSidebarState) IsAddingTask() bool                 { return m.isAddi
 func (m *mockSidebarState) IntelligentNamingEnabled() bool     { return m.intelligentNamingEnabled }
 func (m *mockSidebarState) GroupViewState() *GroupViewState    { return m.groupViewState }
 func (m *mockSidebarState) SidebarMode() SidebarMode           { return m.sidebarMode }
+func (m *mockSidebarState) UltraPlanState() *UltraPlanState    { return nil }
+func (m *mockSidebarState) Orchestrator() *orchestrator.Orchestrator {
+	return nil
+}
+func (m *mockSidebarState) IsInstanceSelected(instanceID string) bool {
+	if m.session == nil || m.activeTab < 0 || m.activeTab >= len(m.session.Instances) {
+		return false
+	}
+	return m.session.Instances[m.activeTab].ID == instanceID
+}
 
 func TestSidebarView_FlatModeFallback(t *testing.T) {
 	// When in flat mode, should render like DashboardView


### PR DESCRIPTION
## Summary
- Ultraplans in TUI mode now render as collapsible groups within the standard grouped sidebar instead of taking over the entire sidebar UI
- Standard instances can now run alongside ultraplans with proper navigation support
- Navigation with `tab`/`l` cycles through ALL instances (both ultraplan and standard)

## Changes
- Extended `SidebarState` interface with `UltraPlanState()`, `Orchestrator()`, and `IsInstanceSelected()` methods
- Added `FlattenGroupsForDisplayWithUltraPlan` to handle ultraplan groups specially
- Created `RenderInlineContent` for rendering ultraplan phase information inline within a group
- Updated `getNavigableInstances` to include both ultraplan and standard instances
- Removed unused `renderUltraPlanSidebar` function (ultraplan now uses standard sidebar)

## Test plan
- [x] All tests pass (`go test ./...`)
- [x] Build succeeds (`go build ./...`)
- [x] Linting passes (`go vet ./...`, `gofmt`)
- [ ] Manual testing: Start an ultraplan, add a standard task, verify navigation works between both
- [ ] Verify ultraplan group can be collapsed/expanded with `gc` or `Space`
- [ ] Verify `J/K` navigation between groups works correctly