### PR TITLE
Remove deprecated APIs and unused code from recent refactors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **Deprecated TripleShot Single Coordinator** - Removed the deprecated `Coordinator` field from `TripleShotState` and `TripleShot` field from `Session`. All code now uses the `Coordinators` map and `TripleShots` slice for multiple concurrent tripleshot support.
+- **Deprecated Plan/Issue Wrapper Functions** - Removed deprecated wrapper functions (`CreateIssue`, `UpdateIssueBody`, `GetIssueNodeID`, `AddSubIssue`) and `IssueOptions` type from `internal/plan/issue.go`. Use `tracker.GitHubTracker` methods directly.
+- **Deprecated PR Wrapper Functions** - Removed deprecated `CreatePR` and `CreatePRDraft` wrapper functions from `internal/pr/pr.go`. Use `pr.Create(PROptions{...})` directly.
+- **Deprecated Instance Manager Constructors** - Removed deprecated constructors `NewManager`, `NewManagerWithConfig`, `NewManagerWithSession`, and method `SetStateMonitor` from `internal/instance/manager.go`. Use `NewManagerWithDeps(ManagerOptions{...})` for explicit dependency injection.
+- **Deprecated Terminal Constants** - Removed deprecated type alias `TerminalDirMode` and constants `TerminalDirInvocation`, `TerminalDirWorktree`, `DefaultTerminalHeight`, `MinTerminalHeight`, `MaxTerminalHeightRatio` from `internal/tui/model.go`. Use the `terminal` package exports directly.
+- **Deprecated GetTripleShotCoordinator** - Removed deprecated `GetTripleShotCoordinator()` method from `command.Dependencies` interface and `Model`. Use `GetTripleShotCoordinators()` which returns all active coordinators.
+- **Deprecated getHistorySize Function** - Removed the deprecated `getHistorySize` method from instance Manager. Use `getSessionStatus` for batched queries with reduced subprocess overhead.
+- **Unused Error Sentinels** - Removed unused error sentinels from `internal/orchestrator/prompt_adapter.go`: `ErrNilUltraPlanSession`, `ErrTaskNotFoundInPlan`, and `ErrNilGroupTracker`. These were leftover from the removed `PromptAdapter` struct.
+
 ### Added
 
 - **Force Quit Command** - Added `:q!` (and `:quit!`) command to force quit Claudio, stopping all running instances, cleaning up all worktrees, and exiting immediately. This provides a quick way to completely exit and clean up when you want to abandon all work in progress.

