### PR TITLE
Fix nested plan JSON wrapper in ParsePlanFromFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Ultraplan Nested Plan JSON Parsing** - Fixed `ParsePlanFromFile` failing with "plan contains no tasks" when the plan JSON has a nested `{"plan": {...}}` wrapper structure. Claude generating plans via `PlanManagerPromptTemplate` sometimes wraps the plan in a `plan` object. The parser now supports both formats: root-level (`{"summary": "...", "tasks": [...]}`) and nested (`{"plan": {"summary": "...", "tasks": [...]}}`). Also added support for alternative field names (`depends` as alias for `depends_on`, `complexity` as alias for `est_complexity`) that Claude may generate. Additionally, updated `PlanManagerPromptTemplate` to include the explicit JSON schema with a note to NOT wrap in a "plan" object, preventing the issue from occurring in future plan generations.
+
 ### Changed
 
 - **Phase Orchestrator Extraction** - Extracted the monolithic Coordinator (~3,800 lines) into four phase-specific orchestrators: `PlanningOrchestrator`, `ExecutionOrchestrator`, `SynthesisOrchestrator`, and `ConsolidationOrchestrator`. Each orchestrator owns one phase of ultra-plan execution with its own state management, monitoring, and restart capability. The main Coordinator is now a thin dispatcher (~500 lines) that instantiates orchestrators and delegates phase operations. This eliminates the god-object anti-pattern and enables independent testing of each phase.

--- a/internal/orchestrator/prompt/planning.go
+++ b/internal/orchestrator/prompt/planning.go
@@ -197,7 +197,22 @@ You must either:
 
 ## Output
 
-Write your final plan to ` + "`" + PlanFileName + "`" + ` using the standard plan JSON schema.
+Write your final plan to ` + "`" + PlanFileName + "`" + ` using the JSON schema below.
+
+### Plan JSON Schema
+
+Write a JSON file with this exact structure at the root level (do NOT wrap in a "plan" object):
+- "summary": Brief executive summary (string)
+- "tasks": Array of task objects, each with:
+  - "id": Unique identifier like "task-1-setup" (string)
+  - "title": Short title (string)
+  - "description": Detailed instructions for another Claude instance to execute independently (string)
+  - "files": Files this task will modify (array of strings)
+  - "depends_on": IDs of tasks that must complete first (array of strings, empty for independent tasks)
+  - "priority": Lower = higher priority within dependency level (number)
+  - "est_complexity": "low", "medium", or "high" (string)
+- "insights": Key findings about the codebase (array of strings)
+- "constraints": Risks or constraints to consider (array of strings)
 
 Before the plan file, output your reasoning in this format:
 <plan_decision>

--- a/internal/orchestrator/ultraplan.go
+++ b/internal/orchestrator/ultraplan.go
@@ -1800,7 +1800,22 @@ You must either:
 
 ## Output
 
-Write your final plan to ` + "`" + PlanFileName + "`" + ` using the standard plan JSON schema.
+Write your final plan to ` + "`" + PlanFileName + "`" + ` using the JSON schema below.
+
+### Plan JSON Schema
+
+Write a JSON file with this exact structure at the root level (do NOT wrap in a "plan" object):
+- "summary": Brief executive summary (string)
+- "tasks": Array of task objects, each with:
+  - "id": Unique identifier like "task-1-setup" (string)
+  - "title": Short title (string)
+  - "description": Detailed instructions for another Claude instance to execute independently (string)
+  - "files": Files this task will modify (array of strings)
+  - "depends_on": IDs of tasks that must complete first (array of strings, empty for independent tasks)
+  - "priority": Lower = higher priority within dependency level (number)
+  - "est_complexity": "low", "medium", or "high" (string)
+- "insights": Key findings about the codebase (array of strings)
+- "constraints": Risks or constraints to consider (array of strings)
 
 Before the plan file, output your reasoning in this format:
 <plan_decision>

--- a/internal/ultraplan/parsing.go
+++ b/internal/ultraplan/parsing.go
@@ -68,26 +68,83 @@ func ParsePlanFromOutput(output string, objective string) (*PlanSpec, error) {
 }
 
 // ParsePlanFromFile reads and parses a plan from a JSON file.
+// It supports two formats:
+//  1. Root-level format: {"summary": "...", "tasks": [...]}
+//  2. Nested format: {"plan": {"summary": "...", "tasks": [...]}}
+//
+// It also handles alternative field names that Claude may generate:
+//   - "depends" as alias for "depends_on"
+//   - "complexity" as alias for "est_complexity"
 func ParsePlanFromFile(filePath string, objective string) (*PlanSpec, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read plan file: %w", err)
 	}
 
