### PR TITLE
Add revision, synthesis, group, and candidate plan converters

### DIFF
--- a/.claude-prompt
+++ b/.claude-prompt
@@ -1,0 +1,60 @@
+# Task: Implement BuildConsolidationContext method
+
+## Part of Ultra-Plan: Create prompt_adapter.go with PromptAdapter struct and converter methods that bridge orchestrator types to prompt.Context, enabling the existing but unused prompt.Builder infrastructure to be used for prompt generation instead of manual string concatenation
+
+## Your Task
+
+Add BuildConsolidationContext method to PromptAdapter:
+1. Accepts mainBranch string parameter (from config)
+2. Creates prompt.Context with Phase=PhaseConsolidation
+3. Populates Plan using planInfoFromPlanSpec
+4. Populates Consolidation using consolidationInfoFromSession
+5. Sets MainBranch on ConsolidationInfo
+6. Populates PreviousGroupContext strings
+7. Calls ctx.Validate() before returning
+
+## Expected Files
+
+You are expected to work with these files:
+- internal/orchestrator/prompt_adapter.go
+
+## Context from Previous Group
+
+This task builds on work consolidated from Group 2.
+
+**Consolidator Notes**: Successfully consolidated 5 tasks that add PromptAdapter infrastructure for bridging orchestrator types to prompt.Context. The consolidated code includes: (1) revision and synthesis info converters from task-2, (2) group context and consolidation converters from task-3, (3) candidatePlanInfoFromPlanSpec for multi-pass planning from task-4, (4) BuildPlanningContext method with error sentinels from task-5, and (5) BuildSynthesisContext method with planInfoWithCommitCounts and buildPreviousGroupContextStrings helpers from task-7. There are some intentionally unused functions (converter helpers) that will be integrated in future prompt building work.
+
+**Important**: The previous group's consolidator flagged these issues:
+- Several converter functions (revisionInfoFromState, synthesisInfoFromCompletion, groupContextFromCompletion, consolidationInfoFromSession, candidatePlanInfoFromPlanSpec) are currently unused - these are infrastructure for future prompt.Builder integration
+- The PromptAdapter has both ErrNilUltraPlanSession and ErrNilSession error sentinels which serve similar but distinct purposes - task-5 uses ErrNilUltraPlanSession for BuildPlanningContext, while task-7 uses ErrNilManager and ErrNilSession for BuildSynthesisContext
+- Consider adding a helper method to extract common context fields (SessionID, Objective, BaseDir) to reduce duplication between Build*Context methods in future work
+
+The consolidated code from the previous group has been verified (build/lint/tests passed).
+
+## Guidelines
+
+- Focus only on this specific task
+- Do not modify files outside of your assigned scope unless necessary
+- Commit your changes before writing the completion file
+
+## Completion Protocol
+
+When your task is complete, you MUST write a completion file to signal the orchestrator:
+
+1. Use Write tool to create `.claudio-task-complete.json` in your worktree root
+2. Include this JSON structure:
+```json
+{
+  "task_id": "task-9-consolidation-context",
+  "status": "complete",
+  "summary": "Brief description of what you accomplished",
+  "files_modified": ["list", "of", "files", "you", "changed"],
+  "notes": "Any implementation notes for the consolidation phase",
+  "issues": ["Any concerns or blocking issues found"],
+  "suggestions": ["Suggestions for integration with other tasks"],
+  "dependencies": ["Any new runtime dependencies added"]
+}
+```
+
+3. Use status "blocked" if you cannot complete (explain in issues), or "failed" if something broke
+4. This file signals that your work is done and provides context for consolidation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **PromptAdapter Infrastructure** - Added `PromptAdapter` struct and converter methods to bridge orchestrator types (`PlanSpec`, `PlannedTask`) to `prompt.Context` types, enabling the existing prompt.Builder infrastructure to be used for prompt generation.
+- **PromptAdapter Infrastructure** - Added `PromptAdapter` struct and converter methods to bridge orchestrator types (`PlanSpec`, `PlannedTask`, `RevisionState`, `SynthesisCompletionFile`) to `prompt.Context` types, enabling the existing prompt.Builder infrastructure to be used for prompt generation. Includes `BuildPlanningContext`, `BuildSynthesisContext`, `BuildTaskContext`, `BuildRevisionContext`, `BuildConsolidationContext`, and `BuildPlanSelectionContext` methods for building phase-specific contexts.
 - **Changelog CI Check** - PRs now require a CHANGELOG.md entry. Add the `skip-changelog` label to bypass for trivial changes (test-only, internal refactors, docs-only, dependency updates).
 - **Multi-Pass Plan Mode** (Experimental) - New `:multiplan` (or `:mp`) command launches competitive multi-pass planning with 3 parallel planners using different strategies (maximize-parallelism, minimize-complexity, balanced-approach) plus a plan manager/assessor that evaluates and merges the best plan. This provides the same competitive planning approach as `:ultraplan --multi-pass` but within the simpler inline plan workflow.
 

--- a/internal/orchestrator/prompt_adapter.go
+++ b/internal/orchestrator/prompt_adapter.go
@@ -21,6 +21,13 @@ var (
 
 	// ErrNilSession is returned when the manager's session is nil.
 	ErrNilSession = errors.New("prompt adapter: session is required")
+
+	// ErrTaskNotFoundInPlan is returned when the requested task ID does not
+	// exist in the current plan.
+	ErrTaskNotFoundInPlan = errors.New("prompt adapter: task not found in plan")
+
+	// ErrNilGroupTracker is returned when the Coordinator's groupTracker is nil.
+	ErrNilGroupTracker = errors.New("prompt adapter: group tracker is required")
 )
 
 // PromptAdapter bridges orchestrator types to prompt.Context, enabling the
@@ -383,6 +390,51 @@ func (a *PromptAdapter) BuildSynthesisContext() (*prompt.Context, error) {
 	return ctx, nil
 }
 
