### PR TITLE
Fix gc command not working on collapsed subgroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Group Navigation Skips Hidden Subgroups** - Fixed `gn`/`gp` navigation and `gc` collapse toggle to respect parent collapse state. Previously, when a parent group was collapsed, keyboard navigation would still traverse hidden subgroups, causing `gc` to appear non-functional (it would toggle a hidden subgroup). Navigation now correctly skips subgroups whose parent is collapsed, ensuring users can only navigate to visible groups.
 - **Footer Input Mode Badge in Special Modes** - Fixed the INPUT and TERMINAL mode badges not appearing in the footer when in triple-shot mode or ultra-plan mode. Previously, entering input mode (`i`) while in these special modes would continue showing the NORMAL/ULTRAPLAN badge instead of the INPUT badge. Now the footer correctly shows the INPUT badge with exit instructions when input forwarding is active, regardless of the underlying session mode.
 - **Git Submodule File Traversal** - Fixed errors and warnings when working with repositories containing git submodules. File traversal in the conflict detector, completion file verifier, and code analyzer now correctly skips submodule directories to prevent permission errors, symlink errors, and duplicate events when submodules are uninitialized or partially initialized.
 

--- a/internal/tui/keypress.go
+++ b/internal/tui/keypress.go
@@ -101,8 +101,8 @@ func (h *GroupKeyHandler) HandleGroupKey(key tea.KeyMsg) GroupKeyResult {
 func (h *GroupKeyHandler) handleToggleCollapse() GroupKeyResult {
 	groupID := h.groupState.SelectedGroupID
 	if groupID == "" {
-		// If no group is selected, try to select the first group and toggle it
-		groupIDs := view.GetGroupIDs(h.session)
+		// If no group is selected, try to select the first visible group and toggle it
+		groupIDs := view.GetVisibleGroupIDs(h.session, h.groupState)
 		if len(groupIDs) > 0 {
 			groupID = groupIDs[0]
 			h.groupState.SelectedGroupID = groupID

--- a/internal/tui/view/sidebar.go
+++ b/internal/tui/view/sidebar.go
@@ -260,14 +260,15 @@ func NewGroupNavigator(session *orchestrator.Session, groupState *GroupViewState
 	}
 }
 
-// MoveToNextGroup moves selection to the next group (gn).
+// MoveToNextGroup moves selection to the next visible group (gn).
 // Returns the new selected group ID.
+// Only navigates to groups that are visible (not hidden by a collapsed parent).
 func (n *GroupNavigator) MoveToNextGroup() string {
 	if n.session == nil || !n.session.HasGroups() {
 		return ""
 	}
 
-	groupIDs := GetGroupIDs(n.session)
+	groupIDs := GetVisibleGroupIDs(n.session, n.groupState)
 	if len(groupIDs) == 0 {
 		return ""
 	}
@@ -292,19 +293,20 @@ func (n *GroupNavigator) MoveToNextGroup() string {
 		}
 	}
 
-	// Current group not found, select first
+	// Current group not found (may have been hidden), select first visible
 	n.groupState.SelectedGroupID = groupIDs[0]
 	return groupIDs[0]
 }
 
-// MoveToPrevGroup moves selection to the previous group (gp).
+// MoveToPrevGroup moves selection to the previous visible group (gp).
 // Returns the new selected group ID.
+// Only navigates to groups that are visible (not hidden by a collapsed parent).
 func (n *GroupNavigator) MoveToPrevGroup() string {
 	if n.session == nil || !n.session.HasGroups() {
 		return ""
 	}
 
-	groupIDs := GetGroupIDs(n.session)
+	groupIDs := GetVisibleGroupIDs(n.session, n.groupState)
 	if len(groupIDs) == 0 {
 		return ""
 	}
@@ -329,7 +331,7 @@ func (n *GroupNavigator) MoveToPrevGroup() string {
 		}
 	}
 
-	// Current group not found, select last
+	// Current group not found (may have been hidden), select last visible
 	n.groupState.SelectedGroupID = groupIDs[len(groupIDs)-1]
 	return groupIDs[len(groupIDs)-1]
 }


### PR DESCRIPTION
## Summary

- Fixed `gn`/`gp` navigation to skip subgroups when their parent is collapsed
- Fixed `gc` collapse toggle to only operate on visible groups
- Added `GetVisibleGroupIDs()` function that respects parent collapse state

**Root Cause**: When a parent group was collapsed, navigation commands still traversed hidden subgroups. Users would unknowingly select a hidden subgroup, then `gc` would toggle it with no visible effect.

## Test plan

- [x] Added `TestGroupKeyHandler_ToggleCollapse_Subgroup` - verifies gc works on subgroups
- [x] Added `TestGroupKeyHandler_NextGroup_Subgroups` - verifies gn traverses expanded subgroups
- [x] Added `TestGroupKeyHandler_NextGroup_ParentCollapsed` - verifies gn skips hidden subgroups
- [x] Added `TestGroupKeyHandler_PrevGroup_ParentCollapsed` - verifies gp skips hidden subgroups
- [x] Added `TestGetVisibleGroupIDs` with subtests for deeply nested groups (3 levels)
- [x] Added `TestGroupNavigator_NextGroup_SelectedGroupHidden` - verifies fallback when selection becomes hidden
- [x] Added `TestGroupNavigator_PrevGroup_SelectedGroupHidden` - verifies fallback when selection becomes hidden
- [x] All existing tests pass (`go test ./...`)
- [x] Manual testing: collapse a parent group, press `gn`/`gp`, verify navigation skips hidden subgroups