### PR TITLE
Simplify instance header to show only branch name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Instance Header Simplified** - Removed the truncated task/prompt text from the instance detail view header. The header now shows only the branch name, reducing visual noise and giving more space to the output area.
+
 ### Added
 
 - **Phase Orchestrator Integration Tests** - Added comprehensive integration tests for the phase orchestrator (`internal/orchestrator/phase/integration_test.go`). These tests exercise full phase lifecycles and transitions between phases (Planning → Execution → Consolidation → Synthesis), which are critical paths that can fail in complex multi-task scenarios. Coverage includes: planning-to-execution transitions, execution-to-consolidation flows with multi-group support, execution-to-synthesis transitions, partial group failure handling, synthesis lifecycle and revision cycle state management, concurrent phase operations, and phase callback consistency. Test infrastructure includes `IntegrationTestCoordinator` for simulating coordinator behavior across phase boundaries.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -919,7 +919,6 @@ func (m Model) calculateInstanceOverhead() int {
 
 	// Build overhead params
 	params := view.OverheadParams{
-		Task:            inst.Task,
 		HasDependencies: len(inst.DependsOn) > 0,
 		HasDependents:   len(inst.Dependents) > 0,
 		ShowMetrics:     showMetrics,

--- a/internal/tui/view/instance.go
+++ b/internal/tui/view/instance.go
@@ -105,10 +105,6 @@ func (v *InstanceView) RenderWithSession(inst *orchestrator.Instance, state Rend
 		}
 	}
 
-	// Render task description
-	b.WriteString(v.RenderTask(inst.Task))
-	b.WriteString("\n")
-
 	// Render dependency information if available (individual instance dependencies)
 	if session != nil {
 		depInfo := v.RenderDependencies(inst, session)
@@ -368,15 +364,9 @@ func truncateTask(task string, maxLen int) string {
 	return task[:maxLen-3] + "..."
 }
 
-// MaxTaskDisplayLines is the maximum number of lines shown for task descriptions.
-// Task text exceeding this limit is truncated with "...".
-const MaxTaskDisplayLines = 5
-
 // OverheadParams contains the parameters needed to calculate overhead lines.
 // These are the variable factors that affect how many lines are used above the output area.
 type OverheadParams struct {
-	// Task is the instance task description
-	Task string
 	// HasDependencies indicates if the instance has dependencies to display
 	HasDependencies bool
 	// HasDependents indicates if the instance has dependents to display
@@ -401,7 +391,7 @@ type OverheadParams struct {
 }
 
 // CalculateOverheadLines calculates the number of lines used by the instance view
-// above the output area. This accounts for header, group status, task, dependencies,
+// above the output area. This accounts for header, group status, dependencies,
 // metrics, status banner, scroll indicator, and search bar.
 func (v *InstanceView) CalculateOverheadLines(params OverheadParams) int {
 	lines := 0
@@ -422,13 +412,6 @@ func (v *InstanceView) CalculateOverheadLines(params OverheadParams) int {
 			lines++
 		}
 	}
-
-	// Task section: 1 to MaxTaskDisplayLines+1 lines (extra for "..." when truncated), plus newline
-	taskLines := strings.Count(params.Task, "\n") + 1
-	if taskLines > MaxTaskDisplayLines {
-		taskLines = MaxTaskDisplayLines + 1 // +1 for the "..." line
-	}
-	lines += taskLines + 1 // +1 for the newline after task
 
 	// Dependencies: 1 line each if present
 	if params.HasDependencies {
@@ -462,12 +445,6 @@ func (v *InstanceView) CalculateOverheadLines(params OverheadParams) int {
 	}
 
 	return lines
-}
-
-// RenderTask renders the task description, truncated to MaxTaskDisplayLines.
-func (v *InstanceView) RenderTask(task string) string {
-	taskDisplay := truncateLines(task, MaxTaskDisplayLines)
-	return styles.Subtitle.Render("Task: " + taskDisplay)
 }
 
 // FormatMetrics formats instance metrics for display.
@@ -735,15 +712,6 @@ func (v *InstanceView) RenderWaitingState(status orchestrator.InstanceStatus) st
 }
 
 // Helper functions
-
-// truncateLines limits text to maxLines, adding ellipsis if truncated.
-func truncateLines(s string, maxLines int) string {
-	lines := strings.Split(s, "\n")
-	if len(lines) <= maxLines {
-		return s
-	}
-	return strings.Join(lines[:maxLines], "\n") + "\n..."
-}
 
 // FormatDuration formats a duration for display.
 func FormatDuration(d time.Duration) string {

--- a/internal/tui/view/instance_test.go
+++ b/internal/tui/view/instance_test.go
@@ -15,9 +15,8 @@ func TestCalculateOverheadLines(t *testing.T) {
 		expected int
 	}{
 		{
-			name: "minimal instance - not running, single line task",
+			name: "minimal instance - not running",
 			params: OverheadParams{
-				Task:               "Simple task",
 				HasDependencies:    false,
 				HasDependents:      false,
 				ShowMetrics:        false,
@@ -26,13 +25,12 @@ func TestCalculateOverheadLines(t *testing.T) {
 				HasSearchActive:    false,
 				HasScrollIndicator: false,
 			},
-			// Header (2) + Task (1 line + 1 newline = 2) + Empty banner (1) = 5
-			expected: 5,
+			// Header (2) + Empty banner (1) = 3
+			expected: 3,
 		},
 		{
 			name: "running instance with scroll indicator",
 			params: OverheadParams{
-				Task:               "Simple task",
 				HasDependencies:    false,
 				HasDependents:      false,
 				ShowMetrics:        false,
@@ -41,13 +39,12 @@ func TestCalculateOverheadLines(t *testing.T) {
 				HasSearchActive:    false,
 				HasScrollIndicator: true,
 			},
-			// Header (2) + Task (2) + Banner (2) + Scroll (2) = 8
-			expected: 8,
+			// Header (2) + Banner (2) + Scroll (2) = 6
+			expected: 6,
 		},
 		{
 			name: "instance with dependencies",
 			params: OverheadParams{
-				Task:               "Task with deps",
 				HasDependencies:    true,
 				HasDependents:      false,
 				ShowMetrics:        false,
@@ -56,13 +53,12 @@ func TestCalculateOverheadLines(t *testing.T) {
 				HasSearchActive:    false,
 				HasScrollIndicator: false,
 			},
-			// Header (2) + Task (2) + Dependencies (1) + Empty banner (1) = 6
-			expected: 6,
+			// Header (2) + Dependencies (1) + Empty banner (1) = 4
+			expected: 4,
 		},
 		{
 			name: "instance with dependents",
 			params: OverheadParams{
-				Task:               "Task with dependents",
 				HasDependencies:    false,
 				HasDependents:      true,
 				ShowMetrics:        false,
@@ -71,13 +67,12 @@ func TestCalculateOverheadLines(t *testing.T) {
 				HasSearchActive:    false,
 				HasScrollIndicator: false,
 			},
-			// Header (2) + Task (2) + Dependents (1) + Empty banner (1) = 6
-			expected: 6,
+			// Header (2) + Dependents (1) + Empty banner (1) = 4
+			expected: 4,
 		},
 		{
 			name: "instance with both dependencies and dependents",
 			params: OverheadParams{
-				Task:               "Task",
 				HasDependencies:    true,
 				HasDependents:      true,
 				ShowMetrics:        false,
@@ -86,13 +81,12 @@ func TestCalculateOverheadLines(t *testing.T) {
 				HasSearchActive:    false,
 				HasScrollIndicator: false,
 			},
-			// Header (2) + Task (2) + Dependencies (1) + Dependents (1) + Empty banner (1) = 7
-			expected: 7,
+			// Header (2) + Dependencies (1) + Dependents (1) + Empty banner (1) = 5
+			expected: 5,
 		},
 		{
 			name: "instance with metrics enabled and available",
 			params: OverheadParams{
-				Task:               "Task",
 				HasDependencies:    false,
 				HasDependents:      false,
 				ShowMetrics:        true,
@@ -101,13 +95,12 @@ func TestCalculateOverheadLines(t *testing.T) {
 				HasSearchActive:    false,
 				HasScrollIndicator: false,
 			},
-			// Header (2) + Task (2) + Metrics (2) + Empty banner (1) = 7
-			expected: 7,
+			// Header (2) + Metrics (2) + Empty banner (1) = 5
+			expected: 5,
 		},
 		{
 			name: "instance with metrics enabled but no data",
 			params: OverheadParams{
-				Task:               "Task",
 				HasDependencies:    false,
 				HasDependents:      false,
 				ShowMetrics:        true,
@@ -116,13 +109,12 @@ func TestCalculateOverheadLines(t *testing.T) {
 				HasSearchActive:    false,
 				HasScrollIndicator: false,
 			},
-			// Header (2) + Task (2) + Empty banner (1) = 5
-			expected: 5,
+			// Header (2) + Empty banner (1) = 3
+			expected: 3,
 		},
 		{
 			name: "instance with search active",
 			params: OverheadParams{
-				Task:               "Task",
 				HasDependencies:    false,
 				HasDependents:      false,
 				ShowMetrics:        false,
@@ -131,75 +123,12 @@ func TestCalculateOverheadLines(t *testing.T) {
 				HasSearchActive:    true,
 				HasScrollIndicator: false,
 			},
-			// Header (2) + Task (2) + Empty banner (1) + Search (2) = 7
-			expected: 7,
-		},
-		{
-			name: "multi-line task (3 lines)",
-			params: OverheadParams{
-				Task:               "Line 1\nLine 2\nLine 3",
-				HasDependencies:    false,
-				HasDependents:      false,
-				ShowMetrics:        false,
-				HasMetrics:         false,
-				IsRunning:          false,
-				HasSearchActive:    false,
-				HasScrollIndicator: false,
-			},
-			// Header (2) + Task (3 lines + 1 newline = 4) + Empty banner (1) = 7
-			expected: 7,
-		},
-		{
-			name: "task at exact max lines (5 lines, no truncation needed)",
-			params: OverheadParams{
-				Task:               "Line 1\nLine 2\nLine 3\nLine 4\nLine 5",
-				HasDependencies:    false,
-				HasDependents:      false,
-				ShowMetrics:        false,
-				HasMetrics:         false,
-				IsRunning:          false,
-				HasSearchActive:    false,
-				HasScrollIndicator: false,
-			},
-			// Header (2) + Task (5 lines + 1 newline = 6) + Empty banner (1) = 9
-			// No "..." line added since we're at exactly the max
-			expected: 9,
-		},
-		{
-			name: "task with trailing newline",
-			params: OverheadParams{
-				Task:               "Line 1\nLine 2\n",
-				HasDependencies:    false,
-				HasDependents:      false,
-				ShowMetrics:        false,
-				HasMetrics:         false,
-				IsRunning:          false,
-				HasSearchActive:    false,
-				HasScrollIndicator: false,
-			},
-			// Trailing newline counts as 3 lines (Line 1, Line 2, empty)
-			// Header (2) + Task (3 lines + 1 newline = 4) + Empty banner (1) = 7
-			expected: 7,
-		},
-		{
-			name: "task exceeds max lines (6 lines, max is 5)",
-			params: OverheadParams{
-				Task:               "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6",
-				HasDependencies:    false,
-				HasDependents:      false,
-				ShowMetrics:        false,
-				HasMetrics:         false,
-				IsRunning:          false,
-				HasSearchActive:    false,
-				HasScrollIndicator: false,
-			},
-			// Header (2) + Task (6 lines but capped to 5+1 for "..." = 7) + Empty banner (1) = 10
-			expected: 10,
+			// Header (2) + Empty banner (1) + Search (2) = 5
+			expected: 5,
 		},
 		{
 			name: "maximum overhead - everything enabled",
 			params: OverheadParams{
-				Task:               "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6",
 				HasDependencies:    true,
 				HasDependents:      true,
 				ShowMetrics:        true,
@@ -208,8 +137,8 @@ func TestCalculateOverheadLines(t *testing.T) {
 				HasSearchActive:    true,
 				HasScrollIndicator: true,
 			},
-			// Header (2) + Task (7) + Deps (1) + Dependents (1) + Metrics (2) + Banner (2) + Scroll (2) + Search (2) = 19
-			expected: 19,
+			// Header (2) + Deps (1) + Dependents (1) + Metrics (2) + Banner (2) + Scroll (2) + Search (2) = 12
+			expected: 12,
 		},
 	}
 
@@ -231,7 +160,6 @@ func TestCalculateOverheadLinesConsistency(t *testing.T) {
 	v := NewInstanceView(80, 20)
 
 	baseParams := OverheadParams{
-		Task:               "Simple task",
 		HasDependencies:    false,
 		HasDependents:      false,
 		ShowMetrics:        false,
@@ -277,15 +205,13 @@ func TestCalculateOverheadLinesConsistency(t *testing.T) {
 
 func TestOverheadAtLeastMinimum(t *testing.T) {
 	// Ensure overhead is always at least a reasonable minimum
-	// (header + single-line task + newlines)
-	minExpectedOverhead := 5
+	// (header + empty banner)
+	minExpectedOverhead := 3
 
 	v := NewInstanceView(80, 20)
 
-	// Even with empty task, should have minimum overhead
-	params := OverheadParams{
-		Task: "",
-	}
+	// Even with all features disabled, should have minimum overhead
+	params := OverheadParams{}
 	result := v.CalculateOverheadLines(params)
 	if result < minExpectedOverhead {
 		t.Errorf("Minimum overhead should be at least %d, got %d", minExpectedOverhead, result)
@@ -301,47 +227,42 @@ func TestCalculateOverheadLinesWithGroupHeader(t *testing.T) {
 		{
 			name: "instance with group header only",
 			params: OverheadParams{
-				Task:           "Simple task",
 				HasGroupHeader: true,
 			},
-			// Header (2) + Group header (2) + Task (2) + Empty banner (1) = 7
-			expected: 7,
+			// Header (2) + Group header (2) + Empty banner (1) = 5
+			expected: 5,
 		},
 		{
 			name: "instance with group header and dependencies",
 			params: OverheadParams{
-				Task:                 "Simple task",
 				HasGroupHeader:       true,
 				HasGroupDependencies: true,
 			},
-			// Header (2) + Group header (2) + Dep status (1) + Task (2) + Empty banner (1) = 8
-			expected: 8,
+			// Header (2) + Group header (2) + Dep status (1) + Empty banner (1) = 6
+			expected: 6,
 		},
 		{
 			name: "instance with group header and siblings",
 			params: OverheadParams{
-				Task:           "Simple task",
 				HasGroupHeader: true,
 				HasSiblings:    true,
 			},
-			// Header (2) + Group header (2) + Sibling line (1) + Task (2) + Empty banner (1) = 8
-			expected: 8,
+			// Header (2) + Group header (2) + Sibling line (1) + Empty banner (1) = 6
+			expected: 6,
 		},
 		{
 			name: "instance with group header, dependencies, and siblings",
 			params: OverheadParams{
-				Task:                 "Simple task",
 				HasGroupHeader:       true,
 				HasGroupDependencies: true,
 				HasSiblings:          true,
 			},
-			// Header (2) + Group header (2) + Dep status (1) + Siblings (1) + Task (2) + Empty banner (1) = 9
-			expected: 9,
+			// Header (2) + Group header (2) + Dep status (1) + Siblings (1) + Empty banner (1) = 7
+			expected: 7,
 		},
 		{
 			name: "maximum overhead with group features",
 			params: OverheadParams{
-				Task:                 "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6",
 				HasGroupHeader:       true,
 				HasGroupDependencies: true,
 				HasSiblings:          true,
@@ -353,8 +274,8 @@ func TestCalculateOverheadLinesWithGroupHeader(t *testing.T) {
 				HasSearchActive:      true,
 				HasScrollIndicator:   true,
 			},
-			// Header (2) + Group header (4) + Task (7) + Deps (1) + Dependents (1) + Metrics (2) + Banner (2) + Scroll (2) + Search (2) = 23
-			expected: 23,
+			// Header (2) + Group header (4) + Deps (1) + Dependents (1) + Metrics (2) + Banner (2) + Scroll (2) + Search (2) = 16
+			expected: 16,
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Remove the truncated task/prompt text from the instance detail view header
- The header now displays only the branch name (e.g., `Branch: feature/my-branch`)
- This reduces visual noise and gives more vertical space to the output area

## Changes

- Remove `RenderTask` method from `InstanceView`
- Remove `truncateLines` helper function (no longer used)
- Remove `MaxTaskDisplayLines` constant
- Remove `Task` field from `OverheadParams` struct
- Update `CalculateOverheadLines` to remove task line calculation
- Update all tests with corrected expected overhead values

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Code passes `gofmt` and `go vet`
- [x] Project builds successfully
- [x] Verified no remaining references to removed code via grep
- [x] Manually verified expected overhead calculations in tests