--- a/internal/cmd/tripleshot.go
+++ b/internal/cmd/tripleshot.go
@@ -115,7 +115,7 @@ func runTripleshot(cmd *cobra.Command, args []string) error {
 	tripleSession := orchestrator.NewTripleShotSession(task, tripleConfig)
 
 	// Link triple-shot session to main session for persistence
-	session.TripleShot = tripleSession
+	session.TripleShots = append(session.TripleShots, tripleSession)
 
 	// Create coordinator with logger
 	coordinator := orchestrator.NewTripleShotCoordinator(orch, session, tripleSession, logger)

--- a/internal/orchestrator/prompt_adapter.go
+++ b/internal/orchestrator/prompt_adapter.go
@@ -6,28 +6,18 @@ import (
 	"github.com/Iron-Ham/claudio/internal/orchestrator/prompt"
 )
 
-// Error sentinels for PromptAdapter operations
+// Error sentinels for phase adapter operations.
+// These are used by coordinator_phase_adapter.go for nil checks.
 var (
-	// ErrNilCoordinator is returned when a PromptAdapter method requires a
-	// Coordinator but the adapter was created with a nil coordinator.
+	// ErrNilCoordinator is returned when an operation requires a
+	// Coordinator but nil was provided.
 	ErrNilCoordinator = errors.New("prompt adapter has nil coordinator")
-
-	// ErrNilUltraPlanSession is returned when a PromptAdapter method requires
-	// an UltraPlanSession but the coordinator's manager returns nil.
-	ErrNilUltraPlanSession = errors.New("coordinator has nil ultra-plan session")
 
 	// ErrNilManager is returned when the coordinator's manager is nil.
 	ErrNilManager = errors.New("prompt adapter: manager is required")
 
 	// ErrNilSession is returned when the manager's session is nil.
 	ErrNilSession = errors.New("prompt adapter: session is required")
-
-	// ErrTaskNotFoundInPlan is returned when the requested task ID does not
-	// exist in the current plan.
-	ErrTaskNotFoundInPlan = errors.New("prompt adapter: task not found in plan")
-
-	// ErrNilGroupTracker is returned when the Coordinator's groupTracker is nil.
-	ErrNilGroupTracker = errors.New("prompt adapter: group tracker is required")
 )
 
 // planInfoFromPlanSpec converts a PlanSpec to a prompt.PlanInfo.

--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -135,10 +135,6 @@ type Session struct {
 	// UltraPlan holds the ultra-plan session state (nil for regular sessions)
 	UltraPlan *UltraPlanSession `json:"ultra_plan,omitempty"`
 
-	// TripleShot holds a single triple-shot session for backward compatibility.
-	// Deprecated: Use TripleShots slice for multiple concurrent tripleshots.
-	TripleShot *TripleShotSession `json:"triple_shot,omitempty"`
-
 	// TripleShots holds multiple concurrent triple-shot sessions.
 	// Each tripleshot has its own group and coordinator.
 	TripleShots []*TripleShotSession `json:"triple_shots,omitempty"`

--- a/internal/plan/issue.go
+++ b/internal/plan/issue.go
@@ -1,17 +1,5 @@
 package plan
 
-import (
-	"github.com/Iron-Ham/claudio/internal/plan/tracker"
-)
-
-// IssueOptions contains options for issue creation.
-// This type is maintained for backward compatibility with existing code.
-type IssueOptions struct {
-	Title  string
-	Body   string
-	Labels []string
-}
-
 // IssueCreationResult holds the results of creating all issues
 type IssueCreationResult struct {
 	ParentIssueNumber int
@@ -20,57 +8,4 @@ type IssueCreationResult struct {
 	SubIssueURLs      map[string]string // task_id -> issue_url
 	GroupIssueNumbers []int             // group issue numbers (for groups with >1 task)
 	GroupIssueURLs    []string          // group issue URLs
-}
-
-// defaultTracker is the default IssueTracker used by the legacy functions.
-var defaultTracker = tracker.NewGitHubTracker()
-
-// CreateIssue creates a GitHub issue using the gh CLI.
-// Returns the issue number and URL on success.
-//
-// Deprecated: Use tracker.GitHubTracker.CreateIssue for new code.
-// This function is maintained for backward compatibility.
-func CreateIssue(opts IssueOptions) (int, string, error) {
-	ref, err := defaultTracker.CreateIssue(tracker.IssueOptions{
-		Title:  opts.Title,
-		Body:   opts.Body,
-		Labels: opts.Labels,
-	})
-	if err != nil {
-		return 0, "", err
-	}
-	return ref.Number, ref.URL, nil
-}
-
-// UpdateIssueBody updates an existing issue's body.
-// This is used to update the parent issue after all sub-issues are created.
-//
-// Deprecated: Use tracker.GitHubTracker.UpdateIssue for new code.
-// This function is maintained for backward compatibility.
-func UpdateIssueBody(issueNumber int, newBody string) error {
-	return defaultTracker.UpdateIssue(
-		tracker.IssueRef{Number: issueNumber},
-		tracker.IssueOptions{Body: newBody},
-	)
-}
-
-// GetIssueNodeID retrieves the GraphQL node ID for a GitHub issue.
-// This is required for the addSubIssue GraphQL mutation.
-//
-// Deprecated: Use tracker.GitHubTracker.GetIssueNodeID for new code.
-// This function is maintained for backward compatibility.
-func GetIssueNodeID(issueNumber int) (string, error) {
-	return defaultTracker.GetIssueNodeID(issueNumber)
-}
-
-// AddSubIssue links a sub-issue to a parent issue using GitHub's GraphQL API.
-// This creates a proper parent-child relationship visible in the GitHub UI.
-//
-// Deprecated: Use tracker.GitHubTracker.AddSubIssue for new code.
-// This function is maintained for backward compatibility.
-func AddSubIssue(parentNodeID, subIssueNodeID string) error {
-	return defaultTracker.AddSubIssue(
-		tracker.IssueRef{ID: parentNodeID},
-		tracker.IssueRef{ID: subIssueNodeID},
-	)
 }

--- a/internal/pr/pr.go
+++ b/internal/pr/pr.go
@@ -172,26 +172,6 @@ func Create(opts PROptions) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
-// CreatePR creates a GitHub PR using the gh CLI (legacy wrapper)
-func CreatePR(title, body, branch string) (string, error) {
-	return Create(PROptions{
-		Title:  title,
-		Body:   body,
-		Branch: branch,
-		Draft:  false,
-	})
-}
-
-// CreatePRDraft creates a draft GitHub PR using the gh CLI (legacy wrapper)
-func CreatePRDraft(title, body, branch string) (string, error) {
-	return Create(PROptions{
-		Title:  title,
-		Body:   body,
-		Branch: branch,
-		Draft:  true,
-	})
-}
-
 // CreateStackedPR creates a GitHub PR with a specific base branch (for stacked PRs)
 // This allows creating PRs that target a branch other than the repository default
 func CreateStackedPR(opts PROptions, baseBranch string) (string, error) {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -78,7 +78,6 @@ func NewWithUltraPlan(orch *orchestrator.Orchestrator, session *orchestrator.Ses
 func NewWithTripleShot(orch *orchestrator.Orchestrator, session *orchestrator.Session, coordinator *orchestrator.TripleShotCoordinator, logger *logging.Logger) *App {
 	model := NewModel(orch, session, logger)
 	model.tripleShot = &TripleShotState{
-		Coordinator:  coordinator,
 		Coordinators: make(map[string]*orchestrator.TripleShotCoordinator),
 	}
 	// Add the coordinator to the map keyed by its group ID for multiple tripleshot support
@@ -141,11 +140,6 @@ func NewWithTripleShots(orch *orchestrator.Orchestrator, session *orchestrator.S
 	// Auto-enable grouped sidebar mode if we created any groups
 	if createdGroup {
 		model.autoEnableGroupedMode()
-	}
-
-	// Set the first coordinator as the deprecated single Coordinator for backward compatibility
-	if len(coordinators) > 0 {
-		model.tripleShot.Coordinator = coordinators[0]
 	}
 
 	return &App{
@@ -1373,9 +1367,6 @@ func (m Model) initiateTripleShotMode(task string) (Model, tea.Cmd) {
 	// Add to TripleShots slice for persistence (supports multiple)
 	m.session.TripleShots = append(m.session.TripleShots, tripleSession)
 
-	// Also set single TripleShot field for backward compatibility
-	m.session.TripleShot = tripleSession
-
 	// Create coordinator
 	coordinator := orchestrator.NewTripleShotCoordinator(m.orchestrator, m.session, tripleSession, m.logger)
 
@@ -1393,9 +1384,6 @@ func (m Model) initiateTripleShotMode(task string) (Model, tea.Cmd) {
 
 	// Add coordinator to the map keyed by group ID
 	m.tripleShot.Coordinators[tripleGroup.ID] = coordinator
-
-	// Also set the deprecated single Coordinator for backward compatibility
-	m.tripleShot.Coordinator = coordinator
 
 	numActive := len(m.tripleShot.Coordinators)
 	if numActive > 1 {

--- a/internal/tui/command/handler.go
+++ b/internal/tui/command/handler.go
@@ -35,7 +35,6 @@ type Dependencies interface {
 	IsUltraPlanMode() bool
 	IsTripleShotMode() bool
 	GetUltraPlanCoordinator() *orchestrator.Coordinator
-	GetTripleShotCoordinator() *orchestrator.TripleShotCoordinator    // Deprecated: use GetTripleShotCoordinators
 	GetTripleShotCoordinators() []*orchestrator.TripleShotCoordinator // Returns all active tripleshot coordinators
 
 	// Logger access

--- a/internal/tui/command/handler_test.go
+++ b/internal/tui/command/handler_test.go
@@ -58,9 +58,6 @@ func (m *mockDeps) IsTripleShotMode() bool                      { return m.tripl
 func (m *mockDeps) GetUltraPlanCoordinator() *orchestrator.Coordinator {
 	return m.ultraCoordinator
 }
-func (m *mockDeps) GetTripleShotCoordinator() *orchestrator.TripleShotCoordinator {
-	return m.tripleShotCoordinator
-}
 func (m *mockDeps) GetTripleShotCoordinators() []*orchestrator.TripleShotCoordinator {
 	if m.tripleShotCoordinator != nil {
 		return []*orchestrator.TripleShotCoordinator{m.tripleShotCoordinator}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -16,17 +16,6 @@ import (
 	"github.com/Iron-Ham/claudio/internal/tui/view"
 )
 
-// TerminalDirMode indicates which directory the terminal pane is using.
-// Deprecated: Use terminal.DirMode instead.
-type TerminalDirMode = terminal.DirMode
-
-// Terminal directory mode constants.
-// Deprecated: Use terminal.DirInvocation and terminal.DirWorktree instead.
-const (
-	TerminalDirInvocation = terminal.DirInvocation
-	TerminalDirWorktree   = terminal.DirWorktree
-)
-
 // modelInstanceProvider adapts the Model to the terminal.ActiveInstanceProvider interface.
 type modelInstanceProvider struct {
 	model *Model
@@ -968,20 +957,6 @@ func isWordChar(r rune) bool {
 // Terminal pane helper methods
 // -----------------------------------------------------------------------------
 
-// DefaultTerminalHeight is the default height of the terminal pane in lines.
-// Set to 15 to provide a more useful terminal display showing adequate
-// command output and shell history.
-// Deprecated: Use terminal.DefaultPaneHeight instead.
-const DefaultTerminalHeight = terminal.DefaultPaneHeight
-
-// MinTerminalHeight is the minimum height of the terminal pane.
-// Deprecated: Use terminal.MinPaneHeight instead.
-const MinTerminalHeight = terminal.MinPaneHeight
-
-// MaxTerminalHeightRatio is the maximum ratio of terminal height to total height.
-// Deprecated: Use terminal.MaxPaneHeightRatio instead.
-const MaxTerminalHeightRatio = terminal.MaxPaneHeightRatio
-
 // IsTerminalMode returns true if the terminal pane has input focus.
 func (m Model) IsTerminalMode() bool {
 	return m.terminalManager.IsFocused()
@@ -1153,14 +1128,6 @@ func (m Model) GetUltraPlanCoordinator() *orchestrator.Coordinator {
 	return m.ultraPlan.Coordinator
 }
 
-// GetTripleShotCoordinator returns the triple-shot coordinator if in triple-shot mode.
-func (m Model) GetTripleShotCoordinator() *orchestrator.TripleShotCoordinator {
-	if m.tripleShot == nil {
-		return nil
-	}
-	return m.tripleShot.Coordinator
-}
-
 // GetTripleShotCoordinators returns all active tripleshot coordinators.
 func (m Model) GetTripleShotCoordinators() []*orchestrator.TripleShotCoordinator {
 	if m.tripleShot == nil {
@@ -1187,13 +1154,6 @@ func (m Model) IsInstanceTripleShotJudge(instanceID string) bool {
 	// Check all coordinators in the map
 	for _, coord := range m.tripleShot.Coordinators {
 		session := coord.Session()
-		if session != nil && session.JudgeID == instanceID {
-			return true
-		}
-	}
-	// Also check deprecated single coordinator for backward compatibility
-	if m.tripleShot.Coordinator != nil {
-		session := m.tripleShot.Coordinator.Session()
 		if session != nil && session.JudgeID == instanceID {
 			return true
 		}

--- a/internal/tui/terminal_test.go
+++ b/internal/tui/terminal_test.go
@@ -8,35 +8,34 @@ import (
 
 func TestTerminalHeightConstants(t *testing.T) {
 	// Verify the terminal height constants are set to reasonable values
-	// These are re-exported from terminal package for backward compatibility
-	t.Run("DefaultTerminalHeight is at least MinTerminalHeight", func(t *testing.T) {
-		if DefaultTerminalHeight < MinTerminalHeight {
-			t.Errorf("DefaultTerminalHeight (%d) should be >= MinTerminalHeight (%d)",
-				DefaultTerminalHeight, MinTerminalHeight)
+	t.Run("DefaultPaneHeight is at least MinPaneHeight", func(t *testing.T) {
+		if terminal.DefaultPaneHeight < terminal.MinPaneHeight {
+			t.Errorf("DefaultPaneHeight (%d) should be >= MinPaneHeight (%d)",
+				terminal.DefaultPaneHeight, terminal.MinPaneHeight)
 		}
 	})
 
-	t.Run("DefaultTerminalHeight is reasonable", func(t *testing.T) {
+	t.Run("DefaultPaneHeight is reasonable", func(t *testing.T) {
 		// The default height should be at least 10 lines to be useful
-		if DefaultTerminalHeight < 10 {
-			t.Errorf("DefaultTerminalHeight (%d) should be >= 10 for usability",
-				DefaultTerminalHeight)
+		if terminal.DefaultPaneHeight < 10 {
+			t.Errorf("DefaultPaneHeight (%d) should be >= 10 for usability",
+				terminal.DefaultPaneHeight)
 		}
 	})
 
-	t.Run("MinTerminalHeight allows for content", func(t *testing.T) {
+	t.Run("MinPaneHeight allows for content", func(t *testing.T) {
 		// Minimum height should account for border (2) + header (1) + at least 1 content line
 		// So minimum should be at least 4
-		if MinTerminalHeight < 4 {
-			t.Errorf("MinTerminalHeight (%d) should be >= 4 to allow for border, header, and content",
-				MinTerminalHeight)
+		if terminal.MinPaneHeight < 4 {
+			t.Errorf("MinPaneHeight (%d) should be >= 4 to allow for border, header, and content",
+				terminal.MinPaneHeight)
 		}
 	})
 
-	t.Run("MaxTerminalHeightRatio is sensible", func(t *testing.T) {
-		if MaxTerminalHeightRatio <= 0 || MaxTerminalHeightRatio > 0.8 {
-			t.Errorf("MaxTerminalHeightRatio (%f) should be between 0 and 0.8",
-				MaxTerminalHeightRatio)
+	t.Run("MaxPaneHeightRatio is sensible", func(t *testing.T) {
+		if terminal.MaxPaneHeightRatio <= 0 || terminal.MaxPaneHeightRatio > 0.8 {
+			t.Errorf("MaxPaneHeightRatio (%f) should be between 0 and 0.8",
+				terminal.MaxPaneHeightRatio)
 		}
 	})
 }

--- a/internal/tui/view/tripleshot_test.go
+++ b/internal/tui/view/tripleshot_test.go
@@ -242,12 +242,14 @@ func TestTripleShotState_HasActiveCoordinators(t *testing.T) {
 		}
 	})
 
-	t.Run("state with deprecated Coordinator returns true", func(t *testing.T) {
+	t.Run("state with coordinator in map returns true", func(t *testing.T) {
 		state := &TripleShotState{
-			Coordinator: &orchestrator.TripleShotCoordinator{},
+			Coordinators: map[string]*orchestrator.TripleShotCoordinator{
+				"group-1": {},
+			},
 		}
 		if !state.HasActiveCoordinators() {
-			t.Error("expected true for deprecated single coordinator")
+			t.Error("expected true when coordinator exists in map")
 		}
 	})
 }
@@ -305,18 +307,14 @@ func TestTripleShotState_GetAllCoordinators(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to deprecated Coordinator when map empty", func(t *testing.T) {
-		coord := &orchestrator.TripleShotCoordinator{}
+	t.Run("returns nil when map empty", func(t *testing.T) {
 		state := &TripleShotState{
-			Coordinator: coord,
+			Coordinators: make(map[string]*orchestrator.TripleShotCoordinator),
 		}
 
 		result := state.GetAllCoordinators()
-		if len(result) != 1 {
-			t.Errorf("expected 1 coordinator from fallback, got %d", len(result))
-		}
-		if result[0] != coord {
-			t.Error("expected fallback coordinator to be returned")
+		if result != nil {
+			t.Errorf("expected nil for empty map, got %d coordinators", len(result))
 		}
 	})
 }
@@ -349,32 +347,23 @@ func TestTripleShotState_GetCoordinatorForGroup(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to deprecated Coordinator when not in map", func(t *testing.T) {
-		fallbackCoord := &orchestrator.TripleShotCoordinator{}
+	t.Run("returns nil when not in map", func(t *testing.T) {
 		state := &TripleShotState{
 			Coordinators: map[string]*orchestrator.TripleShotCoordinator{},
-			Coordinator:  fallbackCoord,
 		}
 
 		result := state.GetCoordinatorForGroup("any-group")
-		if result != fallbackCoord {
-			t.Error("expected fallback to deprecated Coordinator")
+		if result != nil {
+			t.Error("expected nil for missing group")
 		}
 	})
 
-	t.Run("prefers map over fallback when key exists", func(t *testing.T) {
-		mapCoord := &orchestrator.TripleShotCoordinator{}
-		fallbackCoord := &orchestrator.TripleShotCoordinator{}
-		state := &TripleShotState{
-			Coordinators: map[string]*orchestrator.TripleShotCoordinator{
-				"target": mapCoord,
-			},
-			Coordinator: fallbackCoord,
-		}
+	t.Run("returns nil when coordinators map is nil", func(t *testing.T) {
+		state := &TripleShotState{}
 
-		result := state.GetCoordinatorForGroup("target")
-		if result != mapCoord {
-			t.Error("expected map coordinator over fallback")
+		result := state.GetCoordinatorForGroup("any-group")
+		if result != nil {
+			t.Error("expected nil when coordinators map is nil")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Remove deprecated TripleShot single coordinator pattern (`Coordinator` field, `TripleShot` field, and related fallback logic) - all code now uses `Coordinators` map and `TripleShots` slice
- Remove deprecated instance manager constructors (`NewManager`, `NewManagerWithConfig`, `NewManagerWithSession`) and `SetStateMonitor` - use `NewManagerWithDeps` instead
- Remove deprecated `getHistorySize` function - use `getSessionStatus` for batched queries
- Remove deprecated PR wrappers (`CreatePR`, `CreatePRDraft`) - use `pr.Create(PROptions{...})` directly
- Remove deprecated issue wrappers and `IssueOptions` type - use `tracker.GitHubTracker` methods directly
- Remove deprecated terminal constants and type aliases - use `terminal` package exports directly
- Remove deprecated `GetTripleShotCoordinator` interface method - use `GetTripleShotCoordinators()`
- Remove unused error sentinels from `prompt_adapter.go` (`ErrNilUltraPlanSession`, `ErrTaskNotFoundInPlan`, `ErrNilGroupTracker`)

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes  
- [x] `go test ./...` passes (all 50 packages)
- [x] Removed test for deleted `getHistorySize` function