### PR TITLE
Require mandatory changelog entries for all pull requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,20 +176,22 @@ This project uses standard Go testing conventions:
 
 This project maintains a [CHANGELOG.md](CHANGELOG.md) following the [Keep a Changelog](https://keepachangelog.com/) format. The changelog has an **Unreleased** section at the top where changes accumulate until the next release.
 
-### When to Update
+### MANDATORY: Every Pull Request MUST Include a Changelog Entry
 
-Add an entry to the Unreleased section when making:
-- **New features** (`### Added`)
-- **Bug fixes** (`### Fixed`)
-- **Performance improvements** (`### Performance`)
-- **Breaking changes** (`### Changed` or `### Removed`)
-- **Deprecations** (`### Deprecated`)
+**NO EXCEPTIONS.** Every pull request must add an entry to the `## [Unreleased]` section of CHANGELOG.md. This requirement is absolute and applies to all changes, regardless of size or type.
 
-Skip changelog entries for:
-- Internal refactors that don't change behavior
-- Test-only changes
-- Documentation-only changes (unless significant)
-- Dependency updates (unless they fix bugs or add features)
+Use the appropriate category for your change:
+- **New features** → `### Added`
+- **Bug fixes** → `### Fixed`
+- **Performance improvements** → `### Performance`
+- **Breaking changes** → `### Changed` or `### Removed`
+- **Deprecations** → `### Deprecated`
+- **Internal refactors** → `### Changed`
+- **Test improvements** → `### Changed`
+- **Documentation updates** → `### Changed`
+- **Dependency updates** → `### Changed`
+
+If you're unsure which category to use, use `### Changed`.
 
 ### Entry Format
 
@@ -222,7 +224,7 @@ Before committing, ensure:
 3. Build succeeds: `go build ./...`
 4. All tests pass: `go test ./...`
 5. New code has tests with reasonable coverage
-6. Notable changes have a CHANGELOG.md entry (see above)
+6. **CHANGELOG.md has been updated (MANDATORY - NO EXCEPTIONS)**
 
 ## Project Structure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Mandatory Changelog Entries** - AGENTS.md now requires a changelog entry for every pull request with no exceptions. Previously allowed skipping changelog for internal refactors, test-only changes, documentation-only changes, and dependency updates.
 - **Instance Header Simplified** - Removed redundant status badge from instance detail header since task state is already displayed in the sidebar with 4-character abbreviations (WAIT, WORK, DONE, etc.)
 - **TUI Architecture Refactored** - Major restructuring of the TUI codebase: extracted `app.go` into focused packages (`msg/`, `filter/`, `update/`, `search/`, `view/`, `input/`), reducing it from ~3700 to 1369 lines (63% reduction). Added 14 new test files with comprehensive coverage. This creates a cleaner foundation for future TUI enhancements. (#443)
 


### PR DESCRIPTION
## Summary
- Updates AGENTS.md to require a changelog entry for every pull request with **no exceptions**
- Removes the list of change types that could previously skip changelog entries (internal refactors, test-only changes, documentation-only changes, dependency updates)
- Provides category guidance for all change types, including a fallback to "Changed" when unsure
- Updates the pre-commit checklist to emphasize the mandatory nature

## Test plan
- [ ] Review the AGENTS.md changes to ensure the requirements are clear
- [ ] Verify the changelog entry format guidance covers all change types