### PR TITLE
Remove additional deprecated APIs and unused code from recent refactors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Deprecated GetTripleShotCoordinator** - Removed deprecated `GetTripleShotCoordinator()` method from `command.Dependencies` interface and `Model`. Use `GetTripleShotCoordinators()` which returns all active coordinators.
 - **Deprecated getHistorySize Function** - Removed the deprecated `getHistorySize` method from instance Manager. Use `getSessionStatus` for batched queries with reduced subprocess overhead.
 - **Unused Error Sentinels** - Removed unused error sentinels from `internal/orchestrator/prompt_adapter.go`: `ErrNilUltraPlanSession`, `ErrTaskNotFoundInPlan`, and `ErrNilGroupTracker`. These were leftover from the removed `PromptAdapter` struct.
+- **Unused Inline Plan Functions** - Removed unused integration stub functions from `internal/tui/inlineplan.go`: `handleInlinePlanCompletion`, `getPlanForInlineEditor`, `handleInlinePlanTaskDelete`, `handleInlinePlanTaskAdd`, `handleInlinePlanTaskReorder`, and duplicate `findInstanceIndex`. These were marked as pending integration but never completed. Code now uses `findInstanceIndexByID` for consistent instance lookup behavior.
+- **Deprecated SessionExists Method** - Removed the deprecated `SessionExists` method from `internal/instance/lifecycle/manager.go`. Use `SessionExistsWithSocket` for socket-specific session checks.
+- **Legacy RenderParentIssueBody Function** - Removed the unused `RenderParentIssueBody` function and `GroupedTasks` field from `internal/plan/template.go`. Production code exclusively uses `RenderParentIssueBodyHierarchical` which supports hierarchical children. The template was simplified to remove the legacy fallback path for grouped tasks.
+- **Unused Planning Orchestrator Method** - Removed unused `setInstanceID` method from `PlanningOrchestrator` in `internal/orchestrator/phase/planning.go`.
 
 ### Added
 

--- a/internal/instance/lifecycle/manager.go
+++ b/internal/instance/lifecycle/manager.go
@@ -481,13 +481,6 @@ func (m *Manager) Reconnect(inst Instance) error {
 	return nil
 }
 
-// SessionExists checks if a tmux session with the given name exists on the default socket.
-// Deprecated: Use SessionExistsWithSocket for socket-specific checks.
-func (m *Manager) SessionExists(sessionName string) bool {
-	cmd := tmux.Command("has-session", "-t", sessionName)
-	return cmd.Run() == nil
-}
-
 // SessionExistsWithSocket checks if a tmux session exists on a specific socket.
 func (m *Manager) SessionExistsWithSocket(sessionName, socketName string) bool {
 	cmd := tmux.CommandWithSocket(socketName, "has-session", "-t", sessionName)

--- a/internal/instance/lifecycle/manager_test.go
+++ b/internal/instance/lifecycle/manager_test.go
@@ -264,10 +264,10 @@ func TestManager_Reconnect_SessionNotFound(t *testing.T) {
 	}
 }
 
