### PR TITLE
Add git submodule support for worktree operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Header Mode Indicator** - Added a prominent mode indicator in the header bar that shows the current input mode (INPUT, TERMINAL, COMMAND, SEARCH, FILTER, NEW TASK). High-priority modes like INPUT and TERMINAL use contrasting colors (amber and green backgrounds respectively) to make it immediately clear when keyboard input is being forwarded to Claude or the terminal pane rather than controlling the TUI. This helps users avoid accidentally typing in the wrong mode.
+- **Git Submodule Support** - Worktrees now automatically initialize git submodules on creation. Added `HasSubmodules()`, `GetSubmodules()`, `GetSubmodulePaths()`, `InitSubmodules()`, `GetSubmoduleStatus()`, and `IsSubmoduleDir()` to the worktree package. The `protocol.file.allow=always` flag is used for git 2.38+ compatibility with local submodule references.
+
 - **Prompt Type Conversion Helpers** - Added interface-based type conversion helpers in `internal/orchestrator/prompt/convert.go` to enable decoupled conversion from orchestrator types to prompt types. Includes `PlannedTaskLike`, `PlanSpecLike`, and `GroupConsolidationLike` interfaces with corresponding conversion functions (`ConvertPlannedTaskToTaskInfo`, `ConvertPlanSpecToPlanInfo`, `ConvertPlanSpecsToCandidatePlans`, `ConvertGroupConsolidationToGroupContext`). This enables extracting prompt-building logic from coordinator.go into the prompt package without creating circular imports.
 - **Strategy Names Context Support** - Added `StrategyNames` field to `prompt.Context` to provide fallback strategy names when `CandidatePlanInfo.Strategy` is empty. This allows the coordinator to pass strategy names via Context rather than requiring the prompt package to import from ultraplan.go (avoiding circular imports). Also added `FormatCompactPlansWithContext` method to `PlanningBuilder` for compact plan formatting with strategy name fallback support.
+
+### Fixed
+
+- **Git Submodule File Traversal** - Fixed errors and warnings when working with repositories containing git submodules. File traversal in the conflict detector, completion file verifier, and code analyzer now correctly skips submodule directories to prevent permission errors, symlink errors, and duplicate events when submodules are uninitialized or partially initialized.
 
 ### Changed
 

--- a/internal/orchestrator/verify/verifier.go
+++ b/internal/orchestrator/verify/verifier.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/Iron-Ham/claudio/internal/logging"
+	"github.com/Iron-Ham/claudio/internal/worktree"
 )
 
 // TaskCompletionFileName is the sentinel file that tasks write when complete.
@@ -258,6 +259,12 @@ func (v *TaskVerifier) findCompletionFile(worktreePath, filename string) string 
 
 		// Skip known large/irrelevant directories
 		if d.IsDir() && skippedDirectories[d.Name()] {
+			return fs.SkipDir
+		}
+
+		// Skip git submodule directories to avoid errors when traversing
+		// uninitialized or partially initialized submodules
+		if d.IsDir() && worktree.IsSubmoduleDir(path) {
 			return fs.SkipDir
 		}
 

--- a/internal/ultraplan/decomposition/analyzer.go
+++ b/internal/ultraplan/decomposition/analyzer.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/Iron-Ham/claudio/internal/ultraplan"
+	"github.com/Iron-Ham/claudio/internal/worktree"
 )
 
 // Analyzer performs code structure analysis to enhance task decomposition.
