### PR TITLE
Fix completion file detection when Claude changes directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Completion File Detection in Subdirectories** - Fixed completion files not being detected when Claude instances change into a subdirectory during task execution. When Claude runs `cd project/` and then writes `.claudio-task-complete.json`, the file ends up in the subdirectory instead of the worktree root. The verifier now uses a recursive search with depth limiting (max 5 levels) and directory skipping (node_modules, vendor, .git, Pods, etc.) to find completion files in subdirectories. Also updated all completion protocol prompts to emphasize that the file must be written at the worktree root.
 - **Ultraplan Nested Plan JSON Parsing** - Fixed `ParsePlanFromFile` failing with "plan contains no tasks" when the plan JSON has a nested `{"plan": {...}}` wrapper structure. Claude generating plans via `PlanManagerPromptTemplate` sometimes wraps the plan in a `plan` object. The parser now supports both formats: root-level (`{"summary": "...", "tasks": [...]}`) and nested (`{"plan": {"summary": "...", "tasks": [...]}}`). Also added support for alternative field names (`depends` as alias for `depends_on`, `complexity` as alias for `est_complexity`) that Claude may generate. Additionally, updated `PlanManagerPromptTemplate` to include the explicit JSON schema with a note to NOT wrap in a "plan" object, preventing the issue from occurring in future plan generations.
 
 ### Changed