-func TestManager_SessionExists_NonExistent(t *testing.T) {
+func TestManager_SessionExistsWithSocket_NonExistent(t *testing.T) {
 	mgr := NewManager(nil)
-	if mgr.SessionExists("nonexistent-test-session-abc") {
-		t.Error("SessionExists should return false for non-existent session")
+	if mgr.SessionExistsWithSocket("nonexistent-test-session-abc", "test-socket") {
+		t.Error("SessionExistsWithSocket should return false for non-existent session")
 	}
 }
 

--- a/internal/orchestrator/phase/planning.go
+++ b/internal/orchestrator/phase/planning.go
@@ -456,14 +456,6 @@ func (p *PlanningOrchestrator) GetInstanceID() string {
 	return p.state.InstanceID
 }
 
-// setInstanceID updates the planning instance ID.
-// nolint:unused // Reserved for future use when Execute implementation is complete
-func (p *PlanningOrchestrator) setInstanceID(id string) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.state.InstanceID = id
-}
-
 // IsAwaitingCompletion returns true if planning is waiting for instance(s) to finish.
 func (p *PlanningOrchestrator) IsAwaitingCompletion() bool {
 	p.mu.RLock()

--- a/internal/plan/template_test.go
+++ b/internal/plan/template_test.go
@@ -67,77 +67,6 @@ func TestRenderSubIssueBodyWithDependencies(t *testing.T) {
 	}
 }
 
-func TestRenderParentIssueBody(t *testing.T) {
-	plan := &orchestrator.PlanSpec{
-		Objective: "Test objective",
-		Summary:   "Test summary for the parent issue",
-		Tasks: []orchestrator.PlannedTask{
-			{ID: "task-1", Title: "First Task"},
-			{ID: "task-2", Title: "Second Task", DependsOn: []string{"task-1"}},
-		},
-		ExecutionOrder: [][]string{{"task-1"}, {"task-2"}},
-		Insights:       []string{"Key insight about codebase"},
-		Constraints:    []string{"Important constraint"},
-	}
-
-	subIssueNumbers := map[string]int{
-		"task-1": 101,
-		"task-2": 102,
-	}
-
-	body, err := RenderParentIssueBody(plan, subIssueNumbers)
-	if err != nil {
-		t.Fatalf("RenderParentIssueBody() error = %v", err)
-	}
-
-	// Check required sections
-	if !strings.Contains(body, "Test summary for the parent issue") {
-		t.Error("Body missing summary")
-	}
-	if !strings.Contains(body, "Key insight about codebase") {
-		t.Error("Body missing insights")
-	}
-	if !strings.Contains(body, "Important constraint") {
-		t.Error("Body missing constraints")
-	}
-	if !strings.Contains(body, "#101") || !strings.Contains(body, "#102") {
-		t.Error("Body missing sub-issue references")
-	}
-	if !strings.Contains(body, "Group 1") {
-		t.Error("Body missing execution groups")
-	}
-	if !strings.Contains(body, "can start immediately") {
-		t.Error("Body missing group annotation")
-	}
-}
-
-func TestRenderParentIssueBodyEmptySections(t *testing.T) {
-	plan := &orchestrator.PlanSpec{
-		Objective: "Test objective",
-		Summary:   "Test summary",
-		Tasks: []orchestrator.PlannedTask{
-			{ID: "task-1", Title: "Only Task"},
-		},
-		ExecutionOrder: [][]string{{"task-1"}},
-		Insights:       nil,
-		Constraints:    nil,
-	}
-
-	subIssueNumbers := map[string]int{
-		"task-1": 101,
-	}
-
-	body, err := RenderParentIssueBody(plan, subIssueNumbers)
-	if err != nil {
-		t.Fatalf("RenderParentIssueBody() error = %v", err)
-	}
-
-	// Should still render without insights/constraints sections
-	if !strings.Contains(body, "Test summary") {
-		t.Error("Body missing summary")
-	}
-}
-
 func TestRenderParentIssueBodyHierarchical(t *testing.T) {
 	plan := &orchestrator.PlanSpec{
 		Objective:   "Test objective",
@@ -184,6 +113,32 @@ func TestRenderParentIssueBodyHierarchical(t *testing.T) {
 	}
 	if !strings.Contains(body, "Constraint 1") {
 		t.Error("Body missing constraints")
+	}
+}
+
+func TestRenderParentIssueBodyHierarchicalEmptySections(t *testing.T) {
+	plan := &orchestrator.PlanSpec{
+		Objective:   "Test objective",
+		Summary:     "Test summary",
+		Insights:    nil,
+		Constraints: nil,
+	}
+
+	children := []ParentChild{
+		{Title: "Only Task", IssueNumber: 101, IsGroup: false, TaskCount: 1},
+	}
+
+	body, err := RenderParentIssueBodyHierarchical(plan, children)
+	if err != nil {
+		t.Fatalf("RenderParentIssueBodyHierarchical() error = %v", err)
+	}
+
+	// Should still render without insights/constraints sections
+	if !strings.Contains(body, "Test summary") {
+		t.Error("Body missing summary")
+	}
+	if !strings.Contains(body, "#101") {
+		t.Error("Body missing child reference")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Removes 6 unused inline plan stub functions (~120 lines) that were marked as "integration pending" but never completed
- Removes deprecated `SessionExists` method from lifecycle manager (use `SessionExistsWithSocket` instead)
- Removes legacy `RenderParentIssueBody` function and `GroupedTasks` field from templates (production uses `RenderParentIssueBodyHierarchical` exclusively)
- Removes unused `setInstanceID` method from `PlanningOrchestrator`
- Updates callers to use `findInstanceIndexByID` which returns -1 on not-found (more idiomatic Go)
- Updates tests to use current APIs

**Net change:** -284 lines of dead code

## Test plan

- [x] All tests pass: `go test ./...`
- [x] Build succeeds: `go build ./...`
- [x] Linting passes: `go vet ./...`
- [x] Formatting is clean: `gofmt -d .`
- [x] Verified all removed functions had no callers via grep
- [x] PR review toolkit code-reviewer: no issues found
- [x] PR review toolkit test-analyzer: no coverage gaps