### PR TITLE
Fix INPUT and TERMINAL mode badges in footer for all modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Footer Input Mode Badge in Special Modes** - Fixed the INPUT and TERMINAL mode badges not appearing in the footer when in triple-shot mode or ultra-plan mode. Previously, entering input mode (`i`) while in these special modes would continue showing the NORMAL/ULTRAPLAN badge instead of the INPUT badge. Now the footer correctly shows the INPUT badge with exit instructions when input forwarding is active, regardless of the underlying session mode.
 - **Git Submodule File Traversal** - Fixed errors and warnings when working with repositories containing git submodules. File traversal in the conflict detector, completion file verifier, and code analyzer now correctly skips submodule directories to prevent permission errors, symlink errors, and duplicate events when submodules are uninitialized or partially initialized.
 
 ### Changed

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1346,7 +1346,7 @@ func (m Model) renderTripleShotSidebar(width, height int) string {
 // renderTripleShotHelp renders the help bar for triple-shot mode.
 // Delegates to view.RenderTripleShotHelp for the actual rendering.
 func (m Model) renderTripleShotHelp() string {
-	return view.RenderTripleShotHelp()
+	return view.RenderTripleShotHelp(m.buildHelpBarState())
 }
 
 // initiateTripleShotMode creates and starts a triple-shot session.

--- a/internal/tui/ultraplan.go
+++ b/internal/tui/ultraplan.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Iron-Ham/claudio/internal/orchestrator"
 	tuimsg "github.com/Iron-Ham/claudio/internal/tui/msg"
+	"github.com/Iron-Ham/claudio/internal/tui/terminal"
 	"github.com/Iron-Ham/claudio/internal/tui/view"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -85,6 +86,14 @@ func (m *Model) createUltraplanView() *view.UltraplanView {
 		IsSelected: func(instanceID string) bool {
 			return m.isInstanceSelected(instanceID)
 		},
+		InputMode:       m.inputMode,
+		TerminalFocused: m.terminalManager.IsFocused(),
+		TerminalDirMode: func() string {
+			if m.terminalManager.DirMode() == terminal.DirWorktree {
+				return "worktree"
+			}
+			return "invoke"
+		}(),
 	}
 	return view.NewUltraplanView(ctx)
 }

--- a/internal/tui/view/help_bar.go
+++ b/internal/tui/view/help_bar.go
@@ -208,7 +208,30 @@ func (v *HelpBarView) RenderHelp(state *HelpBarState) string {
 }
 
 // RenderTripleShotHelp renders the help bar for triple-shot mode.
-func (v *HelpBarView) RenderTripleShotHelp() string {
+// Accepts optional state to properly display INPUT mode when active.
+func (v *HelpBarView) RenderTripleShotHelp(state *HelpBarState) string {
+	// Check for input mode first - this takes priority
+	if state != nil && state.InputMode {
+		badge := styles.ModeBadgeInput.Render("INPUT")
+		help := styles.HelpKey.Render("[Ctrl+]]") + " exit  " +
+			styles.Muted.Render("All keystrokes forwarded to Claude")
+		return styles.HelpBar.Render(badge + "  " + help)
+	}
+
+	// Check for terminal focused mode
+	if state != nil && state.TerminalFocused {
+		badge := styles.ModeBadgeTerminal.Render("TERMINAL")
+		dirMode := "invoke"
+		if state.TerminalDirMode == "worktree" {
+			dirMode = "worktree"
+		}
+		help := styles.HelpKey.Render("[Ctrl+]]") + " exit  " +
+			styles.HelpKey.Render("[Ctrl+Shift+T]") + " switch dir  " +
+			styles.Muted.Render("("+dirMode+")")
+		return styles.HelpBar.Render(badge + "  " + help)
+	}
+
+	// Normal triple-shot mode
 	badge := styles.ModeBadgeNormal.Render("NORMAL")
 	keys := []string{
 		styles.HelpKey.Render("[:]") + " cmd",
@@ -237,6 +260,6 @@ func RenderHelp(state *HelpBarState) string {
 }
 
 // RenderTripleShotHelp renders the help bar for triple-shot mode.
-func RenderTripleShotHelp() string {
-	return helpBarView.RenderTripleShotHelp()
+func RenderTripleShotHelp(state *HelpBarState) string {
+	return helpBarView.RenderTripleShotHelp(state)
 }


### PR DESCRIPTION
## Summary

- Fixed the INPUT and TERMINAL mode badges not appearing in the footer when in triple-shot mode or ultra-plan mode
- Previously, entering input mode (`i`) while in these special modes would continue showing the NORMAL/ULTRAPLAN badge instead of the INPUT badge
- Now the footer correctly shows the INPUT badge with exit instructions when input forwarding is active, regardless of the underlying session mode

## Problem

When using triple-shot or ultra-plan modes, pressing `i` to enter input mode would forward keystrokes to Claude, but the footer would still show the mode-specific help (NORMAL or ULTRAPLAN) instead of the INPUT badge with exit instructions (`Ctrl+]`). This was confusing because users couldn't see that they were in input mode or how to exit.

## Solution

Updated the specialized render functions to check for high-priority modes first:
- `RenderTripleShotHelp` now accepts `HelpBarState` and checks for `InputMode` and `TerminalFocused` before rendering normal triple-shot help
- `UltraplanView.RenderHelp()` now checks `InputMode` and `TerminalFocused` in `RenderContext` before rendering ultraplan-specific help
- Added `InputMode`, `TerminalFocused`, and `TerminalDirMode` fields to `RenderContext` so ultraplan views have access to this state

## Test plan

- [x] Added comprehensive tests for `RenderTripleShotHelp` covering:
  - Normal mode without state (nil)
  - Normal mode with state
  - Input mode shows INPUT badge
  - Terminal focused shows TERMINAL badge  
  - Input mode takes priority over terminal
- [x] All existing tests pass
- [x] Build passes
- [x] Manual verification: Enter triple-shot mode, press `i` - footer now shows INPUT badge