### PR TITLE
Consolidate ultraplan initialization - Part 2: Coordinator factory

### DIFF
--- a/internal/cmd/ultraplan.go
+++ b/internal/cmd/ultraplan.go
@@ -12,6 +12,7 @@ import (
 	orchsession "github.com/Iron-Ham/claudio/internal/orchestrator/session"
 	sessutil "github.com/Iron-Ham/claudio/internal/session"
 	"github.com/Iron-Ham/claudio/internal/tui"
+	"github.com/Iron-Ham/claudio/internal/ultraplan"
 	"github.com/Iron-Ham/claudio/internal/util"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -127,38 +128,9 @@ func runUltraplan(cmd *cobra.Command, args []string) error {
 	sessionID := orchsession.GenerateID()
 	cfg := config.Get()
 
-	// Create ultra-plan configuration from defaults, then override with config file, then flags
-	ultraConfig := orchestrator.DefaultUltraPlanConfig()
-
-	// Apply config file settings
-	ultraConfig.MaxParallel = cfg.Ultraplan.MaxParallel
-	ultraConfig.MultiPass = cfg.Ultraplan.MultiPass
-
-	// Apply consolidation settings from config
-	if cfg.Ultraplan.ConsolidationMode != "" {
-		ultraConfig.ConsolidationMode = orchestrator.ConsolidationMode(cfg.Ultraplan.ConsolidationMode)
-	}
-	ultraConfig.CreateDraftPRs = cfg.Ultraplan.CreateDraftPRs
-	if len(cfg.Ultraplan.PRLabels) > 0 {
-		ultraConfig.PRLabels = cfg.Ultraplan.PRLabels
-	}
-	ultraConfig.BranchPrefix = cfg.Ultraplan.BranchPrefix
-
-	// Apply task verification settings from config
-	ultraConfig.MaxTaskRetries = cfg.Ultraplan.MaxTaskRetries
-	ultraConfig.RequireVerifiedCommits = cfg.Ultraplan.RequireVerifiedCommits
-
-	// CLI flags override config file (only if explicitly set)
-	if cmd.Flags().Changed("max-parallel") {
-		ultraConfig.MaxParallel = ultraplanMaxParallel
-	}
-	if cmd.Flags().Changed("multi-pass") {
-		ultraConfig.MultiPass = ultraplanMultiPass
-	}
-	ultraConfig.DryRun = ultraplanDryRun
-	ultraConfig.NoSynthesis = ultraplanNoSynthesis
-	ultraConfig.AutoApprove = ultraplanAutoApprove
-	ultraConfig.Review = ultraplanReview
+	// Build ultraplan config from app config, then apply CLI flag overrides
+	ultraConfig := ultraplan.BuildConfigFromAppConfig(cfg)
+	applyUltraplanFlagOverrides(cmd, &ultraConfig)
 
 	// Create logger if enabled - we need session dir which requires session ID
 	sessionDir := sessutil.GetSessionDir(cwd, sessionID)
@@ -190,17 +162,7 @@ func runUltraplan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to start session: %w", err)
 	}
 
-	// Log startup with objective (truncated) and config summary
-	logger.Info("ultraplan started",
-		"session_id", sessionID,
-		"objective", util.TruncateString(objective, 100),
-		"max_parallel", ultraConfig.MaxParallel,
-		"multi_pass", ultraConfig.MultiPass,
-		"dry_run", ultraConfig.DryRun,
-		"auto_approve", ultraConfig.AutoApprove,
-	)
-
-	// Create or load the plan
+	// Load plan file if provided
 	var plan *orchestrator.PlanSpec
 	if ultraplanPlanFile != "" {
 		plan, err = loadPlanFile(ultraplanPlanFile)
@@ -210,18 +172,38 @@ func runUltraplan(cmd *cobra.Command, args []string) error {
 		objective = plan.Objective
 	}
 
-	// Create ultra-plan session
-	ultraSession := orchestrator.NewUltraPlanSession(objective, ultraConfig)
-	if plan != nil {
-		ultraSession.Plan = plan
-		ultraSession.Phase = orchestrator.PhaseRefresh // Skip to refresh if plan provided
+	// Initialize ultraplan using shared initialization
+	initParams := ultraplan.InitParams{
+		Orchestrator: orch,
+		Session:      session,
+		Objective:    objective,
+		Config:       &ultraConfig,
+		Plan:         plan,
+		Logger:       logger,
+		CreateGroup:  false, // CLI TUI handles group creation separately
 	}
 
-	// Link ultra-plan session to main session for persistence
-	session.UltraPlan = ultraSession
+	var initResult *ultraplan.InitResult
+	if plan != nil {
+		// Use InitWithPlan for additional validation (plan already validated in loadPlanFile,
+		// but InitWithPlan also calls SetPlan to ensure coordinator state is synchronized)
+		initResult, err = ultraplan.InitWithPlan(initParams, plan)
+		if err != nil {
+			return fmt.Errorf("failed to initialize ultraplan with plan: %w", err)
+		}
+	} else {
+		initResult = ultraplan.Init(initParams)
+	}
 
-	// Create coordinator with logger
-	coordinator := orchestrator.NewCoordinator(orch, session, ultraSession, logger)
+	// Log startup with objective (truncated) and config summary
+	logger.Info("ultraplan started",
+		"session_id", sessionID,
+		"objective", util.TruncateString(objective, 100),
+		"max_parallel", initResult.Config.MaxParallel,
+		"multi_pass", initResult.Config.MultiPass,
+		"dry_run", initResult.Config.DryRun,
+		"auto_approve", initResult.Config.AutoApprove,
+	)
 
 	// Get terminal dimensions
 	if termWidth, termHeight, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
@@ -232,12 +214,28 @@ func runUltraplan(cmd *cobra.Command, args []string) error {
 	}
 
 	// Launch TUI with ultra-plan mode
-	app := tui.NewWithUltraPlan(orch, session, coordinator, logger.WithSession(session.ID))
+	app := tui.NewWithUltraPlan(orch, session, initResult.Coordinator, logger.WithSession(session.ID))
 	if err := app.Run(); err != nil {
 		return fmt.Errorf("TUI error: %w", err)
 	}
 
 	return nil
+}
+
+// applyUltraplanFlagOverrides applies CLI flag values to the ultraplan config.
+// Flags only override config file values when explicitly set by the user.
+func applyUltraplanFlagOverrides(cmd *cobra.Command, cfg *orchestrator.UltraPlanConfig) {
+	if cmd.Flags().Changed("max-parallel") {
+		cfg.MaxParallel = ultraplanMaxParallel
+	}
+	if cmd.Flags().Changed("multi-pass") {
+		cfg.MultiPass = ultraplanMultiPass
+	}
+	// These flags always apply (no "changed" check needed since they have sensible defaults)
+	cfg.DryRun = ultraplanDryRun
+	cfg.NoSynthesis = ultraplanNoSynthesis
+	cfg.AutoApprove = ultraplanAutoApprove
+	cfg.Review = ultraplanReview
 }
 
 // promptObjective prompts the user to enter an objective

--- a/internal/ultraplan/init.go
+++ b/internal/ultraplan/init.go
@@ -292,6 +292,8 @@ func InitWithPlan(params InitParams, plan *orchestrator.PlanSpec) (*InitResult, 
 	result := Init(params)
 
 	// Set the plan on the coordinator (ensures all internal state is updated)
+	// Coverage: This error branch is unreachable because ValidatePlan above validates
+	// the same conditions that SetPlan checks, so a valid plan will never fail here.
 	if err := result.Coordinator.SetPlan(plan); err != nil {
 		return nil, err
 	}

--- a/internal/ultraplan/init_integration_test.go
+++ b/internal/ultraplan/init_integration_test.go
@@ -1,0 +1,442 @@
+//go:build integration
+
+package ultraplan
+
+import (
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/testutil"
+)
+
+// TestInit_FullIntegration tests the Init function with a real orchestrator.
+// This exercises the complete initialization path that creates a Coordinator.
+func TestInit_FullIntegration(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	tests := []struct {
+		name        string
+		objective   string
+		config      *orchestrator.UltraPlanConfig
+		plan        *orchestrator.PlanSpec
+		createGroup bool
+		wantPhase   orchestrator.UltraPlanPhase
+		wantGroup   bool
+	}{
+		{
+			name:      "basic init without group creates coordinator",
+			objective: "Test objective",
+			config: &orchestrator.UltraPlanConfig{
+				MaxParallel: 5,
+			},
+			createGroup: false,
+			wantPhase:   orchestrator.PhasePlanning,
+			wantGroup:   false,
+		},
+		{
+			name:      "init with group creates and links group",
+			objective: "Group test objective",
+			config: &orchestrator.UltraPlanConfig{
+				MaxParallel: 3,
+				MultiPass:   false,
+			},
+			createGroup: true,
+			wantPhase:   orchestrator.PhasePlanning,
+			wantGroup:   true,
+		},
+		{
+			name:      "init with multi-pass creates PlanMulti group type",
+			objective: "Multi-pass test",
+			config: &orchestrator.UltraPlanConfig{
+				MaxParallel: 3,
+				MultiPass:   true,
+			},
+			createGroup: true,
+			wantPhase:   orchestrator.PhasePlanning,
+			wantGroup:   true,
+		},
+		{
+			name:      "init with pre-loaded plan sets phase to refresh",
+			objective: "Plan loaded test",
+			config: &orchestrator.UltraPlanConfig{
+				MaxParallel: 3,
+			},
+			plan: &orchestrator.PlanSpec{
+				ID:        "test-plan",
+				Objective: "Plan objective",
+				Tasks: []orchestrator.PlannedTask{
+					{ID: "task-1", Title: "Test task", DependsOn: []string{}},
+				},
+				DependencyGraph: map[string][]string{"task-1": {}},
+				ExecutionOrder:  [][]string{{"task-1"}},
+			},
+			createGroup: false,
+			wantPhase:   orchestrator.PhaseRefresh,
+			wantGroup:   false,
+		},
+		{
+			name:      "init with nil config uses defaults",
+			objective: "Default config test",
+			config:    nil,
+			wantPhase: orchestrator.PhasePlanning,
+			wantGroup: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup test repository and orchestrator
+			repoDir := testutil.SetupTestRepo(t)
+			orch, err := orchestrator.New(repoDir)
+			if err != nil {
+				t.Fatalf("failed to create orchestrator: %v", err)
+			}
+			if err := orch.Init(); err != nil {
+				t.Fatalf("failed to init orchestrator: %v", err)
+			}
+
+			// Start a session
+			session, err := orch.StartSession("test-session")
+			if err != nil {
+				t.Fatalf("failed to start session: %v", err)
+			}
+
+			// Build params
+			params := InitParams{
+				Orchestrator: orch,
+				Session:      session,
+				Objective:    tt.objective,
+				Config:       tt.config,
+				Plan:         tt.plan,
+				CreateGroup:  tt.createGroup,
+			}
+
+			result := Init(params)
+
+			// Verify result is not nil
+			if result == nil {
+				t.Fatal("Init returned nil")
+			}
+
+			// Verify Coordinator is created
+			if result.Coordinator == nil {
+				t.Error("Coordinator should not be nil")
+			}
+
+			// Verify UltraSession is created
+			if result.UltraSession == nil {
+				t.Fatal("UltraSession should not be nil")
+			}
+
+			// Verify phase
+			if result.UltraSession.Phase != tt.wantPhase {
+				t.Errorf("Phase = %v, want %v", result.UltraSession.Phase, tt.wantPhase)
+			}
+
+			// Verify group creation
+			if tt.wantGroup {
+				if result.Group == nil {
+					t.Error("Group should be created when CreateGroup is true")
+				}
+				if result.UltraSession.GroupID == "" {
+					t.Error("GroupID should be set when CreateGroup is true")
+				}
+				if result.UltraSession.GroupID != result.Group.ID {
+					t.Error("GroupID should match result.Group.ID")
+				}
+			} else {
+				if result.Group != nil {
+					t.Error("Group should not be created when CreateGroup is false")
+				}
+			}
+
+			// Verify session is linked to ultraplan
+			if session.UltraPlan != result.UltraSession {
+				t.Error("Session.UltraPlan should be linked to the result UltraSession")
+			}
+
+			// Verify config is populated
+			if tt.config == nil {
+				// Should use defaults
+				defaults := orchestrator.DefaultUltraPlanConfig()
+				if result.Config.MaxParallel != defaults.MaxParallel {
+					t.Errorf("MaxParallel = %d, want default %d",
+						result.Config.MaxParallel, defaults.MaxParallel)
+				}
+			} else {
+				if result.Config.MaxParallel != tt.config.MaxParallel {
+					t.Errorf("MaxParallel = %d, want %d",
+						result.Config.MaxParallel, tt.config.MaxParallel)
+				}
+			}
+
+			// Verify plan handling
+			if tt.plan != nil {
+				if result.UltraSession.Plan == nil {
+					t.Error("Plan should be set on UltraSession")
+				}
+			}
+		})
+	}
+}
+
+// TestInit_ObjectivePrecedence tests that Init correctly determines the objective
+// from params or from a pre-loaded plan.
+func TestInit_ObjectivePrecedence(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	tests := []struct {
+		name          string
+		objective     string
+		planObjective string
+		wantObjective string
+	}{
+		{
+			name:          "objective from params when no plan",
+			objective:     "Params objective",
+			planObjective: "",
+			wantObjective: "Params objective",
+		},
+		{
+			name:          "plan objective takes precedence",
+			objective:     "Params objective",
+			planObjective: "Plan objective",
+			wantObjective: "Plan objective",
+		},
+		{
+			name:          "params objective used when plan objective empty",
+			objective:     "Fallback to params",
+			planObjective: "",
+			wantObjective: "Fallback to params",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoDir := testutil.SetupTestRepo(t)
+			orch, err := orchestrator.New(repoDir)
+			if err != nil {
+				t.Fatalf("failed to create orchestrator: %v", err)
+			}
+			if err := orch.Init(); err != nil {
+				t.Fatalf("failed to init orchestrator: %v", err)
+			}
+
+			session, err := orch.StartSession("test-session")
+			if err != nil {
+				t.Fatalf("failed to start session: %v", err)
+			}
+
+			var plan *orchestrator.PlanSpec
+			if tt.planObjective != "" {
+				plan = &orchestrator.PlanSpec{
+					ID:              "test-plan",
+					Objective:       tt.planObjective,
+					Tasks:           []orchestrator.PlannedTask{{ID: "task-1", Title: "Task", DependsOn: []string{}}},
+					DependencyGraph: map[string][]string{"task-1": {}},
+					ExecutionOrder:  [][]string{{"task-1"}},
+				}
+			}
+
+			result := Init(InitParams{
+				Orchestrator: orch,
+				Session:      session,
+				Objective:    tt.objective,
+				Config:       &orchestrator.UltraPlanConfig{MaxParallel: 3},
+				Plan:         plan,
+			})
+
+			if result.UltraSession.Objective != tt.wantObjective {
+				t.Errorf("Objective = %q, want %q",
+					result.UltraSession.Objective, tt.wantObjective)
+			}
+		})
+	}
+}
+
+// TestInit_GroupSessionTypes verifies correct SessionType on created groups.
+func TestInit_GroupSessionTypes(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	tests := []struct {
+		name            string
+		multiPass       bool
+		wantSessionType orchestrator.SessionType
+	}{
+		{
+			name:            "single-pass creates UltraPlan type",
+			multiPass:       false,
+			wantSessionType: orchestrator.SessionTypeUltraPlan,
+		},
+		{
+			name:            "multi-pass creates PlanMulti type",
+			multiPass:       true,
+			wantSessionType: orchestrator.SessionTypePlanMulti,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoDir := testutil.SetupTestRepo(t)
+			orch, err := orchestrator.New(repoDir)
+			if err != nil {
+				t.Fatalf("failed to create orchestrator: %v", err)
+			}
+			if err := orch.Init(); err != nil {
+				t.Fatalf("failed to init orchestrator: %v", err)
+			}
+
+			session, err := orch.StartSession("test-session")
+			if err != nil {
+				t.Fatalf("failed to start session: %v", err)
+			}
+
+			result := Init(InitParams{
+				Orchestrator: orch,
+				Session:      session,
+				Objective:    "Test group types",
+				Config: &orchestrator.UltraPlanConfig{
+					MaxParallel: 3,
+					MultiPass:   tt.multiPass,
+				},
+				CreateGroup: true,
+			})
+
+			if result.Group == nil {
+				t.Fatal("Group should be created")
+			}
+
+			if result.Group.SessionType != tt.wantSessionType {
+				t.Errorf("Group.SessionType = %v, want %v",
+					result.Group.SessionType, tt.wantSessionType)
+			}
+		})
+	}
+}
+
+// TestInitWithPlan_FullIntegration tests the InitWithPlan function with a real orchestrator.
+func TestInitWithPlan_FullIntegration(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir := testutil.SetupTestRepo(t)
+	orch, err := orchestrator.New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create orchestrator: %v", err)
+	}
+	if err := orch.Init(); err != nil {
+		t.Fatalf("failed to init orchestrator: %v", err)
+	}
+
+	session, err := orch.StartSession("test-session")
+	if err != nil {
+		t.Fatalf("failed to start session: %v", err)
+	}
+
+	plan := &orchestrator.PlanSpec{
+		ID:        "test-plan",
+		Objective: "Test InitWithPlan",
+		Summary:   "Test summary",
+		Tasks: []orchestrator.PlannedTask{
+			{ID: "task-1", Title: "Task 1", DependsOn: []string{}},
+			{ID: "task-2", Title: "Task 2", DependsOn: []string{"task-1"}},
+		},
+		DependencyGraph: map[string][]string{
+			"task-1": {},
+			"task-2": {"task-1"},
+		},
+		ExecutionOrder: [][]string{{"task-1"}, {"task-2"}},
+	}
+
+	params := InitParams{
+		Orchestrator: orch,
+		Session:      session,
+		Objective:    "Params objective",
+		Config: &orchestrator.UltraPlanConfig{
+			MaxParallel: 3,
+		},
+	}
+
+	result, err := InitWithPlan(params, plan)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify result fields
+	if result.Coordinator == nil {
+		t.Error("Coordinator should not be nil")
+	}
+	if result.UltraSession == nil {
+		t.Error("UltraSession should not be nil")
+	}
+	if result.UltraSession.Plan == nil {
+		t.Error("Plan should be set on UltraSession")
+	}
+	if result.UltraSession.Phase != orchestrator.PhaseRefresh {
+		t.Errorf("Phase = %v, want %v", result.UltraSession.Phase, orchestrator.PhaseRefresh)
+	}
+
+	// Verify the plan is accessible through the coordinator
+	coordSession := result.Coordinator.Session()
+	if coordSession == nil {
+		t.Fatal("Coordinator.Session() returned nil")
+	}
+	if coordSession.Plan == nil {
+		t.Error("Plan should be set on coordinator's session")
+	}
+	if coordSession.Plan.ID != plan.ID {
+		t.Errorf("Plan ID = %q, want %q", coordSession.Plan.ID, plan.ID)
+	}
+}
+
+// TestInitWithPlan_WithGroupCreation tests that InitWithPlan works correctly
+// when CreateGroup is true.
+func TestInitWithPlan_WithGroupCreation(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	repoDir := testutil.SetupTestRepo(t)
+	orch, err := orchestrator.New(repoDir)
+	if err != nil {
+		t.Fatalf("failed to create orchestrator: %v", err)
+	}
+	if err := orch.Init(); err != nil {
+		t.Fatalf("failed to init orchestrator: %v", err)
+	}
+
+	session, err := orch.StartSession("test-session")
+	if err != nil {
+		t.Fatalf("failed to start session: %v", err)
+	}
+
+	plan := &orchestrator.PlanSpec{
+		ID:              "test-plan",
+		Objective:       "Test with group",
+		Tasks:           []orchestrator.PlannedTask{{ID: "task-1", Title: "Task 1", DependsOn: []string{}}},
+		DependencyGraph: map[string][]string{"task-1": {}},
+		ExecutionOrder:  [][]string{{"task-1"}},
+	}
+
+	params := InitParams{
+		Orchestrator: orch,
+		Session:      session,
+		Objective:    "Params objective",
+		Config: &orchestrator.UltraPlanConfig{
+			MaxParallel: 3,
+		},
+		CreateGroup: true,
+	}
+
+	result, err := InitWithPlan(params, plan)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Group == nil {
+		t.Error("Group should be created")
+	}
+	if result.UltraSession.GroupID == "" {
+		t.Error("GroupID should be set")
+	}
+	if result.UltraSession.GroupID != result.Group.ID {
+		t.Error("GroupID should match result.Group.ID")
+	}
+}


### PR DESCRIPTION
## Summary

This is **Part 2 of 4** in a stacked PR series that consolidates duplicate ultraplan initialization code between CLI and TUI paths.

**This PR introduces:**
- `Init()` factory function that combines config building, session creation, coordinator initialization, and optional group creation
- `InitWithPlan()` convenience function for initializing with a pre-loaded plan
- `InitParams` and `InitResult` structs for clean API design

### Changes
- `internal/ultraplan/init.go` - Added `Init()` and `InitWithPlan()` factory functions

## Test plan
- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test ./...` passes
- [ ] Factory functions provide a single cohesive initialization path

## Stack
- Part 1: Shared helpers and utilities
- **→ Part 2** (this PR): Coordinator factory
- Part 3: Tests and TUI integration
- Part 4: CLI and resume refactoring

**Depends on:** #452