+// BuildPlanSelectionContext creates a prompt.Context configured for the plan selection phase.
+// This is used during multi-pass planning when multiple candidate plans have been generated
+// and need to be compared/selected. It populates CandidatePlans by converting each PlanSpec
+// from the session's CandidatePlans using candidatePlanInfoFromPlanSpec.
+//
+// Returns an error if the adapter has no coordinator, no manager, no session,
+// or if the resulting context fails validation (which requires non-empty CandidatePlans).
+func (a *PromptAdapter) BuildPlanSelectionContext() (*prompt.Context, error) {
+	if a.coordinator == nil {
+		return nil, ErrNilCoordinator
+	}
+
+	manager := a.coordinator.manager
+	if manager == nil {
+		return nil, ErrNilManager
+	}
+
+	session := manager.Session()
+	if session == nil {
+		return nil, ErrNilSession
+	}
+
+	ctx := &prompt.Context{
+		Phase:     prompt.PhasePlanSelection,
+		SessionID: session.ID,
+		Objective: session.Objective,
+	}
+
+	// Convert session.CandidatePlans to prompt.CandidatePlanInfo slice
+	// Strategy names are derived from the index position in MultiPassPlanningPrompts:
+	// 0=maximize-parallelism, 1=minimize-complexity, 2=balanced-approach
+	if len(session.CandidatePlans) > 0 {
+		ctx.CandidatePlans = make([]prompt.CandidatePlanInfo, len(session.CandidatePlans))
+		for i, planSpec := range session.CandidatePlans {
+			ctx.CandidatePlans[i] = candidatePlanInfoFromPlanSpec(planSpec, i)
+		}
+	}
+
+	if err := ctx.Validate(); err != nil {
+		return nil, err
+	}
+
+	return ctx, nil
+}
+
 // buildPreviousGroupContextStrings extracts context strings from GroupConsolidationCompletionFile entries.
 // For each completed group, it formats the notes and issues into a readable string.
 func buildPreviousGroupContextStrings(contexts []*GroupConsolidationCompletionFile) []string {
@@ -422,4 +474,199 @@ func buildPreviousGroupContextStrings(contexts []*GroupConsolidationCompletionFi
 		return nil
 	}
 	return result
+}
+
+// BuildTaskContext creates a prompt.Context configured for the task execution phase.
+// It populates the context with plan info, task info (looked up by ID), group index,
+// previous group context (if applicable), and completed/failed task lists.
+//
+// Parameters:
+//   - taskID: The ID of the task to build context for
+//
+// Returns an error if:
+//   - The adapter has no coordinator (ErrNilCoordinator)
+//   - The coordinator has no manager (ErrNilManager)
+//   - The manager has no session (ErrNilSession)
+//   - The coordinator has no groupTracker (ErrNilGroupTracker)
+//   - The task is not found in the plan (ErrTaskNotFoundInPlan)
+//   - The resulting context fails validation
+func (a *PromptAdapter) BuildTaskContext(taskID string) (*prompt.Context, error) {
+	if a.coordinator == nil {
+		return nil, ErrNilCoordinator
+	}
+
+	manager := a.coordinator.manager
+	if manager == nil {
+		return nil, ErrNilManager
+	}
+
+	session := manager.Session()
+	if session == nil {
+		return nil, ErrNilSession
+	}
+
+	groupTracker := a.coordinator.groupTracker
+	if groupTracker == nil {
+		return nil, ErrNilGroupTracker
+	}
+
+	// Look up task by ID
+	plannedTask := session.GetTask(taskID)
+	if plannedTask == nil {
+		return nil, ErrTaskNotFoundInPlan
+	}
+
+	// Get group index for this task
+	groupIndex := groupTracker.GetTaskGroupIndex(taskID)
+
+	// Build the context
+	ctx := &prompt.Context{
+		Phase:      prompt.PhaseTask,
+		SessionID:  session.ID,
+		Objective:  session.Objective,
+		GroupIndex: groupIndex,
+	}
+
+	// Populate Plan using planInfoFromPlanSpec
+	ctx.Plan = planInfoFromPlanSpec(session.Plan)
+
+	// Populate Task using taskInfoFromPlannedTask
+	taskInfo := taskInfoFromPlannedTask(*plannedTask)
+	ctx.Task = &taskInfo
+
+	// Populate PreviousGroup from GroupConsolidationContexts if GroupIndex > 0
+	if groupIndex > 0 && len(session.GroupConsolidationContexts) > 0 {
+		// Get the context from the immediately preceding group
+		prevGroupIdx := groupIndex - 1
+		if prevGroupIdx < len(session.GroupConsolidationContexts) {
+			prevGroupCompletion := session.GroupConsolidationContexts[prevGroupIdx]
+			ctx.PreviousGroup = groupContextFromCompletion(prevGroupCompletion)
+		}
+	}
+
+	// Populate completed and failed tasks from session
+	ctx.CompletedTasks = session.CompletedTasks
+	ctx.FailedTasks = session.FailedTasks
+
+	if err := ctx.Validate(); err != nil {
+		return nil, err
+	}
+
+	return ctx, nil
+}
+
+// findTaskByID searches for a PlannedTask by its ID in the given plan.
+// Returns nil if the plan is nil or the task is not found.
+func findTaskByID(plan *PlanSpec, taskID string) *PlannedTask {
+	if plan == nil || taskID == "" {
+		return nil
+	}
+
+	for i := range plan.Tasks {
+		if plan.Tasks[i].ID == taskID {
+			return &plan.Tasks[i]
+		}
+	}
+	return nil
+}
+
+// BuildRevisionContext creates a prompt.Context configured for the revision phase.
+// It populates the context with plan info, task info for the specific task being revised,
+// revision state, and optionally synthesis info if available from a prior synthesis.
+//
+// Parameters:
+//   - taskID: The ID of the task being revised
+//
+// Returns an error if the adapter has no coordinator, no manager, no session,
+// the task is not found in the plan, or if the resulting context fails validation.
+func (a *PromptAdapter) BuildRevisionContext(taskID string) (*prompt.Context, error) {
+	if a.coordinator == nil {
+		return nil, ErrNilCoordinator
+	}
+
+	manager := a.coordinator.manager
+	if manager == nil {
+		return nil, ErrNilManager
+	}
+
+	session := manager.Session()
+	if session == nil {
+		return nil, ErrNilSession
+	}
+
+	// Build the base context with common fields
+	ctx := &prompt.Context{
+		Phase:     prompt.PhaseRevision,
+		SessionID: session.ID,
+		Objective: session.Objective,
+	}
+
+	// Populate Plan using planInfoFromPlanSpec
+	ctx.Plan = planInfoFromPlanSpec(session.Plan)
+
+	// Find and populate Task for the specific task being revised
+	task := findTaskByID(session.Plan, taskID)
+	if task == nil {
+		return nil, ErrTaskNotFound{TaskID: taskID}
+	}
+	taskInfo := taskInfoFromPlannedTask(*task)
+	ctx.Task = &taskInfo
+
+	// Populate Revision using revisionInfoFromState
+	ctx.Revision = revisionInfoFromState(session.Revision)
+
+	// Populate Synthesis from SynthesisCompletion if available
+	ctx.Synthesis = synthesisInfoFromCompletion(session.SynthesisCompletion)
+
+	if err := ctx.Validate(); err != nil {
+		return nil, err
+	}
+
+	return ctx, nil
+}
+
+// BuildConsolidationContext creates a prompt.Context configured for the consolidation phase.
+// It populates the context with plan info, consolidation info (including main branch configuration),
+// and previous group context strings from earlier consolidation outputs.
+//
+// The mainBranch parameter specifies the repository's primary branch (e.g., "main" or "master")
+// and is included in the ConsolidationInfo for branch management during consolidation.
+//
+// Returns an error if the adapter has no coordinator, no manager, no session,
+// or if the resulting context fails validation.
+func (a *PromptAdapter) BuildConsolidationContext(mainBranch string) (*prompt.Context, error) {
+	if a.coordinator == nil {
+		return nil, ErrNilCoordinator
+	}
+
+	manager := a.coordinator.manager
+	if manager == nil {
+		return nil, ErrNilManager
+	}
+
+	session := manager.Session()
+	if session == nil {
+		return nil, ErrNilSession
+	}
+
+	ctx := &prompt.Context{
+		Phase:     prompt.PhaseConsolidation,
+		SessionID: session.ID,
+		Objective: session.Objective,
+	}
+
+	// Populate Plan using planInfoFromPlanSpec
+	ctx.Plan = planInfoFromPlanSpec(session.Plan)
+
+	// Populate Consolidation using consolidationInfoFromSession with mainBranch
+	ctx.Consolidation = consolidationInfoFromSession(session, mainBranch)
+
+	// Populate PreviousGroupContext strings from GroupConsolidationContexts
+	ctx.PreviousGroupContext = buildPreviousGroupContextStrings(session.GroupConsolidationContexts)
+
+	if err := ctx.Validate(); err != nil {
+		return nil, err
+	}
+
+	return ctx, nil
 }

--- a/internal/orchestrator/prompt_adapter_test.go
+++ b/internal/orchestrator/prompt_adapter_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/Iron-Ham/claudio/internal/orchestrator/group"
 	"github.com/Iron-Ham/claudio/internal/orchestrator/prompt"
 )
 
@@ -1691,6 +1692,1030 @@ func TestBuildPreviousGroupContextStrings(t *testing.T) {
 	}
 }
 