--- a/internal/orchestrator/coordinator.go
+++ b/internal/orchestrator/coordinator.go
@@ -1136,6 +1136,8 @@ func (c *Coordinator) buildTaskPrompt(task *PlannedTask) string {
 	// Add completion protocol instructions
 	sb.WriteString("## Completion Protocol\n\n")
 	sb.WriteString("When your task is complete, you MUST write a completion file to signal the orchestrator:\n\n")
+	sb.WriteString("**CRITICAL**: Write this file at the ROOT of your worktree directory, not in any subdirectory.\n")
+	sb.WriteString("If you changed directories during the task (e.g., `cd project/`), use an absolute path or navigate back to the root first.\n\n")
 	sb.WriteString(fmt.Sprintf("1. Use Write tool to create `%s` in your worktree root\n", TaskCompletionFileName))
 	sb.WriteString("2. Include this JSON structure:\n")
 	sb.WriteString("```json\n")
@@ -3816,6 +3818,8 @@ func (c *Coordinator) buildGroupConsolidatorPrompt(groupIndex int) string {
 
 	// Completion protocol
 	sb.WriteString("## Completion Protocol\n\n")
+	sb.WriteString("**CRITICAL**: Write this file at the ROOT of your worktree directory, not in any subdirectory.\n")
+	sb.WriteString("If you changed directories during the task, use an absolute path or navigate back to the root first.\n\n")
 	sb.WriteString(fmt.Sprintf("When consolidation is complete, write `%s` in your worktree root:\n\n", GroupConsolidationCompletionFileName))
 	sb.WriteString("```json\n")
 	sb.WriteString("{\n")

--- a/internal/orchestrator/phase/execution.go
+++ b/internal/orchestrator/phase/execution.go
@@ -806,6 +806,8 @@ func (e *ExecutionOrchestrator) buildTaskPrompt(taskID string, task any) string 
 	// Add completion protocol instructions
 	sb.WriteString("## Completion Protocol\n\n")
 	sb.WriteString("When your task is complete, you MUST write a completion file to signal the orchestrator:\n\n")
+	sb.WriteString("**CRITICAL**: Write this file at the ROOT of your worktree directory, not in any subdirectory.\n")
+	sb.WriteString("If you changed directories during the task (e.g., `cd project/`), use an absolute path or navigate back to the root first.\n\n")
 	sb.WriteString(fmt.Sprintf("1. Use Write tool to create `%s` in your worktree root\n", TaskCompletionFileName))
 	sb.WriteString("2. Include this JSON structure:\n")
 	sb.WriteString("```json\n")

--- a/internal/orchestrator/prompt/consolidation.go
+++ b/internal/orchestrator/prompt/consolidation.go
@@ -187,6 +187,9 @@ const consolidationPromptTemplate = `You are consolidating work from multiple pa
 
 ## Completion Protocol
 
+**CRITICAL**: Write this file at the ROOT of your worktree directory, not in any subdirectory.
+If you changed directories during the task, use an absolute path or navigate back to the root first.
+
 When consolidation is complete, write ` + "`" + ConsolidationCompletionFileName + "`" + `:
 
 ` + "```json" + `
@@ -398,6 +401,8 @@ func (b *GroupConsolidatorBuilder) writeInstructions(sb *strings.Builder, consol
 // writeCompletionProtocol writes the completion protocol for group consolidation.
 func (b *GroupConsolidatorBuilder) writeCompletionProtocol(sb *strings.Builder, groupIndex int, consolidatedBranch string) {
 	sb.WriteString("## Completion Protocol\n\n")
+	sb.WriteString("**CRITICAL**: Write this file at the ROOT of your worktree directory, not in any subdirectory.\n")
+	sb.WriteString("If you changed directories during the task, use an absolute path or navigate back to the root first.\n\n")
 	fmt.Fprintf(sb, "When consolidation is complete, write `%s` in your worktree root:\n\n", GroupConsolidationCompletionFileName)
 	sb.WriteString("```json\n")
 	sb.WriteString("{\n")

--- a/internal/orchestrator/prompt/revision.go
+++ b/internal/orchestrator/prompt/revision.go
@@ -119,6 +119,9 @@ Focus only on addressing the identified issues. Do not refactor or make other ch
 
 ## Completion Protocol
 
+**CRITICAL**: Write this file at the ROOT of your worktree directory, not in any subdirectory.
+If you changed directories during the task, use an absolute path or navigate back to the root first.
+
 When your revision is complete, you MUST write a completion file:
 
 1. Use Write tool to create ` + "`" + RevisionCompletionFileName + "`" + ` in your worktree root

--- a/internal/orchestrator/prompt/synthesis.go
+++ b/internal/orchestrator/prompt/synthesis.go
@@ -132,6 +132,9 @@ const synthesisPromptTemplate = `You are reviewing the results of a parallel exe
 
 ## Completion Protocol
 
+**CRITICAL**: Write this file at the ROOT of your worktree directory, not in any subdirectory.
+If you changed directories during the task, use an absolute path or navigate back to the root first.
+
 When your review is complete, you MUST write a completion file to signal the orchestrator:
 
 1. Use Write tool to create ` + "`" + SynthesisCompletionFileName + "`" + ` in your worktree root

--- a/internal/orchestrator/prompt/task.go
+++ b/internal/orchestrator/prompt/task.go
@@ -115,6 +115,8 @@ func (b *TaskBuilder) writePreviousGroupContext(sb *strings.Builder, prev *Group
 func (b *TaskBuilder) writeCompletionProtocol(sb *strings.Builder, taskID string) {
 	sb.WriteString("## Completion Protocol\n\n")
 	sb.WriteString("When your task is complete, you MUST write a completion file to signal the orchestrator:\n\n")
+	sb.WriteString("**CRITICAL**: Write this file at the ROOT of your worktree directory, not in any subdirectory.\n")
+	sb.WriteString("If you changed directories during the task (e.g., `cd project/`), use an absolute path or navigate back to the root first.\n\n")
 	fmt.Fprintf(sb, "1. Use Write tool to create `%s` in your worktree root\n", TaskCompletionFileName)
 	sb.WriteString("2. Include this JSON structure:\n")
 	sb.WriteString("```json\n")


### PR DESCRIPTION
## Summary

- Fixed completion files not being detected when Claude instances change into a subdirectory during task execution
- When Claude runs `cd project/` and then writes `.claudio-task-complete.json`, the file ends up in the subdirectory instead of the worktree root
- The verifier now uses a recursive search with depth limiting (max 5 levels) and directory skipping (node_modules, vendor, .git, Pods, etc.) to find completion files in subdirectories
- Updated all completion protocol prompts to emphasize that the file must be written at the worktree root

## Test plan

- [x] Added 8 new tests for subdirectory detection scenarios
- [x] All existing tests pass
- [x] `go vet ./...` passes
- [x] `go build ./...` passes