### PR TITLE
Reorganize internal/cmd into domain-specific subpackages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CLI Command Package Reorganization** - Reorganized the flat `internal/cmd/` package (17 files) into domain-specific subpackages for better maintainability and easier onboarding. Commands are now grouped into: `session/` (start, stop, sessions, cleanup), `planning/` (plan, ultraplan, tripleshot), `instance/` (add, remove, status, stats), `observability/` (logs, harvest), `project/` (init, pr), and `config/` (config management). Each subpackage has a `Register()` function that wires its commands to the root command. This change is purely organizational and has no impact on CLI behavior.
+
 ## [0.8.2] - 2026-01-16
 
 ### Fixed

--- a/internal/cmd/instance/add.go
+++ b/internal/cmd/instance/add.go
@@ -1,4 +1,6 @@
-package cmd
+// Package instance provides CLI commands for managing Claude instances.
+// This includes adding, removing, and querying instance status.
+package instance
 
 import (
 	"fmt"
@@ -34,9 +36,13 @@ var (
 )
 
 func init() {
-	rootCmd.AddCommand(addCmd)
 	addCmd.Flags().BoolVarP(&autoStart, "start", "s", false, "Automatically start the instance after adding (ignored if --depends-on is set)")
 	addCmd.Flags().StringVarP(&dependsOn, "depends-on", "d", "", "Instance ID(s) or task name(s) that must complete before this instance starts (comma-separated)")
+}
+
+// RegisterAddCmd registers the add command with the given parent command.
+func RegisterAddCmd(parent *cobra.Command) {
+	parent.AddCommand(addCmd)
 }
 
 func runAdd(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/instance/register.go
+++ b/internal/cmd/instance/register.go
@@ -1,0 +1,13 @@
+package instance
+
+import "github.com/spf13/cobra"
+
+// Register adds all instance-related commands to the given parent command.
+// This is the main entry point for integrating the instance subpackage with
+// the root command.
+func Register(parent *cobra.Command) {
+	RegisterAddCmd(parent)
+	RegisterRemoveCmd(parent)
+	RegisterStatusCmd(parent)
+	RegisterStatsCmd(parent)
+}

--- a/internal/cmd/instance/remove.go
+++ b/internal/cmd/instance/remove.go
@@ -1,4 +1,4 @@
-package cmd
+package instance
 
 import (
 	"fmt"
@@ -20,8 +20,12 @@ its worktree and branch. Use --force to remove even if there are uncommitted cha
 var forceRemove bool
 
 func init() {
-	rootCmd.AddCommand(removeCmd)
 	removeCmd.Flags().BoolVarP(&forceRemove, "force", "f", false, "Force removal even with uncommitted changes")
+}
+
+// RegisterRemoveCmd registers the remove command with the given parent command.
+func RegisterRemoveCmd(parent *cobra.Command) {
+	parent.AddCommand(removeCmd)
 }
 
 func runRemove(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/instance/stats.go
+++ b/internal/cmd/instance/stats.go
@@ -1,4 +1,4 @@
-package cmd
+package instance
 
 import (
 	"fmt"
@@ -31,7 +31,11 @@ var (
 
 func init() {
 	statsCmd.Flags().BoolVar(&statsJSON, "json", false, "Output statistics as JSON")
-	rootCmd.AddCommand(statsCmd)
+}
+
+// RegisterStatsCmd registers the stats command with the given parent command.
+func RegisterStatsCmd(parent *cobra.Command) {
+	parent.AddCommand(statsCmd)
 }
 
 func runStats(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/instance/status.go
+++ b/internal/cmd/instance/status.go
@@ -1,4 +1,4 @@
-package cmd
+package instance
 
 import (
 	"fmt"
@@ -15,8 +15,9 @@ var statusCmd = &cobra.Command{
 	RunE:  runStatus,
 }
 
-func init() {
-	rootCmd.AddCommand(statusCmd)
+// RegisterStatusCmd registers the status command with the given parent command.
+func RegisterStatusCmd(parent *cobra.Command) {
+	parent.AddCommand(statusCmd)
 }
 
 func runStatus(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/observability/logs.go
+++ b/internal/cmd/observability/logs.go
@@ -1,4 +1,6 @@
-package cmd
+// Package observability provides CLI commands for monitoring and observing
+// Claudio sessions and instances. This includes log viewing and worktree harvesting.
+package observability
 
 import (
 	"bufio"
@@ -56,14 +58,17 @@ var (
 )
 
 func init() {
-	rootCmd.AddCommand(logsCmd)
-
 	logsCmd.Flags().StringVarP(&logsSessionID, "session", "s", "", "Session ID (default: most recent)")
 	logsCmd.Flags().IntVarP(&logsTail, "tail", "n", 50, "Number of lines to show (0 for all)")
 	logsCmd.Flags().BoolVarP(&logsFollow, "follow", "f", false, "Follow log output (like tail -f)")
 	logsCmd.Flags().StringVar(&logsLevel, "level", "", "Filter by minimum level (debug/info/warn/error)")
 	logsCmd.Flags().StringVar(&logsSince, "since", "", "Show logs since duration ago (e.g., 1h, 30m)")
 	logsCmd.Flags().StringVar(&logsGrep, "grep", "", "Filter logs matching pattern (regex)")
+}
+
+// RegisterLogsCmd registers the logs command with the given parent command.
+func RegisterLogsCmd(parent *cobra.Command) {
+	parent.AddCommand(logsCmd)
 }
 
 // logEntry represents a parsed JSON log line

--- a/internal/cmd/observability/register.go
+++ b/internal/cmd/observability/register.go
@@ -1,0 +1,11 @@
+package observability
+
+import "github.com/spf13/cobra"
+
+// Register adds all observability-related commands to the given parent command.
+// This is the main entry point for integrating the observability subpackage with
+// the root command.
+func Register(parent *cobra.Command) {
+	RegisterLogsCmd(parent)
+	RegisterHarvestCmd(parent)
+}

--- a/internal/cmd/planning/plan.go
+++ b/internal/cmd/planning/plan.go
@@ -1,4 +1,6 @@
-package cmd
+// Package planning provides CLI commands for planning and orchestration modes.
+// This includes the plan, ultraplan, and tripleshot commands.
+package planning
 
 import (
 	"bufio"
@@ -56,8 +58,6 @@ var (
 )
 
 func init() {
-	rootCmd.AddCommand(planCmd)
-
 	planCmd.Flags().BoolVar(&planDryRun, "dry-run", false, "Show plan without creating output")
 	planCmd.Flags().BoolVar(&planMultiPass, "multi-pass", false, "Use 3-strategy planning for complex tasks")
 	planCmd.Flags().StringSliceVar(&planLabels, "labels", nil, "Labels to add to GitHub Issues")
@@ -65,6 +65,11 @@ func init() {
 	planCmd.Flags().BoolVar(&planNoConfirm, "no-confirm", false, "Skip confirmation prompt")
 	planCmd.Flags().StringVar(&planOutputFormat, "output-format", "issues",
 		"Output format: 'json' (for ultraplan), 'issues' (GitHub Issues), or 'both'")
+}
+
+// RegisterPlanCmd registers the plan command with the given parent command.
+func RegisterPlanCmd(parent *cobra.Command) {
+	parent.AddCommand(planCmd)
 }
 
 func runPlan(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/planning/register.go
+++ b/internal/cmd/planning/register.go
@@ -1,0 +1,12 @@
+package planning
+
+import "github.com/spf13/cobra"
+
+// Register adds all planning-related commands to the given parent command.
+// This is the main entry point for integrating the planning subpackage with
+// the root command.
+func Register(parent *cobra.Command) {
+	RegisterPlanCmd(parent)
+	RegisterUltraplanCmd(parent)
+	RegisterTripleshotCmd(parent)
+}

--- a/internal/cmd/planning/tripleshot.go
+++ b/internal/cmd/planning/tripleshot.go
@@ -1,4 +1,4 @@
-package cmd
+package planning
 
 import (
 	"bufio"
@@ -48,9 +48,12 @@ var (
 )
 
 func init() {
-	rootCmd.AddCommand(tripleshotCmd)
-
 	tripleshotCmd.Flags().BoolVar(&tripleshotAutoApprove, "auto-approve", false, "Auto-approve applying the winning solution")
+}
+
+// RegisterTripleshotCmd registers the tripleshot command with the given parent command.
+func RegisterTripleshotCmd(parent *cobra.Command) {
+	parent.AddCommand(tripleshotCmd)
 }
 
 func runTripleshot(cmd *cobra.Command, args []string) error {
@@ -80,7 +83,7 @@ func runTripleshot(cmd *cobra.Command, args []string) error {
 
 	// Create logger if enabled
 	sessionDir := sessutil.GetSessionDir(cwd, sessionID)
-	logger := CreateLogger(sessionDir, cfg)
+	logger := createLogger(sessionDir, cfg)
 	defer func() { _ = logger.Close() }()
 
 	// Create orchestrator with multi-session support
@@ -97,7 +100,7 @@ func runTripleshot(cmd *cobra.Command, args []string) error {
 	if len(words) > 3 {
 		words = words[:3]
 	}
-	sessionName := "tripleshot-" + slugifyWords(words)
+	sessionName := "tripleshot-" + SlugifyWords(words)
 
 	session, err := orch.StartSession(sessionName)
 	if err != nil {

--- a/internal/cmd/project/init.go
+++ b/internal/cmd/project/init.go
@@ -1,4 +1,6 @@
-package cmd
+// Package project provides CLI commands for project-level operations.
+// This includes initialization and pull request management.
+package project
 
 import (
 	"fmt"
@@ -18,8 +20,9 @@ This creates a .claudio directory to store session state and worktrees.`,
 	RunE: runInit,
 }
 
-func init() {
-	rootCmd.AddCommand(initCmd)
+// RegisterInitCmd registers the init command with the given parent command.
+func RegisterInitCmd(parent *cobra.Command) {
+	parent.AddCommand(initCmd)
 }
 
 func runInit(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/project/pr.go
+++ b/internal/cmd/project/pr.go
@@ -1,4 +1,4 @@
-package cmd
+package project
 
 import (
 	"fmt"
@@ -37,7 +37,6 @@ var (
 )
 
 func init() {
-	rootCmd.AddCommand(prCmd)
 	prCmd.Flags().BoolVarP(&prDraft, "draft", "d", false, "Create as a draft PR")
 	prCmd.Flags().BoolVar(&prNoPush, "no-push", false, "Don't push the branch before creating the PR")
 	prCmd.Flags().BoolVar(&prNoAI, "no-ai", false, "Skip AI generation, use simple defaults")
@@ -47,6 +46,11 @@ func init() {
 	prCmd.Flags().StringSliceVarP(&prReviewers, "reviewer", "r", nil, "Add reviewers (can be specified multiple times)")
 	prCmd.Flags().StringSliceVarP(&prLabels, "label", "l", nil, "Add labels (can be specified multiple times)")
 	prCmd.Flags().StringSliceVar(&prCloses, "closes", nil, "Link issues to close (e.g., --closes 42)")
+}
+
+// RegisterPRCmd registers the pr command with the given parent command.
+func RegisterPRCmd(parent *cobra.Command) {
+	parent.AddCommand(prCmd)
 }
 
 func runPR(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/project/register.go
+++ b/internal/cmd/project/register.go
@@ -1,0 +1,11 @@
+package project
+
+import "github.com/spf13/cobra"
+
+// Register adds all project-related commands to the given parent command.
+// This is the main entry point for integrating the project subpackage with
+// the root command.
+func Register(parent *cobra.Command) {
+	RegisterInitCmd(parent)
+	RegisterPRCmd(parent)
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,9 +1,26 @@
+// Package cmd provides the CLI command structure for Claudio.
+// Commands are organized into domain-specific subpackages for better
+// maintainability and easier onboarding.
+//
+// Subpackage organization:
+//   - session/: Session lifecycle (start, stop, sessions, cleanup)
+//   - planning/: Planning modes (plan, ultraplan, tripleshot)
+//   - instance/: Instance management (add, remove, status, stats)
+//   - observability/: Monitoring (logs, harvest)
+//   - project/: Project-level operations (init, pr)
+//   - config/: Configuration management
 package cmd
 
 import (
 	"strings"
 
-	"github.com/Iron-Ham/claudio/internal/config"
+	"github.com/Iron-Ham/claudio/internal/cmd/config"
+	"github.com/Iron-Ham/claudio/internal/cmd/instance"
+	"github.com/Iron-Ham/claudio/internal/cmd/observability"
+	"github.com/Iron-Ham/claudio/internal/cmd/planning"
+	"github.com/Iron-Ham/claudio/internal/cmd/project"
+	"github.com/Iron-Ham/claudio/internal/cmd/session"
+	appconfig "github.com/Iron-Ham/claudio/internal/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -27,18 +44,26 @@ func init() {
 	// Global flags
 	rootCmd.PersistentFlags().StringP("config", "c", "", "config file (default is $HOME/.config/claudio/config.yaml)")
 	_ = viper.BindPFlag("config", rootCmd.PersistentFlags().Lookup("config"))
+
+	// Register all command subpackages
+	session.Register(rootCmd)
+	planning.Register(rootCmd)
+	instance.Register(rootCmd)
+	observability.Register(rootCmd)
+	project.Register(rootCmd)
+	config.Register(rootCmd)
 }
 
 func initConfig() {
 	// Set defaults first so they're available even without a config file
-	config.SetDefaults()
+	appconfig.SetDefaults()
 
 	if cfgFile := viper.GetString("config"); cfgFile != "" {
 		viper.SetConfigFile(cfgFile)
 	} else {
 		viper.SetConfigName("config")
 		viper.SetConfigType("yaml")
-		viper.AddConfigPath(config.ConfigDir())
+		viper.AddConfigPath(appconfig.ConfigDir())
 		viper.AddConfigPath("$HOME/.config/claudio")
 		viper.AddConfigPath(".")
 	}

--- a/internal/cmd/session/cleanup_test.go
+++ b/internal/cmd/session/cleanup_test.go
@@ -1,0 +1,103 @@
+package session
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+)
+
+// captureOutput captures stdout during function execution
+func captureOutput(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	f()
+
+	_ = w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestPrintCleanupSummary(t *testing.T) {
+	result := &CleanupResult{
+		StaleWorktrees: []StaleWorktree{
+			{Path: "/path/to/wt1", Branch: "claudio/abc-feature", HasUncommitted: false},
+			{Path: "/path/to/wt2", Branch: "claudio/def-bugfix", HasUncommitted: true},
+		},
+		StaleBranches:    []string{"claudio/orphan-branch"},
+		OrphanedTmuxSess: []string{"claudio-orphan123"},
+	}
+
+	// Temporarily set flags to enable all output sections
+	originalWorktrees := cleanupWorktrees
+	originalBranches := cleanupBranches
+	originalTmux := cleanupTmux
+	cleanupWorktrees = true
+	cleanupBranches = true
+	cleanupTmux = true
+	defer func() {
+		cleanupWorktrees = originalWorktrees
+		cleanupBranches = originalBranches
+		cleanupTmux = originalTmux
+	}()
+
+	output := captureOutput(func() {
+		printCleanupSummary(result, false) // cleanAll=false, use specific flags instead
+	})
+
+	// Verify output contains expected sections (using current format)
+	expectedContent := []string{
+		"Stale Resources Found",
+		"Worktrees (2):",
+		"wt1",
+		"wt2",
+		"[uncommitted changes]",
+		"Branches (1):",
+		"claudio/orphan-branch",
+		"Orphaned Tmux Sessions (1):",
+		"claudio-orphan123",
+	}
+
+	for _, expected := range expectedContent {
+		if !bytes.Contains([]byte(output), []byte(expected)) {
+			t.Errorf("printCleanupSummary() output missing expected content: %q\nFull output:\n%s", expected, output)
+		}
+	}
+}
+
+func TestPrintCleanupSummary_NoResources(t *testing.T) {
+	result := &CleanupResult{
+		StaleWorktrees:    []StaleWorktree{},
+		StaleBranches:     []string{},
+		OrphanedTmuxSess:  []string{},
+		ActiveInstanceIDs: make(map[string]bool),
+	}
+
+	output := captureOutput(func() {
+		printCleanupSummary(result, true) // cleanAll=true to print all sections
+	})
+
+	// With no resources, printCleanupSummary still prints the header
+	// The "Nothing to clean up" message is in runCleanup, not printCleanupSummary
+	if !bytes.Contains([]byte(output), []byte("Stale Resources Found")) {
+		t.Errorf("printCleanupSummary() should output header, got: %q", output)
+	}
+
+	// Should NOT contain any resource listings (no worktrees, branches, etc.)
+	unexpectedContent := []string{
+		"Worktrees",
+		"Branches",
+		"Orphaned Tmux Sessions",
+	}
+
+	for _, unexpected := range unexpectedContent {
+		if bytes.Contains([]byte(output), []byte(unexpected)) {
+			t.Errorf("printCleanupSummary() with no resources should not contain %q\nFull output:\n%s", unexpected, output)
+		}
+	}
+}

--- a/internal/cmd/session/register.go
+++ b/internal/cmd/session/register.go
@@ -1,0 +1,13 @@
+package session
+
+import "github.com/spf13/cobra"
+
+// Register adds all session-related commands to the given parent command.
+// This is the main entry point for integrating the session subpackage with
+// the root command.
+func Register(parent *cobra.Command) {
+	RegisterStartCmd(parent)
+	RegisterStopCmd(parent)
+	RegisterSessionsCmd(parent)
+	RegisterCleanupCmd(parent)
+}

--- a/internal/cmd/session/sessions.go
+++ b/internal/cmd/session/sessions.go
@@ -1,4 +1,4 @@
-package cmd
+package session
 
 import (
 	"fmt"
@@ -26,7 +26,7 @@ var sessionsListCmd = &cobra.Command{
 - Number of instances
 - Lock status (whether another process is attached)
 - Orphaned tmux sessions`,
-	RunE: runSessionsList,
+	RunE: RunSessionsList,
 }
 
 var sessionsAttachCmd = &cobra.Command{
@@ -73,7 +73,6 @@ var (
 )
 
 func init() {
-	rootCmd.AddCommand(sessionsCmd)
 	sessionsCmd.AddCommand(sessionsListCmd)
 	sessionsCmd.AddCommand(sessionsAttachCmd)
 	sessionsCmd.AddCommand(sessionsRecoverCmd)
@@ -83,7 +82,14 @@ func init() {
 	sessionsCleanCmd.Flags().StringVar(&cleanSessionID, "session", "", "Clean specific session by ID")
 }
 
-func runSessionsList(cmd *cobra.Command, args []string) error {
+// RegisterSessionsCmd registers the sessions command with the given parent command.
+func RegisterSessionsCmd(parent *cobra.Command) {
+	parent.AddCommand(sessionsCmd)
+}
+
+// RunSessionsList lists all Claudio sessions with their status.
+// This is exported so it can be called from start.go.
+func RunSessionsList(cmd *cobra.Command, args []string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get current directory: %w", err)
@@ -223,7 +229,7 @@ func runSessionsAttach(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Attaching to session %s...\n", targetSession.ID)
 
 	cfg := config.Get()
-	return attachToSession(cwd, targetSession.ID, cfg)
+	return AttachToSession(cwd, targetSession.ID, cfg)
 }
 
 func runSessionsRecover(cmd *cobra.Command, args []string) error {
@@ -236,7 +242,7 @@ func runSessionsRecover(cmd *cobra.Command, args []string) error {
 
 	// If session ID is provided, use attach
 	if len(args) > 0 {
-		return attachToSession(cwd, args[0], cfg)
+		return AttachToSession(cwd, args[0], cfg)
 	}
 
 	// Try to recover legacy session

--- a/internal/cmd/session/start.go
+++ b/internal/cmd/session/start.go
@@ -1,4 +1,6 @@
-package cmd
+// Package session provides CLI commands for managing Claudio sessions.
+// This includes starting, stopping, listing, and cleaning up sessions.
+package session
 
 import (
 	"bufio"
@@ -39,9 +41,13 @@ var (
 )
 
 func init() {
-	rootCmd.AddCommand(startCmd)
 	startCmd.Flags().BoolVar(&forceNew, "new", false, "Force start a new session")
 	startCmd.Flags().StringVar(&attachSession, "session", "", "Attach to a specific session by ID")
+}
+
+// RegisterStartCmd registers the start command with the given parent command.
+func RegisterStartCmd(parent *cobra.Command) {
+	parent.AddCommand(startCmd)
 }
 
 func runStart(cmd *cobra.Command, args []string) error {
@@ -75,7 +81,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 
 	// If --session flag is set, attach to that specific session
 	if attachSession != "" {
-		return attachToSession(cwd, attachSession, cfg)
+		return AttachToSession(cwd, attachSession, cfg)
 	}
 
 	// List available sessions
@@ -102,12 +108,12 @@ sessionLoop:
 
 		switch action {
 		case "attach":
-			return attachToSession(cwd, selectedID, cfg)
+			return AttachToSession(cwd, selectedID, cfg)
 		case "new":
 			// Exit loop to create new session below
 			break sessionLoop
 		case "list":
-			return runSessionsList(cmd, args)
+			return RunSessionsList(cmd, args)
 		case "quit":
 			return nil
 		case "refresh":
@@ -130,8 +136,9 @@ sessionLoop:
 	return startNewSession(cwd, sessionName, cfg)
 }
 
-// attachToSession attaches to an existing session by ID
-func attachToSession(cwd, sessionID string, cfg *config.Config) error {
+// AttachToSession attaches to an existing session by ID.
+// This is exported so other packages (like sessions command) can use it.
+func AttachToSession(cwd, sessionID string, cfg *config.Config) error {
 	// Check if session exists
 	if !session.SessionExists(cwd, sessionID) {
 		return fmt.Errorf("session %s not found", sessionID)
@@ -309,7 +316,7 @@ func migrateAndStartLegacySession(cwd, sessionName string, cfg *config.Config) e
 	fmt.Println()
 
 	// Now start with the migrated session
-	return attachToSession(cwd, sessionID, cfg)
+	return AttachToSession(cwd, sessionID, cfg)
 }
 
 // launchTUI sets up terminal dimensions and launches the TUI

--- a/internal/cmd/session/stop.go
+++ b/internal/cmd/session/stop.go
@@ -1,4 +1,4 @@
-package cmd
+package session
 
 import (
 	"fmt"
@@ -19,8 +19,12 @@ You will be prompted for what to do with each instance's work.`,
 var forceStop bool
 
 func init() {
-	rootCmd.AddCommand(stopCmd)
 	stopCmd.Flags().BoolVarP(&forceStop, "force", "f", false, "Force stop without prompts")
+}
+
+// RegisterStopCmd registers the stop command with the given parent command.
+func RegisterStopCmd(parent *cobra.Command) {
+	parent.AddCommand(stopCmd)
 }
 
 func runStop(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary

- Reorganizes the flat `internal/cmd/` package (17 files) into domain-specific subpackages for better maintainability and easier onboarding
- Uses an elegant `Register(parent *cobra.Command)` pattern for command wiring, resulting in a clean root.go
- Package names are idiomatic Go (no redundant "cmd" suffix): `session/`, `planning/`, `instance/`, `observability/`, `project/`, `config/`
- No behavioral changes - purely organizational refactoring

### New Package Structure

```
internal/cmd/
├── session/     # start, stop, sessions, cleanup commands
├── planning/    # plan, ultraplan, tripleshot commands  
├── instance/    # add, remove, status, stats commands
├── observability/ # logs, harvest commands
├── project/     # init, pr commands
├── config/      # config management
└── root.go      # root command setup with Register() calls
```

## Test plan

- [x] All tests pass (`go test ./...`)
- [x] Build succeeds (`go build ./...`)
- [x] Lint passes (`golangci-lint run`)
- [x] go vet passes (`go vet ./...`)
- [x] Added `cleanup_test.go` to session package for test coverage
- [x] Verified CLI commands still work as expected