+func TestBuildTaskContext(t *testing.T) {
+	t.Run("nil coordinator returns error", func(t *testing.T) {
+		adapter := NewPromptAdapter(nil)
+		ctx, err := adapter.BuildTaskContext("task-1")
+		if err != ErrNilCoordinator {
+			t.Errorf("BuildTaskContext() error = %v, want %v", err, ErrNilCoordinator)
+		}
+		if ctx != nil {
+			t.Errorf("BuildTaskContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("nil manager returns error", func(t *testing.T) {
+		coordinator := &Coordinator{manager: nil}
+		adapter := NewPromptAdapter(coordinator)
+		ctx, err := adapter.BuildTaskContext("task-1")
+		if err != ErrNilManager {
+			t.Errorf("BuildTaskContext() error = %v, want %v", err, ErrNilManager)
+		}
+		if ctx != nil {
+			t.Errorf("BuildTaskContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("nil session returns error", func(t *testing.T) {
+		manager := &UltraPlanManager{session: nil}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+		ctx, err := adapter.BuildTaskContext("task-1")
+		if err != ErrNilSession {
+			t.Errorf("BuildTaskContext() error = %v, want %v", err, ErrNilSession)
+		}
+		if ctx != nil {
+			t.Errorf("BuildTaskContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("nil groupTracker returns error", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-1",
+			Objective: "Test objective",
+			Plan: &PlanSpec{
+				ID:    "plan-1",
+				Tasks: []PlannedTask{{ID: "task-1", Title: "Task 1"}},
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{
+			manager:      manager,
+			groupTracker: nil, // Explicitly nil
+		}
+		adapter := NewPromptAdapter(coordinator)
+		ctx, err := adapter.BuildTaskContext("task-1")
+		if err != ErrNilGroupTracker {
+			t.Errorf("BuildTaskContext() error = %v, want %v", err, ErrNilGroupTracker)
+		}
+		if ctx != nil {
+			t.Errorf("BuildTaskContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("task not found in plan returns error", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-1",
+			Objective: "Test objective",
+			Plan: &PlanSpec{
+				ID:             "plan-1",
+				Tasks:          []PlannedTask{{ID: "task-1", Title: "Task 1"}},
+				ExecutionOrder: [][]string{{"task-1"}},
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		tracker := createTestGroupTracker(session)
+		coordinator := &Coordinator{
+			manager:      manager,
+			groupTracker: tracker,
+		}
+		adapter := NewPromptAdapter(coordinator)
+		ctx, err := adapter.BuildTaskContext("nonexistent-task")
+		if err != ErrTaskNotFoundInPlan {
+			t.Errorf("BuildTaskContext() error = %v, want %v", err, ErrTaskNotFoundInPlan)
+		}
+		if ctx != nil {
+			t.Errorf("BuildTaskContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("successful task context for group 0", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-123",
+			Objective: "Implement feature X",
+			Plan: &PlanSpec{
+				ID:      "plan-456",
+				Summary: "Feature implementation plan",
+				Tasks: []PlannedTask{
+					{ID: "task-1", Title: "Task 1", Description: "Do task 1", EstComplexity: ComplexityLow},
+					{ID: "task-2", Title: "Task 2", Description: "Do task 2", EstComplexity: ComplexityMedium, DependsOn: []string{"task-1"}},
+				},
+				ExecutionOrder: [][]string{{"task-1"}, {"task-2"}},
+			},
+			CompletedTasks: []string{},
+			FailedTasks:    []string{},
+		}
+		manager := &UltraPlanManager{session: session}
+		tracker := createTestGroupTracker(session)
+		coordinator := &Coordinator{
+			manager:      manager,
+			groupTracker: tracker,
+		}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildTaskContext("task-1")
+		if err != nil {
+			t.Fatalf("BuildTaskContext() error = %v, want nil", err)
+		}
+
+		if ctx.Phase != prompt.PhaseTask {
+			t.Errorf("ctx.Phase = %v, want %v", ctx.Phase, prompt.PhaseTask)
+		}
+		if ctx.SessionID != "session-123" {
+			t.Errorf("ctx.SessionID = %q, want %q", ctx.SessionID, "session-123")
+		}
+		if ctx.Objective != "Implement feature X" {
+			t.Errorf("ctx.Objective = %q, want %q", ctx.Objective, "Implement feature X")
+		}
+		if ctx.GroupIndex != 0 {
+			t.Errorf("ctx.GroupIndex = %d, want 0", ctx.GroupIndex)
+		}
+
+		// Check plan
+		if ctx.Plan == nil {
+			t.Fatal("ctx.Plan = nil, want non-nil")
+		}
+		if ctx.Plan.ID != "plan-456" {
+			t.Errorf("ctx.Plan.ID = %q, want %q", ctx.Plan.ID, "plan-456")
+		}
+
+		// Check task
+		if ctx.Task == nil {
+			t.Fatal("ctx.Task = nil, want non-nil")
+		}
+		if ctx.Task.ID != "task-1" {
+			t.Errorf("ctx.Task.ID = %q, want %q", ctx.Task.ID, "task-1")
+		}
+		if ctx.Task.Title != "Task 1" {
+			t.Errorf("ctx.Task.Title = %q, want %q", ctx.Task.Title, "Task 1")
+		}
+		if ctx.Task.Description != "Do task 1" {
+			t.Errorf("ctx.Task.Description = %q, want %q", ctx.Task.Description, "Do task 1")
+		}
+
+		// For group 0, PreviousGroup should be nil
+		if ctx.PreviousGroup != nil {
+			t.Errorf("ctx.PreviousGroup = %v, want nil for group 0", ctx.PreviousGroup)
+		}
+	})
+
+	t.Run("successful task context for group 1 with previous group context", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-123",
+			Objective: "Implement feature X",
+			Plan: &PlanSpec{
+				ID:      "plan-456",
+				Summary: "Feature implementation plan",
+				Tasks: []PlannedTask{
+					{ID: "task-1", Title: "Task 1", EstComplexity: ComplexityLow},
+					{ID: "task-2", Title: "Task 2", EstComplexity: ComplexityMedium, DependsOn: []string{"task-1"}},
+				},
+				ExecutionOrder: [][]string{{"task-1"}, {"task-2"}},
+			},
+			CompletedTasks: []string{"task-1"},
+			FailedTasks:    []string{},
+			GroupConsolidationContexts: []*GroupConsolidationCompletionFile{
+				{
+					GroupIndex:         0,
+					Notes:              "Group 0 consolidated successfully",
+					IssuesForNextGroup: []string{"Watch for API changes"},
+					Verification: VerificationResult{
+						OverallSuccess: true,
+					},
+				},
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		tracker := createTestGroupTracker(session)
+		coordinator := &Coordinator{
+			manager:      manager,
+			groupTracker: tracker,
+		}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildTaskContext("task-2")
+		if err != nil {
+			t.Fatalf("BuildTaskContext() error = %v, want nil", err)
+		}
+
+		if ctx.GroupIndex != 1 {
+			t.Errorf("ctx.GroupIndex = %d, want 1", ctx.GroupIndex)
+		}
+
+		// Check task
+		if ctx.Task == nil {
+			t.Fatal("ctx.Task = nil, want non-nil")
+		}
+		if ctx.Task.ID != "task-2" {
+			t.Errorf("ctx.Task.ID = %q, want %q", ctx.Task.ID, "task-2")
+		}
+
+		// For group 1, PreviousGroup should be populated
+		if ctx.PreviousGroup == nil {
+			t.Fatal("ctx.PreviousGroup = nil, want non-nil for group 1")
+		}
+		if ctx.PreviousGroup.GroupIndex != 0 {
+			t.Errorf("ctx.PreviousGroup.GroupIndex = %d, want 0", ctx.PreviousGroup.GroupIndex)
+		}
+		if ctx.PreviousGroup.Notes != "Group 0 consolidated successfully" {
+			t.Errorf("ctx.PreviousGroup.Notes = %q, want %q", ctx.PreviousGroup.Notes, "Group 0 consolidated successfully")
+		}
+		if !ctx.PreviousGroup.VerificationPassed {
+			t.Error("ctx.PreviousGroup.VerificationPassed = false, want true")
+		}
+		if len(ctx.PreviousGroup.IssuesForNextGroup) != 1 || ctx.PreviousGroup.IssuesForNextGroup[0] != "Watch for API changes" {
+			t.Errorf("ctx.PreviousGroup.IssuesForNextGroup = %v, want [Watch for API changes]", ctx.PreviousGroup.IssuesForNextGroup)
+		}
+
+		// Check completed tasks
+		if len(ctx.CompletedTasks) != 1 || ctx.CompletedTasks[0] != "task-1" {
+			t.Errorf("ctx.CompletedTasks = %v, want [task-1]", ctx.CompletedTasks)
+		}
+	})
+
+	t.Run("task in group 1 with no consolidation context", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-123",
+			Objective: "Test objective",
+			Plan: &PlanSpec{
+				ID: "plan-1",
+				Tasks: []PlannedTask{
+					{ID: "task-1", Title: "Task 1"},
+					{ID: "task-2", Title: "Task 2"},
+				},
+				ExecutionOrder: [][]string{{"task-1"}, {"task-2"}},
+			},
+			CompletedTasks:             []string{"task-1"},
+			GroupConsolidationContexts: nil, // No consolidation context yet
+		}
+		manager := &UltraPlanManager{session: session}
+		tracker := createTestGroupTracker(session)
+		coordinator := &Coordinator{
+			manager:      manager,
+			groupTracker: tracker,
+		}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildTaskContext("task-2")
+		if err != nil {
+			t.Fatalf("BuildTaskContext() error = %v, want nil", err)
+		}
+
+		if ctx.GroupIndex != 1 {
+			t.Errorf("ctx.GroupIndex = %d, want 1", ctx.GroupIndex)
+		}
+		// PreviousGroup should be nil since there's no consolidation context
+		if ctx.PreviousGroup != nil {
+			t.Errorf("ctx.PreviousGroup = %v, want nil when no consolidation context", ctx.PreviousGroup)
+		}
+	})
+
+	t.Run("validation error for empty session ID", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "", // Empty session ID should fail validation
+			Objective: "Test objective",
+			Plan: &PlanSpec{
+				ID:             "plan-1",
+				Tasks:          []PlannedTask{{ID: "task-1", Title: "Task 1"}},
+				ExecutionOrder: [][]string{{"task-1"}},
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		tracker := createTestGroupTracker(session)
+		coordinator := &Coordinator{
+			manager:      manager,
+			groupTracker: tracker,
+		}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildTaskContext("task-1")
+		if !errors.Is(err, prompt.ErrEmptySessionID) {
+			t.Errorf("BuildTaskContext() error = %v, want %v", err, prompt.ErrEmptySessionID)
+		}
+		if ctx != nil {
+			t.Errorf("BuildTaskContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("validation error for empty objective", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-1",
+			Objective: "", // Empty objective should fail validation
+			Plan: &PlanSpec{
+				ID:             "plan-1",
+				Tasks:          []PlannedTask{{ID: "task-1", Title: "Task 1"}},
+				ExecutionOrder: [][]string{{"task-1"}},
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		tracker := createTestGroupTracker(session)
+		coordinator := &Coordinator{
+			manager:      manager,
+			groupTracker: tracker,
+		}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildTaskContext("task-1")
+		if !errors.Is(err, prompt.ErrEmptyObjective) {
+			t.Errorf("BuildTaskContext() error = %v, want %v", err, prompt.ErrEmptyObjective)
+		}
+		if ctx != nil {
+			t.Errorf("BuildTaskContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("completed and failed tasks are populated", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-123",
+			Objective: "Test objective",
+			Plan: &PlanSpec{
+				ID: "plan-1",
+				Tasks: []PlannedTask{
+					{ID: "task-1", Title: "Task 1"},
+					{ID: "task-2", Title: "Task 2"},
+					{ID: "task-3", Title: "Task 3"},
+					{ID: "task-4", Title: "Task 4"},
+				},
+				ExecutionOrder: [][]string{{"task-1", "task-2"}, {"task-3", "task-4"}},
+			},
+			CompletedTasks: []string{"task-1"},
+			FailedTasks:    []string{"task-2"},
+		}
+		manager := &UltraPlanManager{session: session}
+		tracker := createTestGroupTracker(session)
+		coordinator := &Coordinator{
+			manager:      manager,
+			groupTracker: tracker,
+		}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildTaskContext("task-3")
+		if err != nil {
+			t.Fatalf("BuildTaskContext() error = %v, want nil", err)
+		}
+
+		if len(ctx.CompletedTasks) != 1 || ctx.CompletedTasks[0] != "task-1" {
+			t.Errorf("ctx.CompletedTasks = %v, want [task-1]", ctx.CompletedTasks)
+		}
+		if len(ctx.FailedTasks) != 1 || ctx.FailedTasks[0] != "task-2" {
+			t.Errorf("ctx.FailedTasks = %v, want [task-2]", ctx.FailedTasks)
+		}
+	})
+}
+
+// createTestGroupTracker creates a group.Tracker for testing using the session adapters.
+func createTestGroupTracker(session *UltraPlanSession) *group.Tracker {
+	planAdapter := group.NewPlanAdapter(
+		func() [][]string {
+			if session.Plan == nil {
+				return nil
+			}
+			return session.Plan.ExecutionOrder
+		},
+		func(taskID string) *group.Task {
+			if session.Plan == nil {
+				return nil
+			}
+			for i := range session.Plan.Tasks {
+				if session.Plan.Tasks[i].ID == taskID {
+					return &group.Task{
+						ID:          session.Plan.Tasks[i].ID,
+						Title:       session.Plan.Tasks[i].Title,
+						Description: session.Plan.Tasks[i].Description,
+						Files:       session.Plan.Tasks[i].Files,
+						DependsOn:   session.Plan.Tasks[i].DependsOn,
+					}
+				}
+			}
+			return nil
+		},
+	)
+
+	sessionAdapter := group.NewSessionAdapter(
+		func() group.PlanData { return planAdapter },
+		func() []string { return session.CompletedTasks },
+		func() []string { return session.FailedTasks },
+		func() map[string]int { return session.TaskCommitCounts },
+		func() int { return session.CurrentGroup },
+	)
+
+	return group.NewTracker(sessionAdapter)
+}
+
+func TestBuildConsolidationContext(t *testing.T) {
+	t.Run("nil coordinator returns error", func(t *testing.T) {
+		adapter := NewPromptAdapter(nil)
+		ctx, err := adapter.BuildConsolidationContext("main")
+		if err != ErrNilCoordinator {
+			t.Errorf("BuildConsolidationContext() error = %v, want %v", err, ErrNilCoordinator)
+		}
+		if ctx != nil {
+			t.Errorf("BuildConsolidationContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("nil manager returns error", func(t *testing.T) {
+		coordinator := &Coordinator{manager: nil}
+		adapter := NewPromptAdapter(coordinator)
+		ctx, err := adapter.BuildConsolidationContext("main")
+		if err != ErrNilManager {
+			t.Errorf("BuildConsolidationContext() error = %v, want %v", err, ErrNilManager)
+		}
+		if ctx != nil {
+			t.Errorf("BuildConsolidationContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("nil session returns error", func(t *testing.T) {
+		manager := &UltraPlanManager{session: nil}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+		ctx, err := adapter.BuildConsolidationContext("main")
+		if err != ErrNilSession {
+			t.Errorf("BuildConsolidationContext() error = %v, want %v", err, ErrNilSession)
+		}
+		if ctx != nil {
+			t.Errorf("BuildConsolidationContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("validation error for empty objective", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-1",
+			Objective: "", // Empty objective should fail validation
+			Plan: &PlanSpec{
+				ID: "plan-1",
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildConsolidationContext("main")
+		if err == nil {
+			t.Error("BuildConsolidationContext() error = nil, want validation error")
+		}
+		if ctx != nil {
+			t.Errorf("BuildConsolidationContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("validation error for nil plan", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-1",
+			Objective: "Test objective",
+			Plan:      nil, // Consolidation phase requires a plan
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildConsolidationContext("main")
+		if err == nil {
+			t.Error("BuildConsolidationContext() error = nil, want validation error for missing plan")
+		}
+		if ctx != nil {
+			t.Errorf("BuildConsolidationContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("successful consolidation context creation", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-123",
+			Objective: "Implement feature X",
+			Plan: &PlanSpec{
+				ID:      "plan-456",
+				Summary: "Feature implementation plan",
+				Tasks: []PlannedTask{
+					{ID: "task-1", Title: "Task 1", EstComplexity: ComplexityLow},
+					{ID: "task-2", Title: "Task 2", EstComplexity: ComplexityMedium},
+				},
+				ExecutionOrder: [][]string{{"task-1"}, {"task-2"}},
+			},
+			Config: UltraPlanConfig{
+				ConsolidationMode: ModeSinglePR,
+				BranchPrefix:      "feature",
+			},
+			TaskWorktrees: []TaskWorktreeInfo{
+				{TaskID: "task-1", TaskTitle: "Task 1", Branch: "feature/task-1", WorktreePath: "/wt/1"},
+				{TaskID: "task-2", TaskTitle: "Task 2", Branch: "feature/task-2", WorktreePath: "/wt/2"},
+			},
+			TaskCommitCounts: map[string]int{
+				"task-1": 3,
+				"task-2": 1,
+			},
+			GroupConsolidationContexts: []*GroupConsolidationCompletionFile{
+				{
+					GroupIndex: 0,
+					Notes:      "Group 0 completed successfully",
+				},
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildConsolidationContext("develop")
+		if err != nil {
+			t.Fatalf("BuildConsolidationContext() error = %v, want nil", err)
+		}
+
+		// Verify phase
+		if ctx.Phase != prompt.PhaseConsolidation {
+			t.Errorf("ctx.Phase = %v, want %v", ctx.Phase, prompt.PhaseConsolidation)
+		}
+
+		// Verify session info
+		if ctx.SessionID != "session-123" {
+			t.Errorf("ctx.SessionID = %q, want %q", ctx.SessionID, "session-123")
+		}
+		if ctx.Objective != "Implement feature X" {
+			t.Errorf("ctx.Objective = %q, want %q", ctx.Objective, "Implement feature X")
+		}
+
+		// Verify Plan was populated
+		if ctx.Plan == nil {
+			t.Fatal("ctx.Plan = nil, want non-nil")
+		}
+		if ctx.Plan.ID != "plan-456" {
+			t.Errorf("ctx.Plan.ID = %q, want %q", ctx.Plan.ID, "plan-456")
+		}
+		if len(ctx.Plan.Tasks) != 2 {
+			t.Errorf("ctx.Plan.Tasks length = %d, want 2", len(ctx.Plan.Tasks))
+		}
+
+		// Verify Consolidation was populated with mainBranch
+		if ctx.Consolidation == nil {
+			t.Fatal("ctx.Consolidation = nil, want non-nil")
+		}
+		if ctx.Consolidation.MainBranch != "develop" {
+			t.Errorf("ctx.Consolidation.MainBranch = %q, want %q", ctx.Consolidation.MainBranch, "develop")
+		}
+		if ctx.Consolidation.Mode != "single" {
+			t.Errorf("ctx.Consolidation.Mode = %q, want %q", ctx.Consolidation.Mode, "single")
+		}
+		if ctx.Consolidation.BranchPrefix != "feature" {
+			t.Errorf("ctx.Consolidation.BranchPrefix = %q, want %q", ctx.Consolidation.BranchPrefix, "feature")
+		}
+		if len(ctx.Consolidation.TaskWorktrees) != 2 {
+			t.Errorf("ctx.Consolidation.TaskWorktrees length = %d, want 2", len(ctx.Consolidation.TaskWorktrees))
+		}
+
+		// Verify commit counts were applied
+		if ctx.Consolidation.TaskWorktrees[0].CommitCount != 3 {
+			t.Errorf("ctx.Consolidation.TaskWorktrees[0].CommitCount = %d, want 3", ctx.Consolidation.TaskWorktrees[0].CommitCount)
+		}
+		if ctx.Consolidation.TaskWorktrees[1].CommitCount != 1 {
+			t.Errorf("ctx.Consolidation.TaskWorktrees[1].CommitCount = %d, want 1", ctx.Consolidation.TaskWorktrees[1].CommitCount)
+		}
+
+		// Verify PreviousGroupContext was populated
+		if len(ctx.PreviousGroupContext) != 1 {
+			t.Fatalf("ctx.PreviousGroupContext length = %d, want 1", len(ctx.PreviousGroupContext))
+		}
+		if ctx.PreviousGroupContext[0] != "Group 0 completed successfully" {
+			t.Errorf("ctx.PreviousGroupContext[0] = %q, want %q", ctx.PreviousGroupContext[0], "Group 0 completed successfully")
+		}
+	})
+
+	t.Run("consolidation context with empty mainBranch defaults correctly", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-1",
+			Objective: "Test objective",
+			Plan: &PlanSpec{
+				ID: "plan-1",
+			},
+			Config: UltraPlanConfig{},
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildConsolidationContext("")
+		if err != nil {
+			t.Fatalf("BuildConsolidationContext() error = %v, want nil", err)
+		}
+
+		// consolidationInfoFromSession defaults empty mainBranch to "main"
+		if ctx.Consolidation.MainBranch != "main" {
+			t.Errorf("ctx.Consolidation.MainBranch = %q, want %q", ctx.Consolidation.MainBranch, "main")
+		}
+	})
+
+	t.Run("consolidation context with group branches and pre-consolidated branch", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-1",
+			Objective: "Test objective",
+			Plan: &PlanSpec{
+				ID:             "plan-1",
+				ExecutionOrder: [][]string{{"task-1"}, {"task-2"}, {"task-3"}},
+			},
+			Config: UltraPlanConfig{
+				ConsolidationMode: ModeStackedPRs,
+				BranchPrefix:      "Iron-Ham",
+			},
+			GroupConsolidatedBranches: []string{
+				"Iron-Ham/ultraplan-abc-group-1",
+				"Iron-Ham/ultraplan-abc-group-2",
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildConsolidationContext("main")
+		if err != nil {
+			t.Fatalf("BuildConsolidationContext() error = %v, want nil", err)
+		}
+
+		// Verify group branches
+		if len(ctx.Consolidation.GroupBranches) != 2 {
+			t.Errorf("ctx.Consolidation.GroupBranches length = %d, want 2", len(ctx.Consolidation.GroupBranches))
+		}
+
+		// Verify pre-consolidated branch is the last group branch
+		if ctx.Consolidation.PreConsolidatedBranch != "Iron-Ham/ultraplan-abc-group-2" {
+			t.Errorf("ctx.Consolidation.PreConsolidatedBranch = %q, want %q", ctx.Consolidation.PreConsolidatedBranch, "Iron-Ham/ultraplan-abc-group-2")
+		}
+	})
+
+	t.Run("consolidation context with multiple group contexts", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-1",
+			Objective: "Test objective",
+			Plan: &PlanSpec{
+				ID: "plan-1",
+			},
+			GroupConsolidationContexts: []*GroupConsolidationCompletionFile{
+				{
+					GroupIndex: 0,
+					Notes:      "Group 0 notes",
+				},
+				{
+					GroupIndex:         1,
+					Notes:              "Group 1 notes",
+					IssuesForNextGroup: []string{"Issue A", "Issue B"},
+				},
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildConsolidationContext("main")
+		if err != nil {
+			t.Fatalf("BuildConsolidationContext() error = %v, want nil", err)
+		}
+
+		if len(ctx.PreviousGroupContext) != 2 {
+			t.Fatalf("ctx.PreviousGroupContext length = %d, want 2", len(ctx.PreviousGroupContext))
+		}
+
+		if ctx.PreviousGroupContext[0] != "Group 0 notes" {
+			t.Errorf("ctx.PreviousGroupContext[0] = %q, want %q", ctx.PreviousGroupContext[0], "Group 0 notes")
+		}
+		if ctx.PreviousGroupContext[1] != "Group 1 notes | Issues: Issue A; Issue B" {
+			t.Errorf("ctx.PreviousGroupContext[1] = %q, want %q", ctx.PreviousGroupContext[1], "Group 1 notes | Issues: Issue A; Issue B")
+		}
+	})
+}
+
+func TestBuildPlanSelectionContext(t *testing.T) {
+	t.Run("nil coordinator returns error", func(t *testing.T) {
+		adapter := NewPromptAdapter(nil)
+		ctx, err := adapter.BuildPlanSelectionContext()
+		if err != ErrNilCoordinator {
+			t.Errorf("BuildPlanSelectionContext() error = %v, want %v", err, ErrNilCoordinator)
+		}
+		if ctx != nil {
+			t.Errorf("BuildPlanSelectionContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("nil manager returns error", func(t *testing.T) {
+		coordinator := &Coordinator{manager: nil}
+		adapter := NewPromptAdapter(coordinator)
+		ctx, err := adapter.BuildPlanSelectionContext()
+		if err != ErrNilManager {
+			t.Errorf("BuildPlanSelectionContext() error = %v, want %v", err, ErrNilManager)
+		}
+		if ctx != nil {
+			t.Errorf("BuildPlanSelectionContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("nil session returns error", func(t *testing.T) {
+		manager := &UltraPlanManager{session: nil}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+		ctx, err := adapter.BuildPlanSelectionContext()
+		if err != ErrNilSession {
+			t.Errorf("BuildPlanSelectionContext() error = %v, want %v", err, ErrNilSession)
+		}
+		if ctx != nil {
+			t.Errorf("BuildPlanSelectionContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("validation error for empty objective", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-1",
+			Objective: "", // Empty objective should fail validation
+			CandidatePlans: []*PlanSpec{
+				{Summary: "Plan 1", Tasks: []PlannedTask{{ID: "t1"}}},
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildPlanSelectionContext()
+		if err == nil {
+			t.Error("BuildPlanSelectionContext() error = nil, want validation error")
+		}
+		if ctx != nil {
+			t.Errorf("BuildPlanSelectionContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("validation error for empty session ID", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "", // Empty session ID should fail validation
+			Objective: "Test objective",
+			CandidatePlans: []*PlanSpec{
+				{Summary: "Plan 1", Tasks: []PlannedTask{{ID: "t1"}}},
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildPlanSelectionContext()
+		if err == nil {
+			t.Error("BuildPlanSelectionContext() error = nil, want validation error")
+		}
+		if ctx != nil {
+			t.Errorf("BuildPlanSelectionContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("validation error for empty candidate plans", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:             "session-1",
+			Objective:      "Test objective",
+			CandidatePlans: []*PlanSpec{}, // Empty candidate plans should fail validation
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildPlanSelectionContext()
+		if err == nil {
+			t.Error("BuildPlanSelectionContext() error = nil, want validation error for empty candidate plans")
+		}
+		if !errors.Is(err, prompt.ErrMissingCandidatePlans) {
+			t.Errorf("BuildPlanSelectionContext() error = %v, want %v", err, prompt.ErrMissingCandidatePlans)
+		}
+		if ctx != nil {
+			t.Errorf("BuildPlanSelectionContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("validation error for nil candidate plans", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:             "session-1",
+			Objective:      "Test objective",
+			CandidatePlans: nil, // Nil candidate plans should fail validation
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildPlanSelectionContext()
+		if err == nil {
+			t.Error("BuildPlanSelectionContext() error = nil, want validation error for nil candidate plans")
+		}
+		if !errors.Is(err, prompt.ErrMissingCandidatePlans) {
+			t.Errorf("BuildPlanSelectionContext() error = %v, want %v", err, prompt.ErrMissingCandidatePlans)
+		}
+		if ctx != nil {
+			t.Errorf("BuildPlanSelectionContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("successful plan selection context with single plan", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-123",
+			Objective: "Implement feature X",
+			CandidatePlans: []*PlanSpec{
+				{
+					Summary: "Maximize parallelism plan",
+					Tasks: []PlannedTask{
+						{ID: "task-1", Title: "Task 1", EstComplexity: ComplexityLow},
+						{ID: "task-2", Title: "Task 2", EstComplexity: ComplexityMedium},
+					},
+					ExecutionOrder: [][]string{{"task-1", "task-2"}},
+					Insights:       []string{"Can run in parallel"},
+					Constraints:    []string{"Memory constraint"},
+				},
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildPlanSelectionContext()
+		if err != nil {
+			t.Fatalf("BuildPlanSelectionContext() error = %v, want nil", err)
+		}
+
+		if ctx.Phase != prompt.PhasePlanSelection {
+			t.Errorf("ctx.Phase = %v, want %v", ctx.Phase, prompt.PhasePlanSelection)
+		}
+		if ctx.SessionID != "session-123" {
+			t.Errorf("ctx.SessionID = %q, want %q", ctx.SessionID, "session-123")
+		}
+		if ctx.Objective != "Implement feature X" {
+			t.Errorf("ctx.Objective = %q, want %q", ctx.Objective, "Implement feature X")
+		}
+
+		// Check candidate plans
+		if len(ctx.CandidatePlans) != 1 {
+			t.Fatalf("ctx.CandidatePlans length = %d, want 1", len(ctx.CandidatePlans))
+		}
+
+		plan := ctx.CandidatePlans[0]
+		if plan.Strategy != "maximize-parallelism" {
+			t.Errorf("ctx.CandidatePlans[0].Strategy = %q, want %q", plan.Strategy, "maximize-parallelism")
+		}
+		if plan.Summary != "Maximize parallelism plan" {
+			t.Errorf("ctx.CandidatePlans[0].Summary = %q, want %q", plan.Summary, "Maximize parallelism plan")
+		}
+		if len(plan.Tasks) != 2 {
+			t.Errorf("ctx.CandidatePlans[0].Tasks length = %d, want 2", len(plan.Tasks))
+		}
+		if len(plan.ExecutionOrder) != 1 {
+			t.Errorf("ctx.CandidatePlans[0].ExecutionOrder length = %d, want 1", len(plan.ExecutionOrder))
+		}
+		if len(plan.Insights) != 1 {
+			t.Errorf("ctx.CandidatePlans[0].Insights length = %d, want 1", len(plan.Insights))
+		}
+		if len(plan.Constraints) != 1 {
+			t.Errorf("ctx.CandidatePlans[0].Constraints length = %d, want 1", len(plan.Constraints))
+		}
+	})
+
+	t.Run("successful plan selection context with three plans", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-456",
+			Objective: "Build REST API",
+			CandidatePlans: []*PlanSpec{
+				{
+					Summary: "Maximize parallelism approach",
+					Tasks: []PlannedTask{
+						{ID: "t1", Title: "Task A"},
+						{ID: "t2", Title: "Task B"},
+					},
+					ExecutionOrder: [][]string{{"t1", "t2"}},
+				},
+				{
+					Summary: "Minimize complexity approach",
+					Tasks: []PlannedTask{
+						{ID: "t1", Title: "Task A"},
+						{ID: "t2", Title: "Task B"},
+					},
+					ExecutionOrder: [][]string{{"t1"}, {"t2"}},
+				},
+				{
+					Summary: "Balanced approach",
+					Tasks: []PlannedTask{
+						{ID: "t1", Title: "Task A"},
+						{ID: "t2", Title: "Task B"},
+						{ID: "t3", Title: "Task C"},
+					},
+					ExecutionOrder: [][]string{{"t1"}, {"t2", "t3"}},
+				},
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildPlanSelectionContext()
+		if err != nil {
+			t.Fatalf("BuildPlanSelectionContext() error = %v, want nil", err)
+		}
+
+		if len(ctx.CandidatePlans) != 3 {
+			t.Fatalf("ctx.CandidatePlans length = %d, want 3", len(ctx.CandidatePlans))
+		}
+
+		// Verify strategy names are mapped correctly by index
+		expectedStrategies := []string{"maximize-parallelism", "minimize-complexity", "balanced-approach"}
+		for i, expected := range expectedStrategies {
+			if ctx.CandidatePlans[i].Strategy != expected {
+				t.Errorf("ctx.CandidatePlans[%d].Strategy = %q, want %q", i, ctx.CandidatePlans[i].Strategy, expected)
+			}
+		}
+
+		// Verify summaries preserved
+		if ctx.CandidatePlans[0].Summary != "Maximize parallelism approach" {
+			t.Errorf("ctx.CandidatePlans[0].Summary = %q, want %q", ctx.CandidatePlans[0].Summary, "Maximize parallelism approach")
+		}
+		if ctx.CandidatePlans[1].Summary != "Minimize complexity approach" {
+			t.Errorf("ctx.CandidatePlans[1].Summary = %q, want %q", ctx.CandidatePlans[1].Summary, "Minimize complexity approach")
+		}
+		if ctx.CandidatePlans[2].Summary != "Balanced approach" {
+			t.Errorf("ctx.CandidatePlans[2].Summary = %q, want %q", ctx.CandidatePlans[2].Summary, "Balanced approach")
+		}
+
+		// Verify third plan has 3 tasks
+		if len(ctx.CandidatePlans[2].Tasks) != 3 {
+			t.Errorf("ctx.CandidatePlans[2].Tasks length = %d, want 3", len(ctx.CandidatePlans[2].Tasks))
+		}
+	})
+
+	t.Run("handles nil plan spec in candidate plans", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-789",
+			Objective: "Test nil handling",
+			CandidatePlans: []*PlanSpec{
+				{Summary: "Valid plan", Tasks: []PlannedTask{{ID: "t1"}}},
+				nil, // nil plan spec - candidatePlanInfoFromPlanSpec returns empty struct
+				{Summary: "Another valid plan", Tasks: []PlannedTask{{ID: "t2"}}},
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildPlanSelectionContext()
+		if err != nil {
+			t.Fatalf("BuildPlanSelectionContext() error = %v, want nil", err)
+		}
+
+		if len(ctx.CandidatePlans) != 3 {
+			t.Fatalf("ctx.CandidatePlans length = %d, want 3", len(ctx.CandidatePlans))
+		}
+
+		// First plan should be valid with maximize-parallelism strategy
+		if ctx.CandidatePlans[0].Strategy != "maximize-parallelism" {
+			t.Errorf("ctx.CandidatePlans[0].Strategy = %q, want %q", ctx.CandidatePlans[0].Strategy, "maximize-parallelism")
+		}
+		if ctx.CandidatePlans[0].Summary != "Valid plan" {
+			t.Errorf("ctx.CandidatePlans[0].Summary = %q, want %q", ctx.CandidatePlans[0].Summary, "Valid plan")
+		}
+
+		// Second plan (nil) returns empty CandidatePlanInfo per candidatePlanInfoFromPlanSpec behavior
+		// The strategy is empty because nil spec returns an empty struct without looking up the index
+		if ctx.CandidatePlans[1].Strategy != "" {
+			t.Errorf("ctx.CandidatePlans[1].Strategy = %q, want empty (nil spec returns empty struct)", ctx.CandidatePlans[1].Strategy)
+		}
+		if ctx.CandidatePlans[1].Summary != "" {
+			t.Errorf("ctx.CandidatePlans[1].Summary = %q, want empty", ctx.CandidatePlans[1].Summary)
+		}
+
+		// Third plan should be valid with balanced-approach strategy
+		if ctx.CandidatePlans[2].Strategy != "balanced-approach" {
+			t.Errorf("ctx.CandidatePlans[2].Strategy = %q, want %q", ctx.CandidatePlans[2].Strategy, "balanced-approach")
+		}
+		if ctx.CandidatePlans[2].Summary != "Another valid plan" {
+			t.Errorf("ctx.CandidatePlans[2].Summary = %q, want %q", ctx.CandidatePlans[2].Summary, "Another valid plan")
+		}
+	})
+
+	t.Run("task complexity is converted correctly", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-complex",
+			Objective: "Test complexity conversion",
+			CandidatePlans: []*PlanSpec{
+				{
+					Summary: "Plan with varied complexity",
+					Tasks: []PlannedTask{
+						{ID: "t1", Title: "Low task", EstComplexity: ComplexityLow},
+						{ID: "t2", Title: "Medium task", EstComplexity: ComplexityMedium},
+						{ID: "t3", Title: "High task", EstComplexity: ComplexityHigh},
+					},
+				},
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildPlanSelectionContext()
+		if err != nil {
+			t.Fatalf("BuildPlanSelectionContext() error = %v, want nil", err)
+		}
+
+		tasks := ctx.CandidatePlans[0].Tasks
+		if len(tasks) != 3 {
+			t.Fatalf("Tasks length = %d, want 3", len(tasks))
+		}
+
+		// Verify complexity is converted to string
+		if tasks[0].EstComplexity != "low" {
+			t.Errorf("tasks[0].EstComplexity = %q, want %q", tasks[0].EstComplexity, "low")
+		}
+		if tasks[1].EstComplexity != "medium" {
+			t.Errorf("tasks[1].EstComplexity = %q, want %q", tasks[1].EstComplexity, "medium")
+		}
+		if tasks[2].EstComplexity != "high" {
+			t.Errorf("tasks[2].EstComplexity = %q, want %q", tasks[2].EstComplexity, "high")
+		}
+	})
+}
+
 func TestBuildSynthesisContext(t *testing.T) {
 	t.Run("nil coordinator returns error", func(t *testing.T) {
 		adapter := NewPromptAdapter(nil)
@@ -1844,6 +2869,403 @@ func TestBuildSynthesisContext(t *testing.T) {
 		}
 		if ctx != nil {
 			t.Errorf("BuildSynthesisContext() ctx = %v, want nil", ctx)
+		}
+	})
+}
+
+func TestFindTaskByID(t *testing.T) {
+	tests := []struct {
+		name   string
+		plan   *PlanSpec
+		taskID string
+		want   *PlannedTask
+	}{
+		{
+			name:   "nil plan returns nil",
+			plan:   nil,
+			taskID: "task-1",
+			want:   nil,
+		},
+		{
+			name: "empty task ID returns nil",
+			plan: &PlanSpec{
+				Tasks: []PlannedTask{
+					{ID: "task-1", Title: "Task 1"},
+				},
+			},
+			taskID: "",
+			want:   nil,
+		},
+		{
+			name: "task not found returns nil",
+			plan: &PlanSpec{
+				Tasks: []PlannedTask{
+					{ID: "task-1", Title: "Task 1"},
+					{ID: "task-2", Title: "Task 2"},
+				},
+			},
+			taskID: "task-3",
+			want:   nil,
+		},
+		{
+			name: "find first task",
+			plan: &PlanSpec{
+				Tasks: []PlannedTask{
+					{ID: "task-1", Title: "Task 1", Description: "First task"},
+					{ID: "task-2", Title: "Task 2", Description: "Second task"},
+				},
+			},
+			taskID: "task-1",
+			want:   &PlannedTask{ID: "task-1", Title: "Task 1", Description: "First task"},
+		},
+		{
+			name: "find last task",
+			plan: &PlanSpec{
+				Tasks: []PlannedTask{
+					{ID: "task-1", Title: "Task 1"},
+					{ID: "task-2", Title: "Task 2"},
+					{ID: "task-3", Title: "Task 3", EstComplexity: ComplexityHigh},
+				},
+			},
+			taskID: "task-3",
+			want:   &PlannedTask{ID: "task-3", Title: "Task 3", EstComplexity: ComplexityHigh},
+		},
+		{
+			name: "empty tasks slice returns nil",
+			plan: &PlanSpec{
+				Tasks: []PlannedTask{},
+			},
+			taskID: "task-1",
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findTaskByID(tt.plan, tt.taskID)
+
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("findTaskByID() = %v, want nil", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Fatal("findTaskByID() = nil, want non-nil")
+			}
+
+			if got.ID != tt.want.ID {
+				t.Errorf("findTaskByID().ID = %q, want %q", got.ID, tt.want.ID)
+			}
+			if got.Title != tt.want.Title {
+				t.Errorf("findTaskByID().Title = %q, want %q", got.Title, tt.want.Title)
+			}
+		})
+	}
+}
+
+func TestBuildRevisionContext(t *testing.T) {
+	t.Run("nil coordinator returns error", func(t *testing.T) {
+		adapter := NewPromptAdapter(nil)
+		ctx, err := adapter.BuildRevisionContext("task-1")
+		if err != ErrNilCoordinator {
+			t.Errorf("BuildRevisionContext() error = %v, want %v", err, ErrNilCoordinator)
+		}
+		if ctx != nil {
+			t.Errorf("BuildRevisionContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("nil manager returns error", func(t *testing.T) {
+		coordinator := &Coordinator{manager: nil}
+		adapter := NewPromptAdapter(coordinator)
+		ctx, err := adapter.BuildRevisionContext("task-1")
+		if err != ErrNilManager {
+			t.Errorf("BuildRevisionContext() error = %v, want %v", err, ErrNilManager)
+		}
+		if ctx != nil {
+			t.Errorf("BuildRevisionContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("nil session returns error", func(t *testing.T) {
+		manager := &UltraPlanManager{session: nil}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+		ctx, err := adapter.BuildRevisionContext("task-1")
+		if err != ErrNilSession {
+			t.Errorf("BuildRevisionContext() error = %v, want %v", err, ErrNilSession)
+		}
+		if ctx != nil {
+			t.Errorf("BuildRevisionContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("task not found returns error", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-1",
+			Objective: "Test objective",
+			Plan: &PlanSpec{
+				ID: "plan-1",
+				Tasks: []PlannedTask{
+					{ID: "task-1", Title: "Task 1"},
+				},
+			},
+			Revision: &RevisionState{
+				RevisionRound: 1,
+				MaxRevisions:  3,
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildRevisionContext("nonexistent-task")
+		if _, ok := err.(ErrTaskNotFound); !ok {
+			t.Errorf("BuildRevisionContext() error = %T, want ErrTaskNotFound", err)
+		}
+		if ctx != nil {
+			t.Errorf("BuildRevisionContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("validation error for empty objective", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-1",
+			Objective: "", // Empty objective should fail validation
+			Plan: &PlanSpec{
+				ID: "plan-1",
+				Tasks: []PlannedTask{
+					{ID: "task-1", Title: "Task 1"},
+				},
+			},
+			Revision: &RevisionState{
+				RevisionRound: 1,
+				MaxRevisions:  3,
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildRevisionContext("task-1")
+		if err == nil {
+			t.Error("BuildRevisionContext() error = nil, want validation error")
+		}
+		if ctx != nil {
+			t.Errorf("BuildRevisionContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("validation error for missing revision state", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-1",
+			Objective: "Test objective",
+			Plan: &PlanSpec{
+				ID: "plan-1",
+				Tasks: []PlannedTask{
+					{ID: "task-1", Title: "Task 1"},
+				},
+			},
+			Revision: nil, // Missing revision state
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildRevisionContext("task-1")
+		if err == nil {
+			t.Error("BuildRevisionContext() error = nil, want validation error for missing revision")
+		}
+		if ctx != nil {
+			t.Errorf("BuildRevisionContext() ctx = %v, want nil", ctx)
+		}
+	})
+
+	t.Run("successful revision context creation", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-123",
+			Objective: "Implement feature X",
+			Plan: &PlanSpec{
+				ID:      "plan-456",
+				Summary: "Feature implementation plan",
+				Tasks: []PlannedTask{
+					{ID: "task-1", Title: "Task 1", Description: "First task", EstComplexity: ComplexityLow},
+					{ID: "task-2", Title: "Task 2", Description: "Second task", EstComplexity: ComplexityMedium},
+				},
+				ExecutionOrder: [][]string{{"task-1"}, {"task-2"}},
+			},
+			Revision: &RevisionState{
+				RevisionRound: 2,
+				MaxRevisions:  5,
+				Issues: []RevisionIssue{
+					{
+						TaskID:      "task-1",
+						Description: "Tests failing",
+						Files:       []string{"task1.go"},
+						Severity:    "critical",
+						Suggestion:  "Fix the assertions",
+					},
+				},
+				TasksToRevise: []string{"task-1"},
+				RevisedTasks:  []string{},
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildRevisionContext("task-1")
+		if err != nil {
+			t.Fatalf("BuildRevisionContext() error = %v, want nil", err)
+		}
+
+		// Check phase
+		if ctx.Phase != prompt.PhaseRevision {
+			t.Errorf("ctx.Phase = %v, want %v", ctx.Phase, prompt.PhaseRevision)
+		}
+
+		// Check session info
+		if ctx.SessionID != "session-123" {
+			t.Errorf("ctx.SessionID = %q, want %q", ctx.SessionID, "session-123")
+		}
+		if ctx.Objective != "Implement feature X" {
+			t.Errorf("ctx.Objective = %q, want %q", ctx.Objective, "Implement feature X")
+		}
+
+		// Check plan
+		if ctx.Plan == nil {
+			t.Fatal("ctx.Plan = nil, want non-nil")
+		}
+		if ctx.Plan.ID != "plan-456" {
+			t.Errorf("ctx.Plan.ID = %q, want %q", ctx.Plan.ID, "plan-456")
+		}
+
+		// Check task
+		if ctx.Task == nil {
+			t.Fatal("ctx.Task = nil, want non-nil")
+		}
+		if ctx.Task.ID != "task-1" {
+			t.Errorf("ctx.Task.ID = %q, want %q", ctx.Task.ID, "task-1")
+		}
+		if ctx.Task.Title != "Task 1" {
+			t.Errorf("ctx.Task.Title = %q, want %q", ctx.Task.Title, "Task 1")
+		}
+
+		// Check revision info
+		if ctx.Revision == nil {
+			t.Fatal("ctx.Revision = nil, want non-nil")
+		}
+		if ctx.Revision.Round != 2 {
+			t.Errorf("ctx.Revision.Round = %d, want 2", ctx.Revision.Round)
+		}
+		if ctx.Revision.MaxRounds != 5 {
+			t.Errorf("ctx.Revision.MaxRounds = %d, want 5", ctx.Revision.MaxRounds)
+		}
+		if len(ctx.Revision.Issues) != 1 {
+			t.Fatalf("ctx.Revision.Issues length = %d, want 1", len(ctx.Revision.Issues))
+		}
+		if ctx.Revision.Issues[0].Description != "Tests failing" {
+			t.Errorf("ctx.Revision.Issues[0].Description = %q, want %q", ctx.Revision.Issues[0].Description, "Tests failing")
+		}
+
+		// Check synthesis is nil when not set
+		if ctx.Synthesis != nil {
+			t.Errorf("ctx.Synthesis = %v, want nil", ctx.Synthesis)
+		}
+	})
+
+	t.Run("revision context with synthesis completion", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-123",
+			Objective: "Implement feature X",
+			Plan: &PlanSpec{
+				ID: "plan-456",
+				Tasks: []PlannedTask{
+					{ID: "task-1", Title: "Task 1"},
+				},
+			},
+			Revision: &RevisionState{
+				RevisionRound: 1,
+				MaxRevisions:  3,
+			},
+			SynthesisCompletion: &SynthesisCompletionFile{
+				Status:           "needs_revision",
+				IntegrationNotes: "Tasks need fixes",
+				Recommendations:  []string{"Fix tests first"},
+				IssuesFound: []RevisionIssue{
+					{Description: "Build failing"},
+				},
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		ctx, err := adapter.BuildRevisionContext("task-1")
+		if err != nil {
+			t.Fatalf("BuildRevisionContext() error = %v, want nil", err)
+		}
+
+		// Check synthesis info is populated
+		if ctx.Synthesis == nil {
+			t.Fatal("ctx.Synthesis = nil, want non-nil")
+		}
+		if len(ctx.Synthesis.Notes) != 1 || ctx.Synthesis.Notes[0] != "Tasks need fixes" {
+			t.Errorf("ctx.Synthesis.Notes = %v, want [Tasks need fixes]", ctx.Synthesis.Notes)
+		}
+		if len(ctx.Synthesis.Recommendations) != 1 || ctx.Synthesis.Recommendations[0] != "Fix tests first" {
+			t.Errorf("ctx.Synthesis.Recommendations = %v, want [Fix tests first]", ctx.Synthesis.Recommendations)
+		}
+		if len(ctx.Synthesis.Issues) != 1 || ctx.Synthesis.Issues[0] != "Build failing" {
+			t.Errorf("ctx.Synthesis.Issues = %v, want [Build failing]", ctx.Synthesis.Issues)
+		}
+	})
+
+	t.Run("finding different tasks", func(t *testing.T) {
+		session := &UltraPlanSession{
+			ID:        "session-123",
+			Objective: "Test multiple tasks",
+			Plan: &PlanSpec{
+				ID: "plan-456",
+				Tasks: []PlannedTask{
+					{ID: "task-1", Title: "Task 1", Description: "First"},
+					{ID: "task-2", Title: "Task 2", Description: "Second"},
+					{ID: "task-3", Title: "Task 3", Description: "Third"},
+				},
+			},
+			Revision: &RevisionState{
+				RevisionRound: 1,
+				MaxRevisions:  3,
+			},
+		}
+		manager := &UltraPlanManager{session: session}
+		coordinator := &Coordinator{manager: manager}
+		adapter := NewPromptAdapter(coordinator)
+
+		// Test finding task-2
+		ctx, err := adapter.BuildRevisionContext("task-2")
+		if err != nil {
+			t.Fatalf("BuildRevisionContext(task-2) error = %v, want nil", err)
+		}
+		if ctx.Task.ID != "task-2" {
+			t.Errorf("ctx.Task.ID = %q, want %q", ctx.Task.ID, "task-2")
+		}
+		if ctx.Task.Description != "Second" {
+			t.Errorf("ctx.Task.Description = %q, want %q", ctx.Task.Description, "Second")
+		}
+
+		// Test finding task-3
+		ctx, err = adapter.BuildRevisionContext("task-3")
+		if err != nil {
+			t.Fatalf("BuildRevisionContext(task-3) error = %v, want nil", err)
+		}
+		if ctx.Task.ID != "task-3" {
+			t.Errorf("ctx.Task.ID = %q, want %q", ctx.Task.ID, "task-3")
+		}
+		if ctx.Task.Description != "Third" {
+			t.Errorf("ctx.Task.Description = %q, want %q", ctx.Task.Description, "Third")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

This PR adds additional converter functions and the first two context builder methods (`BuildPlanningContext` and `BuildSynthesisContext`) to the PromptAdapter.

**Tasks included:**
- Add revision and synthesis info converters (task-2-revision-synthesis-converters)
- Add group context and consolidation converters (task-3-group-context-converter)
- Add candidate plan converter for multi-pass planning (task-4-candidate-plan-converter)
- Implement BuildPlanningContext method (task-5-planning-context)
- Implement BuildSynthesisContext method (task-7-synthesis-context)

**Changes:**
- `revisionInfoFromState`: converts revision state to `prompt.RevisionInfo`
- `synthesisInfoFromCompletion`: converts synthesis completion to `prompt.SynthesisInfo`
- `groupContextFromCompletion`: converts group completion to `prompt.GroupContext`
- `taskWorktreeInfoFromOrchestrator`: converts task worktrees for consolidation context
- `candidatePlanInfoFromPlanSpec`: converts plan specs for multi-pass planning
- `BuildPlanningContext()`: creates context for the planning phase
- `BuildSynthesisContext()`: creates context for the synthesis phase
- Comprehensive unit tests for all new code

## Test plan
- [x] All converter functions have comprehensive unit tests
- [x] BuildPlanningContext tests cover nil inputs, validation errors, and valid contexts
- [x] BuildSynthesisContext tests cover commit counts and task info population
- [x] Tests pass: `go test ./internal/orchestrator/...`
- [x] Build succeeds: `go build ./...`

---
**Part 2 of 3** - Merge after group-1 is merged, then merge group-3.

**⚠️ Base branch:** This PR targets `Iron-Ham/ultraplan-16704965-group-1` (stacked PR workflow).