### PR TITLE
Fix sidebar navigation to follow display order instead of creation order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Prompt Building Refactor** - Extracted prompt-building logic from coordinator.go into the orchestrator/prompt package, improving code organization and testability. Updated `buildPlanManagerPrompt` and `buildPlanComparisonSection` methods to use `PlanningBuilder` with the new conversion helpers. Added `FormatDetailedPlans` and `BuildCompactPlanManagerPrompt` methods to `PlanningBuilder` for flexible plan formatting. Exported `PlanManagerPromptTemplate` in the prompt package.
 - **Complete Coordinator Prompt Builder Migration** - Migrated remaining coordinator prompt-building methods (`buildRevisionPrompt`, `buildSynthesisPrompt`, `buildConsolidationPrompt`) to use the extracted prompt builders (`RevisionBuilder`, `SynthesisBuilder`, `ConsolidationBuilder`). Removed duplicate prompt templates from `ultraplan.go` that are now defined in the `orchestrator/prompt` package. Removed unused `PromptAdapter` struct and its methods (keeping only the standalone type conversion functions that are actively used). This completes the separation of prompt-building concerns from the Coordinator.
 
+### Fixed
+
+- **Sidebar Navigation Order** - Fixed h/l (or tab/shift-tab) navigation in the sidebar navigating by instance creation order instead of display order. When instances are grouped (e.g., in ultraplan mode), the sidebar displays instances in a specific hierarchy (ungrouped first, then by group). Navigation now correctly follows the visual display order rather than the internal creation order, preventing user confusion when pressing tab/l to move to the "next" instance.
+
 ## [0.7.1] - 2026-01-15
 
 This release focuses on **Phase Orchestration** - extracting the monolithic Coordinator into four phase-specific orchestrators and implementing comprehensive synthesis/revision orchestration logic.


### PR DESCRIPTION
## Summary

- Fixes h/l and tab/shift-tab navigation in the grouped sidebar to follow display order (how instances appear visually) instead of creation order
- When instances are grouped (e.g., in ultraplan mode), ungrouped instances appear first followed by grouped instances - navigation now correctly follows this visual order
- Adds `isGroupedSidebarMode()` helper for cleaner condition checks
- Adds comprehensive tests for grouped mode navigation

## Problem

Previously, pressing tab/l would cycle through instances in the order they were created internally, not the order they appeared in the sidebar. This was confusing because the "next" instance visually might not be the next one selected.

## Solution

- `getInstanceDisplayOrder()` returns instance IDs in the order they appear in the sidebar by leveraging the existing `FlattenGroupsForDisplayWithUltraPlan()` function
- Navigation handlers find the current instance's position in display order and move to the next/previous in that order
- Correctly handles UltraPlan mode, collapsed groups, and wrap-around

## Test plan

- [x] `TestIsGroupedSidebarMode` - Verifies helper returns correct values for flat mode, grouped mode, nil cases
- [x] `TestGetInstanceDisplayOrder_FlatMode` - Verifies flat mode returns creation order
- [x] `TestGetInstanceDisplayOrder_GroupedMode` - Verifies grouped mode returns display order (ungrouped first)
- [x] `TestGetInstanceDisplayOrder_CollapsedGroup` - Verifies collapsed group instances are excluded
- [x] `TestNavigationCycle_GroupedMode` - End-to-end navigation cycle verification
- [x] All existing tests pass
- [x] `gofmt` and `go vet` pass