### PR TITLE
Fix triple-shot judge not starting when last attempt has parsing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Triple-Shot Judge Not Triggering** - Fixed a critical bug where the triple-shot judge would not start when the last attempt to complete had a parsing error. Previously, if the completion file for an attempt failed to parse (e.g., due to schema variations like `notes` being an array instead of a string), the error handling path would return early without checking if all attempts were complete. Now the judge-triggering check runs regardless of parsing errors, ensuring the judge starts as long as at least 2 attempts succeeded.
+
+- **Flexible Notes Field in Completion Files** - Changed the `Notes` field in `TripleShotCompletionFile` to use `FlexibleString` type (reusing the existing type from ultraplan.go), which accepts both string and array-of-strings JSON values. This prevents JSON parsing failures when Claude instances write completion files with `notes` as an array, which was causing attempts to be incorrectly marked as failed.
+
 ## [0.8.0] - 2026-01-16
 
 This release focuses on **Multi-Session Support & Deprecation Cleanup** - enabling multiple concurrent `:plan` and `:multiplan` sessions, adding sparse checkout for monorepo support, improved mode visibility, and removing deprecated APIs to streamline the codebase.

--- a/internal/orchestrator/tripleshot.go
+++ b/internal/orchestrator/tripleshot.go
@@ -146,12 +146,12 @@ const TripleShotCompletionFileName = ".claudio-tripleshot-complete.json"
 
 // TripleShotCompletionFile represents the completion report written by an attempt
 type TripleShotCompletionFile struct {
-	AttemptIndex  int      `json:"attempt_index"`
-	Status        string   `json:"status"` // "complete" or "failed"
-	Summary       string   `json:"summary"`
-	FilesModified []string `json:"files_modified"`
-	Approach      string   `json:"approach"` // Description of the approach taken
-	Notes         string   `json:"notes,omitempty"`
+	AttemptIndex  int            `json:"attempt_index"`
+	Status        string         `json:"status"` // "complete" or "failed"
+	Summary       string         `json:"summary"`
+	FilesModified []string       `json:"files_modified"`
+	Approach      string         `json:"approach"`        // Description of the approach taken
+	Notes         FlexibleString `json:"notes,omitempty"` // Uses FlexibleString to accept both string and []string
 }
 
 // TripleShotCompletionFilePath returns the full path to the completion file


### PR DESCRIPTION
## Summary

- **Fix critical bug**: Triple-shot judge now starts even when the last attempt to complete has a parsing error in its completion file
- **Schema flexibility**: Notes field in completion files now accepts both string and array-of-strings JSON values
- **Regression tests**: Added comprehensive tests for flexible notes parsing and extra field handling

## Problem

When running a triple-shot, if the last attempt to finish had a completion file that failed to parse (e.g., the `notes` field was written as an array instead of a string), the judge would never start. This left users stuck with a "working" triple-shot that would never complete.

**Root cause**: The `handleTripleShotAttemptProcessed` function returned early when `msg.Err` was non-nil, skipping the check for whether all attempts were complete and the judge should be started.

## Solution

1. **Control flow fix** (`internal/tui/tripleshot.go`): Removed the early return so the judge-starting check always runs, regardless of whether the individual attempt had a parsing error

2. **Schema fix** (`internal/orchestrator/tripleshot.go`): Changed the `Notes` field in `TripleShotCompletionFile` to use `FlexibleString` type (reusing the existing type from ultraplan.go), which accepts both string and array-of-strings JSON values

## Test plan

- [x] Added `TestParseTripleShotCompletionFile_FlexibleNotes` - tests notes as string, array, empty string, empty array, and omitted
- [x] Added `TestParseTripleShotCompletionFile_ExtraFields` - tests that extra JSON fields don't cause parse errors
- [x] All existing tests pass: `go test ./...`
- [x] Code formatted: `gofmt -d .`
- [x] Linting passes: `go vet ./...`