-	// Parse the JSON
-	var rawPlan struct {
-		Summary     string        `json:"summary"`
-		Tasks       []PlannedTask `json:"tasks"`
-		Insights    []string      `json:"insights"`
-		Constraints []string      `json:"constraints"`
+	// flexibleTask handles alternative field names that Claude may generate
+	type flexibleTask struct {
+		ID            string   `json:"id"`
+		Title         string   `json:"title"`
+		Description   string   `json:"description"`
+		Files         []string `json:"files,omitempty"`
+		DependsOn     []string `json:"depends_on"`
+		Depends       []string `json:"depends"` // Alternative name
+		Priority      int      `json:"priority"`
+		EstComplexity string   `json:"est_complexity"`
+		Complexity    string   `json:"complexity"` // Alternative name
 	}
 
+	type planContent struct {
+		Summary     string         `json:"summary"`
+		Tasks       []flexibleTask `json:"tasks"`
+		Insights    []string       `json:"insights"`
+		Constraints []string       `json:"constraints"`
+	}
+
+	// Try parsing as root-level format first
+	var rawPlan planContent
 	if err := json.Unmarshal(data, &rawPlan); err != nil {
 		return nil, fmt.Errorf("failed to parse plan JSON: %w", err)
 	}
 
+	// If no tasks found, try nested "plan" wrapper format
+	if len(rawPlan.Tasks) == 0 {
+		var wrapped struct {
+			Plan planContent `json:"plan"`
+		}
+		if err := json.Unmarshal(data, &wrapped); err == nil && len(wrapped.Plan.Tasks) > 0 {
+			rawPlan = wrapped.Plan
+		}
+	}
+
 	if len(rawPlan.Tasks) == 0 {
 		return nil, fmt.Errorf("plan contains no tasks")
+	}
+
+	// Convert flexible tasks to PlannedTask, handling alternative field names
+	tasks := make([]PlannedTask, len(rawPlan.Tasks))
+	for i, ft := range rawPlan.Tasks {
+		// Use depends_on if set, otherwise fall back to depends
+		dependsOn := ft.DependsOn
+		if len(dependsOn) == 0 && len(ft.Depends) > 0 {
+			dependsOn = ft.Depends
+		}
+
+		// Use est_complexity if set, otherwise fall back to complexity
+		complexity := ft.EstComplexity
+		if complexity == "" && ft.Complexity != "" {
+			complexity = ft.Complexity
+		}
+
+		tasks[i] = PlannedTask{
+			ID:            ft.ID,
+			Title:         ft.Title,
+			Description:   ft.Description,
+			Files:         ft.Files,
+			DependsOn:     dependsOn,
+			Priority:      ft.Priority,
+			EstComplexity: TaskComplexity(complexity),
+		}
 	}
 
 	// Build the PlanSpec
@@ -95,7 +152,7 @@ func ParsePlanFromFile(filePath string, objective string) (*PlanSpec, error) {
 		ID:              generateID(),
 		Objective:       objective,
 		Summary:         rawPlan.Summary,
-		Tasks:           rawPlan.Tasks,
+		Tasks:           tasks,
 		Insights:        rawPlan.Insights,
 		Constraints:     rawPlan.Constraints,
 		DependencyGraph: make(map[string][]string),


### PR DESCRIPTION
## Summary

- Fixed `ParsePlanFromFile` failing with "plan contains no tasks" when the plan JSON has a nested `{"plan": {...}}` wrapper structure
- Added support for alternative field names (`depends` as alias for `depends_on`, `complexity` as alias for `est_complexity`) that Claude may generate
- Updated `PlanManagerPromptTemplate` to include explicit JSON schema with instruction to NOT wrap in a "plan" object

## Details

**Root Cause**: The `PlanManagerPromptTemplate` said "using the standard plan JSON schema" without actually specifying what that schema is. This caused Claude instances to sometimes wrap the plan in a `{"plan": {...}}` object.

**Two-part Fix**:
1. **Parser resilience** (`internal/ultraplan/parsing.go`): Handle both root-level and nested formats, plus alternative field names
2. **Prompt clarity** (`internal/orchestrator/ultraplan.go`, `internal/orchestrator/prompt/planning.go`): Include explicit JSON schema in the prompt

## Test plan

- [x] Added 8 new tests covering:
  - Root-level JSON format
  - Nested plan wrapper format
  - Alternative field names (depends vs depends_on, complexity vs est_complexity)
  - Mixed field names (standard takes precedence)
  - Error cases (empty tasks, invalid JSON, file not found)
- [x] All existing tests pass
- [x] `go build ./...` succeeds
- [x] `go vet ./...` passes
- [x] `gofmt -d` shows no formatting issues