@@ -140,6 +141,11 @@ func (a *Analyzer) buildPackageGraph() error {
 		name := info.Name()
 		if info.IsDir() {
 			if strings.HasPrefix(name, ".") || name == "vendor" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+			// Skip git submodule directories to avoid errors when walking
+			// uninitialized or partially initialized submodules
+			if worktree.IsSubmoduleDir(path) {
 				return filepath.SkipDir
 			}
 			return nil

--- a/internal/worktree/submodule.go
+++ b/internal/worktree/submodule.go
@@ -1,0 +1,367 @@
+package worktree
+
+import (
+	"bufio"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// SubmoduleInfo contains information about a git submodule.
+type SubmoduleInfo struct {
+	Name   string // The submodule name from .gitmodules
+	Path   string // The relative path to the submodule
+	URL    string // The submodule URL
+	Branch string // Branch to track (empty if not specified)
+}
+
+// SubmoduleStatus represents the status of a submodule.
+type SubmoduleStatus int
+
+const (
+	// SubmoduleUpToDate indicates the submodule is at the recorded commit.
+	SubmoduleUpToDate SubmoduleStatus = iota
+	// SubmoduleNotInitialized indicates the submodule needs to be initialized.
+	SubmoduleNotInitialized
+	// SubmoduleDifferentCommit indicates the submodule is at a different commit.
+	SubmoduleDifferentCommit
+	// SubmoduleMergeConflict indicates the submodule has merge conflicts.
+	SubmoduleMergeConflict
+)
+
+func (s SubmoduleStatus) String() string {
+	switch s {
+	case SubmoduleUpToDate:
+		return "up-to-date"
+	case SubmoduleNotInitialized:
+		return "not-initialized"
+	case SubmoduleDifferentCommit:
+		return "different-commit"
+	case SubmoduleMergeConflict:
+		return "merge-conflict"
+	default:
+		return "unknown"
+	}
+}
+
+// SubmoduleStatusInfo contains status information about a submodule.
+type SubmoduleStatusInfo struct {
+	Path   string          // Path to the submodule relative to worktree root
+	Commit string          // Current commit SHA (may be abbreviated)
+	Status SubmoduleStatus // Current status indicator
+}
+
+// SubmoduleError represents an error during submodule operations.
+type SubmoduleError struct {
+	Operation string // The operation that failed (e.g., "init", "update")
+	Output    string // Command output
+	Err       error  // Underlying error
+}
+
+func (e *SubmoduleError) Error() string {
+	return "submodule " + e.Operation + " failed: " + e.Err.Error() + "\n" + e.Output
+}
+
+func (e *SubmoduleError) Unwrap() error {
+	return e.Err
+}
+
+// HasSubmodules checks if the repository has any git submodules configured.
+// It checks for the presence of a .gitmodules file in the repository root.
+func (m *Manager) HasSubmodules() bool {
+	gitmodulesPath := filepath.Join(m.repoDir, ".gitmodules")
+	info, err := os.Stat(gitmodulesPath)
+	if err != nil {
+		return false
+	}
+	// File must exist, be a regular file, and have content (not be empty)
+	return info.Mode().IsRegular() && info.Size() > 0
+}
+
+// GetSubmodules returns a list of all submodules defined in the repository.
+// Returns an empty slice if no submodules exist.
+func (m *Manager) GetSubmodules() ([]SubmoduleInfo, error) {
+	gitmodulesPath := filepath.Join(m.repoDir, ".gitmodules")
+	if _, err := os.Stat(gitmodulesPath); os.IsNotExist(err) {
+		return []SubmoduleInfo{}, nil
+	}
+
+	file, err := os.Open(gitmodulesPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+
+	return parseGitmodules(file)
+}
+
+// GetSubmodulePaths returns just the paths of all submodules.
+// This is useful for filtering out submodule directories during file operations.
+func (m *Manager) GetSubmodulePaths() ([]string, error) {
+	submodules, err := m.GetSubmodules()
+	if err != nil {
+		return nil, err
+	}
+
+	paths := make([]string, 0, len(submodules))
+	for _, sm := range submodules {
+		if sm.Path != "" {
+			paths = append(paths, sm.Path)
+		}
+	}
+	return paths, nil
+}
+
+// InitSubmodules initializes and updates git submodules in the specified worktree path.
+// This should be called after creating a worktree in a repository that has submodules.
+// If the repository has no submodules, this is a no-op and returns nil.
+//
+// The function runs: git -c protocol.file.allow=always submodule update --init --recursive
+// The protocol.file.allow=always flag is needed for git 2.38.1+ which disallows file transport
+// by default for security, but we need it for local submodule references.
+func (m *Manager) InitSubmodules(worktreePath string) error {
+	if !m.HasSubmodules() {
+		return nil
+	}
+
+	// Use -c protocol.file.allow=always to support local file:// submodule URLs
+	// which are blocked by default in newer git versions for security
+	args := []string{"-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive"}
+	cmd := exec.Command("git", args...)
+	cmd.Dir = worktreePath
+
+	output, err := cmd.CombinedOutput()
+	if m.logger != nil {
+		m.logger.Debug("git submodule command", "args", args, "output", truncateOutput(string(output), 500))
+	}
+
+	if err != nil {
+		// Check if this is a critical error or just a warning
+		if isSubmoduleCriticalError(string(output)) {
+			if m.logger != nil {
+				m.logger.Error("git submodule command failed", "args", args, "error", err, "output", string(output))
+			}
+			return &SubmoduleError{
+				Operation: "init",
+				Output:    string(output),
+				Err:       err,
+			}
+		}
+		// Non-critical error - log warning but don't fail
+		if m.logger != nil {
+			m.logger.Warn("submodule initialization had issues",
+				"path", worktreePath,
+				"output", truncateOutput(string(output), 500))
+		}
+		return nil
+	}
+
+	if m.logger != nil {
+		m.logger.Info("submodules initialized", "path", worktreePath)
+	}
+
+	return nil
+}
+
+// GetSubmoduleStatus returns the status of submodules in the given path.
+// Returns nil if the repository has no submodules.
+func (m *Manager) GetSubmoduleStatus(worktreePath string) ([]SubmoduleStatusInfo, error) {
+	if !m.HasSubmodules() {
+		return nil, nil
+	}
+
+	args := []string{"submodule", "status", "--recursive"}
+	cmd := exec.Command("git", args...)
+	cmd.Dir = worktreePath
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseSubmoduleStatus(string(output)), nil
+}
+
+// IsSubmodulePath checks if a given path (relative to repo root) is inside a submodule.
+// This is useful for file watching to skip files inside submodules.
+func (m *Manager) IsSubmodulePath(relativePath string) bool {
+	paths, err := m.GetSubmodulePaths()
+	if err != nil {
+		return false
+	}
+
+	// Normalize path separators
+	relativePath = filepath.ToSlash(relativePath)
+
+	for _, smPath := range paths {
+		smPath = filepath.ToSlash(smPath)
+		// Check if relativePath starts with or equals the submodule path
+		if relativePath == smPath || strings.HasPrefix(relativePath, smPath+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// IsSubmoduleDir checks if a directory is a git submodule by looking for
+// a .git file (not directory) that points to the parent repo's .git/modules.
+// In worktrees, submodule .git entries point to the main repo's modules.
+//
+// This function is safe to call on any path - it returns false if the
+// path doesn't exist, can't be accessed, or isn't a submodule.
+func IsSubmoduleDir(path string) bool {
+	gitPath := filepath.Join(path, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		// Either path doesn't exist or we can't access it - either way, not a submodule
+		return false
+	}
+
+	// A submodule has a .git file (not directory) that contains a gitdir reference
+	if info.Mode().IsRegular() {
+		content, err := os.ReadFile(gitPath)
+		if err != nil {
+			// Can't read the file - assume not a submodule
+			return false
+		}
+		// Submodule .git files contain "gitdir: <path>"
+		return strings.HasPrefix(string(content), "gitdir:")
+	}
+
+	return false
+}
+
+// parseGitmodules parses a .gitmodules file and returns submodule information.
+func parseGitmodules(file *os.File) ([]SubmoduleInfo, error) {
+	var submodules []SubmoduleInfo
+	var current *SubmoduleInfo
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Check for section header [submodule "name"]
+		if strings.HasPrefix(line, "[submodule ") {
+			// Save previous submodule if exists and has a path
+			if current != nil && current.Path != "" {
+				submodules = append(submodules, *current)
+			}
+
+			// Parse the submodule name
+			name := strings.TrimPrefix(line, "[submodule ")
+			name = strings.TrimSuffix(name, "]")
+			name = strings.Trim(name, "\"")
+
+			current = &SubmoduleInfo{Name: name}
+			continue
+		}
+
+		// Parse key = value pairs
+		if current == nil {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		switch key {
+		case "path":
+			current.Path = value
+		case "url":
+			current.URL = value
+		case "branch":
+			current.Branch = value
+		}
+	}
+
+	// Don't forget the last submodule
+	if current != nil && current.Path != "" {
+		submodules = append(submodules, *current)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return submodules, nil
+}
+
+// parseSubmoduleStatus parses the output of 'git submodule status'.
+func parseSubmoduleStatus(output string) []SubmoduleStatusInfo {
+	var submodules []SubmoduleStatusInfo
+
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+
+		var status SubmoduleStatus
+		switch line[0] {
+		case ' ':
+			status = SubmoduleUpToDate
+		case '-':
+			status = SubmoduleNotInitialized
+		case '+':
+			status = SubmoduleDifferentCommit
+		case 'U':
+			status = SubmoduleMergeConflict
+		default:
+			status = SubmoduleUpToDate // Default assumption
+		}
+
+		// Remove the status prefix and parse commit + path
+		// Format: " <commit> <path> (<branch>)" or "-<commit> <path>"
+		rest := strings.TrimLeft(line, " -+U")
+		parts := strings.Fields(rest)
+		if len(parts) >= 2 {
+			submodules = append(submodules, SubmoduleStatusInfo{
+				Commit: parts[0],
+				Path:   parts[1],
+				Status: status,
+			})
+		}
+	}
+
+	return submodules
+}
+
+// isSubmoduleCriticalError checks if the submodule output indicates a critical error
+// that should fail worktree creation, vs a warning that can be safely ignored.
+func isSubmoduleCriticalError(output string) bool {
+	criticalPatterns := []string{
+		"fatal:",                       // Git fatal errors
+		"permission denied",            // Access issues
+		"could not read from remote",   // Network/auth failures for required submodules
+		"repository not found",         // Missing remote repository
+		"unable to access",             // Access failures
+		"authentication failed",        // Auth failures
+		"host key verification failed", // SSH issues
+		"no submodule mapping found",   // Corrupted .gitmodules
+	}
+
+	lowerOutput := strings.ToLower(output)
+	for _, pattern := range criticalPatterns {
+		if strings.Contains(lowerOutput, pattern) {
+			return true
+		}
+	}
+
+	// Check for clone failures specifically (they contain both "clone" and "failed")
+	if strings.Contains(lowerOutput, "clone") && strings.Contains(lowerOutput, "failed") {
+		return true
+	}
+
+	return false
+}

--- a/internal/worktree/submodule_test.go
+++ b/internal/worktree/submodule_test.go
@@ -1,0 +1,371 @@
+//go:build integration
+
+package worktree
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/testutil"
+)
+
+func TestManager_HasSubmodules(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	tests := []struct {
+		name       string
+		setupFunc  func(t *testing.T) string
+		wantResult bool
+	}{
+		{
+			name: "repo without submodules",
+			setupFunc: func(t *testing.T) string {
+				return testutil.SetupTestRepo(t)
+			},
+			wantResult: false,
+		},
+		{
+			name: "repo with submodule",
+			setupFunc: func(t *testing.T) string {
+				mainRepo, _ := testutil.SetupTestRepoWithSubmodule(t)
+				return mainRepo
+			},
+			wantResult: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoDir := tt.setupFunc(t)
+
+			mgr, err := New(repoDir)
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			got := mgr.HasSubmodules()
+			if got != tt.wantResult {
+				t.Errorf("HasSubmodules() = %v, want %v", got, tt.wantResult)
+			}
+		})
+	}
+}
+
+func TestManager_GetSubmodules(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	tests := []struct {
+		name      string
+		setupFunc func(t *testing.T) string
+		wantCount int
+		wantPath  string
+	}{
+		{
+			name: "repo without submodules",
+			setupFunc: func(t *testing.T) string {
+				return testutil.SetupTestRepo(t)
+			},
+			wantCount: 0,
+		},
+		{
+			name: "repo with submodule",
+			setupFunc: func(t *testing.T) string {
+				mainRepo, _ := testutil.SetupTestRepoWithSubmodule(t)
+				return mainRepo
+			},
+			wantCount: 1,
+			wantPath:  "vendor/submod",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoDir := tt.setupFunc(t)
+
+			mgr, err := New(repoDir)
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			submodules, err := mgr.GetSubmodules()
+			if err != nil {
+				t.Fatalf("GetSubmodules() error = %v", err)
+			}
+
+			if len(submodules) != tt.wantCount {
+				t.Errorf("GetSubmodules() returned %d submodules, want %d", len(submodules), tt.wantCount)
+			}
+
+			if tt.wantCount > 0 && tt.wantPath != "" {
+				if submodules[0].Path != tt.wantPath {
+					t.Errorf("GetSubmodules()[0].Path = %q, want %q", submodules[0].Path, tt.wantPath)
+				}
+			}
+		})
+	}
+}
+
+func TestManager_GetSubmodulePaths(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	mainRepo, _ := testutil.SetupTestRepoWithSubmodule(t)
+
+	mgr, err := New(mainRepo)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	paths, err := mgr.GetSubmodulePaths()
+	if err != nil {
+		t.Fatalf("GetSubmodulePaths() error = %v", err)
+	}
+
+	if len(paths) != 1 {
+		t.Fatalf("GetSubmodulePaths() returned %d paths, want 1", len(paths))
+	}
+
+	if paths[0] != "vendor/submod" {
+		t.Errorf("GetSubmodulePaths()[0] = %q, want %q", paths[0], "vendor/submod")
+	}
+}
+
+func TestManager_IsSubmodulePath(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	mainRepo, _ := testutil.SetupTestRepoWithSubmodule(t)
+
+	mgr, err := New(mainRepo)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"vendor/submod", true},
+		{"vendor/submod/file.txt", true},
+		{"vendor/submod/nested/deep/file.txt", true},
+		{"vendor/other", false},
+		{"vendor", false},
+		{"README.md", false},
+		{"src/main.go", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := mgr.IsSubmodulePath(tt.path)
+			if got != tt.want {
+				t.Errorf("IsSubmodulePath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSubmoduleDir(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	mainRepo, _ := testutil.SetupTestRepoWithSubmodule(t)
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "submodule directory",
+			path: filepath.Join(mainRepo, "vendor", "submod"),
+			want: true,
+		},
+		{
+			name: "normal directory",
+			path: mainRepo,
+			want: false,
+		},
+		{
+			name: "non-existent directory",
+			path: filepath.Join(mainRepo, "nonexistent"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsSubmoduleDir(tt.path)
+			if got != tt.want {
+				t.Errorf("IsSubmoduleDir(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestManager_InitSubmodules(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	tests := []struct {
+		name        string
+		setupFunc   func(t *testing.T) (string, string)
+		wantErr     bool
+		checkResult func(t *testing.T, worktreePath string)
+	}{
+		{
+			name: "repo without submodules",
+			setupFunc: func(t *testing.T) (string, string) {
+				repo := testutil.SetupTestRepo(t)
+				return repo, repo // No submodules
+			},
+			wantErr: false,
+		},
+		{
+			name: "repo with submodule",
+			setupFunc: func(t *testing.T) (string, string) {
+				mainRepo, _ := testutil.SetupTestRepoWithSubmodule(t)
+				// Create a worktree to test submodule init
+				mgr, _ := New(mainRepo)
+				wtPath := filepath.Join(t.TempDir(), "worktree")
+				_ = mgr.Create(wtPath, "test-branch")
+				return mainRepo, wtPath
+			},
+			wantErr: false,
+			checkResult: func(t *testing.T, worktreePath string) {
+				// Verify submodule content exists in worktree
+				subFile := filepath.Join(worktreePath, "vendor", "submod", "submodule-file.txt")
+				if _, err := os.Stat(subFile); os.IsNotExist(err) {
+					t.Errorf("submodule file should exist at %s after initialization", subFile)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mainRepo, worktreePath := tt.setupFunc(t)
+
+			mgr, err := New(mainRepo)
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			err = mgr.InitSubmodules(worktreePath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("InitSubmodules() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.checkResult != nil {
+				tt.checkResult(t, worktreePath)
+			}
+		})
+	}
+}
+
+func TestManager_CreateWorktree_WithSubmodules(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	tests := []struct {
+		name       string
+		createFunc func(mgr *Manager, wtPath string) error
+	}{
+		{
+			name: "Create initializes submodules",
+			createFunc: func(mgr *Manager, wtPath string) error {
+				return mgr.Create(wtPath, "test-create-branch")
+			},
+		},
+		{
+			name: "CreateFromBranch initializes submodules",
+			createFunc: func(mgr *Manager, wtPath string) error {
+				return mgr.CreateFromBranch(wtPath, "test-from-branch", "main")
+			},
+		},
+		{
+			name: "CreateWorktreeFromBranch initializes submodules",
+			createFunc: func(mgr *Manager, wtPath string) error {
+				// First create a branch without a worktree, then create worktree from it
+				if err := mgr.CreateBranchFrom("test-existing-branch", "main"); err != nil {
+					return err
+				}
+				return mgr.CreateWorktreeFromBranch(wtPath, "test-existing-branch")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mainRepo, _ := testutil.SetupTestRepoWithSubmodule(t)
+
+			mgr, err := New(mainRepo)
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			wtPath := filepath.Join(t.TempDir(), "worktree")
+			if err := tt.createFunc(mgr, wtPath); err != nil {
+				t.Fatalf("worktree creation error = %v", err)
+			}
+
+			// Verify submodule content exists in the new worktree
+			subFile := filepath.Join(wtPath, "vendor", "submod", "submodule-file.txt")
+			if _, err := os.Stat(subFile); os.IsNotExist(err) {
+				t.Errorf("submodule file should exist at %s after worktree creation", subFile)
+			}
+		})
+	}
+}
+
+func TestManager_GetSubmoduleStatus(t *testing.T) {
+	testutil.SkipIfNoGit(t)
+
+	tests := []struct {
+		name       string
+		setupFunc  func(t *testing.T) string
+		wantNil    bool
+		wantStatus SubmoduleStatus
+	}{
+		{
+			name: "repository without submodules returns nil",
+			setupFunc: func(t *testing.T) string {
+				return testutil.SetupTestRepo(t)
+			},
+			wantNil: true,
+		},
+		{
+			name: "initialized submodule shows up-to-date",
+			setupFunc: func(t *testing.T) string {
+				mainRepo, _ := testutil.SetupTestRepoWithSubmodule(t)
+				return mainRepo
+			},
+			wantNil:    false,
+			wantStatus: SubmoduleUpToDate,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoDir := tt.setupFunc(t)
+
+			mgr, err := New(repoDir)
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			status, err := mgr.GetSubmoduleStatus(repoDir)
+			if err != nil {
+				t.Fatalf("GetSubmoduleStatus() error = %v", err)
+			}
+
+			if tt.wantNil && status != nil {
+				t.Errorf("GetSubmoduleStatus() = %v, want nil", status)
+			}
+
+			if !tt.wantNil {
+				if status == nil || len(status) == 0 {
+					t.Fatal("GetSubmoduleStatus() returned nil or empty, want non-empty")
+				}
+				if status[0].Status != tt.wantStatus {
+					t.Errorf("GetSubmoduleStatus()[0].Status = %v, want %v", status[0].Status, tt.wantStatus)
+				}
+			}
+		})
+	}
+}

--- a/internal/worktree/submodule_unit_test.go
+++ b/internal/worktree/submodule_unit_test.go
@@ -1,0 +1,442 @@
+package worktree
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseGitmodules(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantCount int
+		wantFirst *SubmoduleInfo
+	}{
+		{
+			name:      "empty file",
+			content:   "",
+			wantCount: 0,
+		},
+		{
+			name: "single submodule",
+			content: `[submodule "mylib"]
+	path = vendor/mylib
+	url = https://github.com/example/mylib.git
+`,
+			wantCount: 1,
+			wantFirst: &SubmoduleInfo{
+				Name: "mylib",
+				Path: "vendor/mylib",
+				URL:  "https://github.com/example/mylib.git",
+			},
+		},
+		{
+			name: "multiple submodules",
+			content: `[submodule "lib1"]
+	path = vendor/lib1
+	url = https://github.com/example/lib1.git
+
+[submodule "lib2"]
+	path = vendor/lib2
+	url = git@github.com:example/lib2.git
+	branch = develop
+`,
+			wantCount: 2,
+			wantFirst: &SubmoduleInfo{
+				Name: "lib1",
+				Path: "vendor/lib1",
+				URL:  "https://github.com/example/lib1.git",
+			},
+		},
+		{
+			name: "with comments and blank lines",
+			content: `# This is a comment
+[submodule "mylib"]
+	path = libs/mylib
+	url = https://example.com/mylib.git
+	# Another comment
+`,
+			wantCount: 1,
+			wantFirst: &SubmoduleInfo{
+				Name: "mylib",
+				Path: "libs/mylib",
+				URL:  "https://example.com/mylib.git",
+			},
+		},
+		{
+			name: "submodule name with spaces",
+			content: `[submodule "my lib name"]
+	path = vendor/mylib
+	url = https://example.com/mylib.git
+`,
+			wantCount: 1,
+			wantFirst: &SubmoduleInfo{
+				Name: "my lib name",
+				Path: "vendor/mylib",
+				URL:  "https://example.com/mylib.git",
+			},
+		},
+		{
+			name: "handles tabs and spaces in values",
+			content: `[submodule "lib"]
+	path =   vendor/lib
+	url =	https://example.com/lib.git
+`,
+			wantCount: 1,
+			wantFirst: &SubmoduleInfo{
+				Name: "lib",
+				Path: "vendor/lib",
+				URL:  "https://example.com/lib.git",
+			},
+		},
+		{
+			name: "skips submodule without path",
+			content: `[submodule "nopath"]
+	url = https://example.com/nopath.git
+
+[submodule "haspath"]
+	path = vendor/haspath
+	url = https://example.com/haspath.git
+`,
+			wantCount: 1,
+			wantFirst: &SubmoduleInfo{
+				Name: "haspath",
+				Path: "vendor/haspath",
+				URL:  "https://example.com/haspath.git",
+			},
+		},
+		{
+			name: "with branch field",
+			content: `[submodule "lib"]
+	path = vendor/lib
+	url = https://example.com/lib.git
+	branch = feature/dev
+`,
+			wantCount: 1,
+			wantFirst: &SubmoduleInfo{
+				Name:   "lib",
+				Path:   "vendor/lib",
+				URL:    "https://example.com/lib.git",
+				Branch: "feature/dev",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temporary file with the content
+			tmpFile, err := os.CreateTemp("", "gitmodules")
+			if err != nil {
+				t.Fatalf("failed to create temp file: %v", err)
+			}
+			defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+			if _, err := tmpFile.WriteString(tt.content); err != nil {
+				t.Fatalf("failed to write to temp file: %v", err)
+			}
+			if _, err := tmpFile.Seek(0, 0); err != nil {
+				t.Fatalf("failed to seek temp file: %v", err)
+			}
+
+			submodules, err := parseGitmodules(tmpFile)
+			if err != nil {
+				t.Fatalf("parseGitmodules() error = %v", err)
+			}
+
+			if len(submodules) != tt.wantCount {
+				t.Errorf("parseGitmodules() returned %d submodules, want %d", len(submodules), tt.wantCount)
+			}
+
+			if tt.wantFirst != nil && len(submodules) > 0 {
+				got := submodules[0]
+				if got.Name != tt.wantFirst.Name {
+					t.Errorf("Name = %q, want %q", got.Name, tt.wantFirst.Name)
+				}
+				if got.Path != tt.wantFirst.Path {
+					t.Errorf("Path = %q, want %q", got.Path, tt.wantFirst.Path)
+				}
+				if got.URL != tt.wantFirst.URL {
+					t.Errorf("URL = %q, want %q", got.URL, tt.wantFirst.URL)
+				}
+				if got.Branch != tt.wantFirst.Branch {
+					t.Errorf("Branch = %q, want %q", got.Branch, tt.wantFirst.Branch)
+				}
+			}
+		})
+	}
+}
+
+func TestIsSubmoduleDir_Unit(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T) string
+		want  bool
+	}{
+		{
+			name: "directory with .git file pointing to gitdir",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				gitFile := filepath.Join(dir, ".git")
+				if err := os.WriteFile(gitFile, []byte("gitdir: /path/to/main/.git/modules/submod"), 0644); err != nil {
+					t.Fatalf("failed to write .git file: %v", err)
+				}
+				return dir
+			},
+			want: true,
+		},
+		{
+			name: "directory with .git directory",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				gitDir := filepath.Join(dir, ".git")
+				if err := os.Mkdir(gitDir, 0755); err != nil {
+					t.Fatalf("failed to create .git directory: %v", err)
+				}
+				return dir
+			},
+			want: false,
+		},
+		{
+			name: "directory without .git",
+			setup: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			want: false,
+		},
+		{
+			name: "directory with .git file but no gitdir prefix",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				gitFile := filepath.Join(dir, ".git")
+				if err := os.WriteFile(gitFile, []byte("some other content"), 0644); err != nil {
+					t.Fatalf("failed to write .git file: %v", err)
+				}
+				return dir
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := tt.setup(t)
+			got := IsSubmoduleDir(dir)
+			if got != tt.want {
+				t.Errorf("IsSubmoduleDir() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSubmoduleStatus_String(t *testing.T) {
+	tests := []struct {
+		status SubmoduleStatus
+		want   string
+	}{
+		{SubmoduleUpToDate, "up-to-date"},
+		{SubmoduleNotInitialized, "not-initialized"},
+		{SubmoduleDifferentCommit, "different-commit"},
+		{SubmoduleMergeConflict, "merge-conflict"},
+		{SubmoduleStatus(99), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := tt.status.String()
+			if got != tt.want {
+				t.Errorf("SubmoduleStatus.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSubmoduleStatus(t *testing.T) {
+	tests := []struct {
+		name      string
+		output    string
+		wantCount int
+		wantFirst *SubmoduleStatusInfo
+	}{
+		{
+			name:      "empty output",
+			output:    "",
+			wantCount: 0,
+		},
+		{
+			name:      "up-to-date submodule",
+			output:    " abc1234 vendor/lib (v1.0.0)",
+			wantCount: 1,
+			wantFirst: &SubmoduleStatusInfo{
+				Path:   "vendor/lib",
+				Commit: "abc1234",
+				Status: SubmoduleUpToDate,
+			},
+		},
+		{
+			name:      "not initialized submodule",
+			output:    "-abc1234 vendor/lib",
+			wantCount: 1,
+			wantFirst: &SubmoduleStatusInfo{
+				Path:   "vendor/lib",
+				Commit: "abc1234",
+				Status: SubmoduleNotInitialized,
+			},
+		},
+		{
+			name:      "different commit submodule",
+			output:    "+abc1234 vendor/lib (heads/main)",
+			wantCount: 1,
+			wantFirst: &SubmoduleStatusInfo{
+				Path:   "vendor/lib",
+				Commit: "abc1234",
+				Status: SubmoduleDifferentCommit,
+			},
+		},
+		{
+			name:      "merge conflict submodule",
+			output:    "Uabc1234 vendor/lib",
+			wantCount: 1,
+			wantFirst: &SubmoduleStatusInfo{
+				Path:   "vendor/lib",
+				Commit: "abc1234",
+				Status: SubmoduleMergeConflict,
+			},
+		},
+		{
+			name: "multiple submodules",
+			output: ` abc1234 vendor/lib1 (v1.0.0)
++def5678 vendor/lib2 (heads/main)
+-ghi9012 vendor/lib3`,
+			wantCount: 3,
+			wantFirst: &SubmoduleStatusInfo{
+				Path:   "vendor/lib1",
+				Commit: "abc1234",
+				Status: SubmoduleUpToDate,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSubmoduleStatus(tt.output)
+
+			if len(got) != tt.wantCount {
+				t.Errorf("parseSubmoduleStatus() returned %d results, want %d", len(got), tt.wantCount)
+			}
+
+			if tt.wantFirst != nil && len(got) > 0 {
+				if got[0].Path != tt.wantFirst.Path {
+					t.Errorf("Path = %q, want %q", got[0].Path, tt.wantFirst.Path)
+				}
+				if got[0].Commit != tt.wantFirst.Commit {
+					t.Errorf("Commit = %q, want %q", got[0].Commit, tt.wantFirst.Commit)
+				}
+				if got[0].Status != tt.wantFirst.Status {
+					t.Errorf("Status = %v, want %v", got[0].Status, tt.wantFirst.Status)
+				}
+			}
+		})
+	}
+}
+
+func TestIsSubmoduleCriticalError(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name:   "normal output",
+			output: "Submodule 'vendor/lib' (https://example.com/lib.git) registered for path 'vendor/lib'",
+			want:   false,
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   false,
+		},
+		{
+			name:   "fatal error",
+			output: "fatal: repository 'https://example.com/lib.git' not found",
+			want:   true,
+		},
+		{
+			name:   "permission denied",
+			output: "error: permission denied for 'vendor/lib'",
+			want:   true,
+		},
+		{
+			name:   "repository not found",
+			output: "error: Repository not found",
+			want:   true,
+		},
+		{
+			name:   "authentication failed",
+			output: "error: Authentication failed for 'https://example.com/repo.git'",
+			want:   true,
+		},
+		{
+			name:   "host key verification",
+			output: "Host key verification failed",
+			want:   true,
+		},
+		{
+			name:   "clone failed",
+			output: "Clone of 'https://example.com/repo.git' into submodule path 'vendor/lib' failed",
+			want:   true,
+		},
+		{
+			name:   "could not read from remote",
+			output: "fatal: Could not read from remote repository",
+			want:   true,
+		},
+		{
+			name:   "unable to access",
+			output: "fatal: unable to access 'https://example.com/repo.git/': Connection refused",
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isSubmoduleCriticalError(tt.output)
+			if got != tt.want {
+				t.Errorf("isSubmoduleCriticalError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSubmoduleError_Error(t *testing.T) {
+	err := &SubmoduleError{
+		Operation: "init",
+		Output:    "some output",
+		Err:       os.ErrPermission,
+	}
+
+	got := err.Error()
+	if !strings.Contains(got, "init") {
+		t.Errorf("Error() should contain operation name 'init', got %q", got)
+	}
+	if !strings.Contains(got, "permission") {
+		t.Errorf("Error() should contain underlying error, got %q", got)
+	}
+	if !strings.Contains(got, "some output") {
+		t.Errorf("Error() should contain output, got %q", got)
+	}
+}
+
+func TestSubmoduleError_Unwrap(t *testing.T) {
+	underlying := os.ErrPermission
+	err := &SubmoduleError{
+		Operation: "init",
+		Output:    "output",
+		Err:       underlying,
+	}
+
+	if err.Unwrap() != underlying {
+		t.Errorf("Unwrap() = %v, want %v", err.Unwrap(), underlying)
+	}
+}


### PR DESCRIPTION
## Summary
- Add comprehensive git submodule detection and initialization for worktree operations
- Automatically initialize submodules after creating new worktrees to prevent stale .git file errors
- Skip submodule directories during file traversal in conflict detector, verifier, and analyzer
- Add smart error handling to distinguish critical submodule errors from benign warnings

## Details

### Problem
When Claudio creates worktrees in repositories with git submodules, the submodule directories contain `.git` files (not directories) that point to the parent repo's `.git/modules` directory. If submodules aren't properly initialized after worktree creation, these `.git` files point to non-existent locations, causing errors when:
- The conflict detector traverses files looking for changes
- The verifier searches for completion files
- The analyzer builds the package graph

### Solution
This PR adds comprehensive submodule support:

1. **Detection**: `IsSubmoduleDir()` identifies submodule directories by checking for `.git` files containing `gitdir:` references

2. **Initialization**: `InitSubmodules()` runs `git submodule update --init --recursive` in new worktrees to ensure all submodule content is available

3. **Traversal Skipping**: Components that traverse the file system now skip submodule directories:
   - `conflict.Detector` - skips events from inside submodules
   - `verify.Verifier` - skips submodule dirs when searching for completion files  
   - `decomposition.Analyzer` - skips submodule dirs when building package graph

4. **Smart Error Handling**: `isSubmoduleCriticalError()` distinguishes fatal errors (authentication failures, network issues) from benign warnings that git submodule commands may emit

## Test plan
- [x] Unit tests for submodule parsing and detection (`submodule_unit_test.go`)
- [x] Unit test for `isInsideSubmodule()` in conflict detector
- [x] Integration tests for submodule operations (`submodule_test.go` with `//go:build integration`)
- [x] All existing tests pass
- [x] Manual testing with actual submodule repositories