### PR TITLE
Add intelligent expand/collapse for ultraplan execution groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Changelog CI Check** - PRs now require a CHANGELOG.md entry. Add the `skip-changelog` label to bypass for trivial changes (test-only, internal refactors, docs-only, dependency updates).
 - **Multi-Pass Plan Mode** (Experimental) - New `:multiplan` (or `:mp`) command launches competitive multi-pass planning with 3 parallel planners using different strategies (maximize-parallelism, minimize-complexity, balanced-approach) plus a plan manager/assessor that evaluates and merges the best plan. This provides the same competitive planning approach as `:ultraplan --multi-pass` but within the simpler inline plan workflow.
+- **Ultraplan Group Expand/Collapse** - Execution groups in ultraplan sessions now support intelligent expand/collapse behavior. By default, only the currently active group is expanded; past and future groups are collapsed. When execution moves to a new group, it auto-expands and the previous group auto-collapses (unless you're viewing a task from that group). Groups show ▼/▶ indicators and can be manually toggled via group navigation mode (press `g` to enter, then `j/k` to navigate and `Enter`/`Space` to toggle). Collapsed groups display a summary showing completion progress like `[✓ 3/5]`. Tasks in collapsed groups are not navigable until the group is expanded.
 
 ### Changed
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -63,8 +63,9 @@ func NewWithUltraPlan(orch *orchestrator.Orchestrator, session *orchestrator.Ses
 	}
 
 	model.ultraPlan = &UltraPlanState{
-		Coordinator:  coordinator,
-		ShowPlanView: false,
+		Coordinator:           coordinator,
+		ShowPlanView:          false,
+		LastAutoExpandedGroup: -1, // Sentinel value to trigger initial expansion
 	}
 	return &App{
 		model:        model,
@@ -345,6 +346,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.ultraPlan.NeedsNotification = false
 			cmds = append(cmds, tuimsg.NotifyUser())
 		}
+
+		// Update ultraplan group collapse state when current group changes
+		m.updateGroupCollapseState()
+
 		return m, tea.Batch(cmds...)
 
 	case tuimsg.UltraPlanInitMsg:

--- a/internal/tui/inlineplan.go
+++ b/internal/tui/inlineplan.go
@@ -127,8 +127,9 @@ func (m *Model) initInlineUltraPlanMode(result command.Result) {
 		m.autoEnableGroupedMode()
 
 		m.ultraPlan = &view.UltraPlanState{
-			Coordinator:  coordinator,
-			ShowPlanView: false,
+			Coordinator:           coordinator,
+			ShowPlanView:          false,
+			LastAutoExpandedGroup: -1,
 		}
 
 		// Enter plan editor for review
@@ -172,8 +173,9 @@ func (m *Model) initInlineUltraPlanMode(result command.Result) {
 		}
 
 		m.ultraPlan = &view.UltraPlanState{
-			Coordinator:  coordinator,
-			ShowPlanView: false,
+			Coordinator:           coordinator,
+			ShowPlanView:          false,
+			LastAutoExpandedGroup: -1,
 		}
 		m.infoMessage = "Planning started..."
 		return
@@ -701,8 +703,9 @@ func (m *Model) handleUltraPlanObjectiveSubmit(objective string) {
 	}
 
 	m.ultraPlan = &view.UltraPlanState{
-		Coordinator:  coordinator,
-		ShowPlanView: false,
+		Coordinator:           coordinator,
+		ShowPlanView:          false,
+		LastAutoExpandedGroup: -1,
 	}
 	m.infoMessage = "Planning started..."
 }


### PR DESCRIPTION
## Summary

- Implement smart expand/collapse behavior for execution groups in ultraplan sessions
- Groups default to collapsed unless they are the currently active group
- Auto-expand new group when execution moves to it, auto-collapse previous group (unless user is viewing it)
- Tasks in collapsed groups are not navigable until the group is expanded
- Groups show ▼/▶ indicators and display completion progress when collapsed (e.g., `[✓ 3/5]`)
- Manual toggle via group navigation mode: press `g` to enter, `j/k` to navigate, `Enter`/`Space` to toggle

## Test plan

- [x] All existing tests pass
- [x] New unit tests for `IsGroupCollapsed()`, `SetGroupExpanded()`, `SetGroupCollapsed()`
- [x] Verify groups auto-expand when execution moves to them
- [x] Verify groups auto-collapse when leaving (unless viewing a task from that group)
- [x] Verify collapsed groups show summary stats
- [x] Verify tasks in collapsed groups are not navigable
- [x] Verify manual expand/collapse via `g` mode works correctly