### PR TITLE
Fix incorrect sidebar navigation hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Sidebar Navigation Order** - Fixed h/l (or tab/shift-tab) navigation in the sidebar navigating by instance creation order instead of display order. When instances are grouped (e.g., in ultraplan mode), the sidebar displays instances in a specific hierarchy (ungrouped first, then by group). Navigation now correctly follows the visual display order rather than the internal creation order, preventing user confusion when pressing tab/l to move to the "next" instance.
+- **Sidebar Navigation Hints** - Fixed incorrect keyboard hints in the grouped sidebar view. The hints incorrectly showed `[j/k] nav [J/K] groups [Space] toggle` when the actual bindings are `[j/k] scroll [gn/gp] groups [gc] toggle`. The `j/k` keys scroll the output panel (not sidebar navigation), and group navigation uses vim-style g-prefix commands (`gn`/`gp` for next/previous group, `gc` for toggle collapse).
 
 ## [0.7.1] - 2026-01-15
 

--- a/internal/tui/view/sidebar.go
+++ b/internal/tui/view/sidebar.go
@@ -188,9 +188,9 @@ func (sv *SidebarView) RenderGroupedSidebar(state SidebarState, width, height in
 	// Help hints
 	if len(items) > 0 {
 		hintStyle := styles.Muted
-		helpHint := hintStyle.Render("[j/k]") + " " + hintStyle.Render("nav") + "  " +
-			hintStyle.Render("[J/K]") + " " + hintStyle.Render("groups") + "  " +
-			hintStyle.Render("[Space]") + " " + hintStyle.Render("toggle")
+		helpHint := hintStyle.Render("[j/k]") + " " + hintStyle.Render("scroll") + "  " +
+			hintStyle.Render("[gn/gp]") + " " + hintStyle.Render("groups") + "  " +
+			hintStyle.Render("[gc]") + " " + hintStyle.Render("toggle")
 		b.WriteString(helpHint)
 	} else {
 		addHint := styles.Muted.Render("[:a]") + " " + styles.Muted.Render("Add new")
@@ -260,7 +260,7 @@ func NewGroupNavigator(session *orchestrator.Session, groupState *GroupViewState
 	}
 }
 
-// MoveToNextGroup moves selection to the next group (Shift+J).
+// MoveToNextGroup moves selection to the next group (gn).
 // Returns the new selected group ID.
 func (n *GroupNavigator) MoveToNextGroup() string {
 	if n.session == nil || !n.session.HasGroups() {
@@ -297,7 +297,7 @@ func (n *GroupNavigator) MoveToNextGroup() string {
 	return groupIDs[0]
 }
 
-// MoveToPrevGroup moves selection to the previous group (Shift+K).
+// MoveToPrevGroup moves selection to the previous group (gp).
 // Returns the new selected group ID.
 func (n *GroupNavigator) MoveToPrevGroup() string {
 	if n.session == nil || !n.session.HasGroups() {

--- a/internal/tui/view/sidebar_test.go
+++ b/internal/tui/view/sidebar_test.go
@@ -233,11 +233,11 @@ func TestSidebarView_GroupNavHints(t *testing.T) {
 	result := sv.RenderSidebar(state, 50, 25)
 
 	// Should contain group navigation hints
-	if !strings.Contains(result, "[J/K]") {
-		t.Errorf("should show [J/K] hint for group navigation, got:\n%s", result)
+	if !strings.Contains(result, "[gn/gp]") {
+		t.Errorf("should show [gn/gp] hint for group navigation, got:\n%s", result)
 	}
-	if !strings.Contains(result, "[Space]") || !strings.Contains(result, "toggle") {
-		t.Errorf("should show [Space] toggle hint, got:\n%s", result)
+	if !strings.Contains(result, "[gc]") || !strings.Contains(result, "toggle") {
+		t.Errorf("should show [gc] toggle hint, got:\n%s", result)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixed incorrect keyboard hints in the grouped sidebar view
- Updated hints from `[j/k] nav [J/K] groups [Space] toggle` to `[j/k] scroll [gn/gp] groups [gc] toggle`
- Fixed misleading comments in GroupNavigator that mentioned Shift+J/K instead of actual gn/gp bindings

## Test plan
- [x] All existing tests pass
- [x] Updated `TestSidebarView_GroupNavHints` to verify correct hints
- [ ] Manual verification: run Claudio with grouped instances (e.g., ultraplan mode) and verify the sidebar shows the correct hints