### PR TITLE
Add configurable sidebar width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Configurable Sidebar Width** - The sidebar width is now user-configurable through the interactive configuration UI (`tui.sidebar_width`). The default width has been increased from 30 to 36 columns to provide more space for instance names and metrics. Users can configure widths between 20-60 columns.
 - **Group Dismiss Shortcut** - Added `gq` keyboard shortcut to dismiss (remove) all instances in the currently selected group. This applies the `:D` (remove) action to every instance in the group, providing a quick way to clean up an entire group at once.
 
 ### Changed

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,8 @@ type TUIConfig struct {
 	MaxOutputLines int `mapstructure:"max_output_lines"`
 	// VerboseCommandHelp shows full command descriptions in command mode instead of single letters
 	VerboseCommandHelp bool `mapstructure:"verbose_command_help"`
+	// SidebarWidth is the width of the sidebar panel in columns (default: 36, min: 20, max: 60)
+	SidebarWidth int `mapstructure:"sidebar_width"`
 }
 
 // SessionConfig controls session behavior
@@ -329,6 +331,7 @@ func Default() *Config {
 			AutoFocusOnInput:   true,
 			MaxOutputLines:     1000,
 			VerboseCommandHelp: true,
+			SidebarWidth:       36,
 		},
 		Session: SessionConfig{},
 		Instance: InstanceConfig{
@@ -440,6 +443,7 @@ func SetDefaults() {
 	viper.SetDefault("tui.auto_focus_on_input", defaults.TUI.AutoFocusOnInput)
 	viper.SetDefault("tui.max_output_lines", defaults.TUI.MaxOutputLines)
 	viper.SetDefault("tui.verbose_command_help", defaults.TUI.VerboseCommandHelp)
+	viper.SetDefault("tui.sidebar_width", defaults.TUI.SidebarWidth)
 
 	// Session defaults (currently empty)
 

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -125,6 +125,28 @@ func (c *Config) validateTUI() []ValidationError {
 		})
 	}
 
+	// Sidebar width validation (0 means use default, which is valid).
+	// These values must match tui.SidebarMinWidth and tui.SidebarMaxWidth
+	// (defined separately to avoid circular import).
+	const minSidebarWidth = 20
+	const maxSidebarWidth = 60
+	if c.TUI.SidebarWidth != 0 {
+		if c.TUI.SidebarWidth < minSidebarWidth {
+			errors = append(errors, ValidationError{
+				Field:   "tui.sidebar_width",
+				Value:   c.TUI.SidebarWidth,
+				Message: fmt.Sprintf("must be at least %d columns", minSidebarWidth),
+			})
+		}
+		if c.TUI.SidebarWidth > maxSidebarWidth {
+			errors = append(errors, ValidationError{
+				Field:   "tui.sidebar_width",
+				Value:   c.TUI.SidebarWidth,
+				Message: fmt.Sprintf("exceeds maximum of %d columns", maxSidebarWidth),
+			})
+		}
+	}
+
 	return errors
 }
 

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -145,6 +145,66 @@ func TestConfig_Validate_TUI(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("valid sidebar width", func(t *testing.T) {
+		for _, width := range []int{20, 30, 36, 45, 60} {
+			cfg := Default()
+			cfg.TUI.SidebarWidth = width
+			errs := cfg.Validate()
+
+			for _, err := range errs {
+				if err.Field == "tui.sidebar_width" {
+					t.Errorf("width %d should be valid, got error: %v", width, err)
+				}
+			}
+		}
+	})
+
+	t.Run("zero sidebar width uses default (valid)", func(t *testing.T) {
+		cfg := Default()
+		cfg.TUI.SidebarWidth = 0
+		errs := cfg.Validate()
+
+		for _, err := range errs {
+			if err.Field == "tui.sidebar_width" {
+				t.Errorf("zero sidebar width should be valid (uses default), got error: %v", err)
+			}
+		}
+	})
+
+	t.Run("sidebar width too small", func(t *testing.T) {
+		cfg := Default()
+		cfg.TUI.SidebarWidth = 15
+		errs := cfg.Validate()
+
+		found := false
+		for _, err := range errs {
+			if err.Field == "tui.sidebar_width" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("expected error for small sidebar width")
+		}
+	})
+
+	t.Run("sidebar width too large", func(t *testing.T) {
+		cfg := Default()
+		cfg.TUI.SidebarWidth = 80
+		errs := cfg.Validate()
+
+		found := false
+		for _, err := range errs {
+			if err.Field == "tui.sidebar_width" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("expected error for large sidebar width")
+		}
+	})
 }
 
 func TestConfig_Validate_Instance(t *testing.T) {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -838,10 +838,8 @@ func (m Model) View() string {
 
 	// Get pane dimensions, accounting for dynamic footer elements
 	dims := m.terminalManager.GetPaneDimensions(m.calculateExtraFooterLines())
-	effectiveSidebarWidth := SidebarWidth
-	if dims.TerminalWidth < 80 {
-		effectiveSidebarWidth = SidebarMinWidth
-	}
+	cfg := config.Get()
+	effectiveSidebarWidth := CalculateEffectiveSidebarWidthWithConfig(dims.TerminalWidth, cfg.TUI.SidebarWidth)
 	mainContentWidth := dims.TerminalWidth - effectiveSidebarWidth - 3 // 3 for gap between panels
 
 	// Main area height is pre-calculated by terminal manager

--- a/internal/tui/config/config.go
+++ b/internal/tui/config/config.go
@@ -92,6 +92,13 @@ func New() Model {
 					Type:        "bool",
 					Category:    "tui",
 				},
+				{
+					Key:         "tui.sidebar_width",
+					Label:       "Sidebar Width",
+					Description: "Width of the sidebar panel in columns (20-60, default: 36)",
+					Type:        "int",
+					Category:    "tui",
+				},
 			},
 		},
 		{
@@ -1119,6 +1126,7 @@ func (m *Model) resetCurrentToDefault() {
 		"tui.auto_focus_on_input":  defaults.TUI.AutoFocusOnInput,
 		"tui.max_output_lines":     defaults.TUI.MaxOutputLines,
 		"tui.verbose_command_help": defaults.TUI.VerboseCommandHelp,
+		"tui.sidebar_width":        defaults.TUI.SidebarWidth,
 		// Instance
 		"instance.output_buffer_size":         defaults.Instance.OutputBufferSize,
 		"instance.capture_interval_ms":        defaults.Instance.CaptureIntervalMs,

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -3,11 +3,17 @@ package tui
 // Layout constants define the fixed dimensions and offsets used throughout the TUI.
 // These values ensure consistent spacing and sizing across all views.
 const (
-	// SidebarWidth is the standard width for the sidebar panel.
-	SidebarWidth = 30
+	// DefaultSidebarWidth is the default width for the sidebar panel.
+	// This is used when no user configuration is provided.
+	DefaultSidebarWidth = 36
 
 	// SidebarMinWidth is the minimum sidebar width used when terminal is narrow (< 80 columns).
+	// Values below this are rejected during configuration validation.
 	SidebarMinWidth = 20
+
+	// SidebarMaxWidth is the maximum allowed sidebar width to prevent the sidebar
+	// from consuming too much screen space.
+	SidebarMaxWidth = 60
 
 	// ContentWidthOffset accounts for the gap between sidebar and content area.
 	// Calculated as: sidebar gap (3) + output area margin (4) = 7
@@ -18,24 +24,50 @@ const (
 	ContentHeightOffset = 12
 )
 
+// ClampSidebarWidth ensures the sidebar width is within valid bounds
+// (SidebarMinWidth to SidebarMaxWidth).
+func ClampSidebarWidth(width int) int {
+	if width < SidebarMinWidth {
+		return SidebarMinWidth
+	}
+	if width > SidebarMaxWidth {
+		return SidebarMaxWidth
+	}
+	return width
+}
+
 // CalculateContentDimensions returns the effective content area dimensions
 // given the terminal width and height. This accounts for the sidebar and other UI elements.
 // The sidebar width is reduced for narrow terminals (< 80 columns) to preserve content space.
+// Uses the default sidebar width; for custom widths, use CalculateContentDimensionsWithSidebarWidth.
 func CalculateContentDimensions(termWidth, termHeight int) (contentWidth, contentHeight int) {
-	effectiveSidebarWidth := SidebarWidth
-	if termWidth < 80 {
-		effectiveSidebarWidth = SidebarMinWidth
-	}
+	return CalculateContentDimensionsWithSidebarWidth(termWidth, termHeight, DefaultSidebarWidth)
+}
+
+// CalculateContentDimensionsWithSidebarWidth returns the effective content area dimensions
+// given the terminal dimensions and a configured sidebar width.
+// The sidebar width is reduced for narrow terminals (< 80 columns) to preserve content space.
+func CalculateContentDimensionsWithSidebarWidth(termWidth, termHeight, configuredSidebarWidth int) (contentWidth, contentHeight int) {
+	effectiveSidebarWidth := CalculateEffectiveSidebarWidthWithConfig(termWidth, configuredSidebarWidth)
 	contentWidth = termWidth - effectiveSidebarWidth - ContentWidthOffset
 	contentHeight = termHeight - ContentHeightOffset
 	return contentWidth, contentHeight
 }
 
 // CalculateEffectiveSidebarWidth returns the appropriate sidebar width based on terminal width.
-// Returns SidebarMinWidth for terminals narrower than 80 columns, otherwise SidebarWidth.
+// Returns SidebarMinWidth for terminals narrower than 80 columns, otherwise DefaultSidebarWidth.
+// For custom sidebar widths, use CalculateEffectiveSidebarWidthWithConfig.
 func CalculateEffectiveSidebarWidth(termWidth int) int {
+	return CalculateEffectiveSidebarWidthWithConfig(termWidth, DefaultSidebarWidth)
+}
+
+// CalculateEffectiveSidebarWidthWithConfig returns the appropriate sidebar width based on
+// terminal width and user-configured sidebar width.
+// Returns SidebarMinWidth for terminals narrower than 80 columns, otherwise the clamped
+// configured width.
+func CalculateEffectiveSidebarWidthWithConfig(termWidth, configuredSidebarWidth int) int {
 	if termWidth < 80 {
 		return SidebarMinWidth
 	}
-	return SidebarWidth
+	return ClampSidebarWidth(configuredSidebarWidth)
 }

--- a/internal/tui/layout_test.go
+++ b/internal/tui/layout_test.go
@@ -11,11 +11,11 @@ func TestCalculateContentDimensions(t *testing.T) {
 		wantHeight int
 	}{
 		{
-			name:       "standard terminal uses full sidebar width",
+			name:       "standard terminal uses default sidebar width",
 			termWidth:  120,
 			termHeight: 40,
-			wantWidth:  120 - SidebarWidth - ContentWidthOffset, // 120 - 30 - 7 = 83
-			wantHeight: 40 - ContentHeightOffset,                // 40 - 12 = 28
+			wantWidth:  120 - DefaultSidebarWidth - ContentWidthOffset, // 120 - 36 - 7 = 77
+			wantHeight: 40 - ContentHeightOffset,                       // 40 - 12 = 28
 		},
 		{
 			name:       "narrow terminal uses minimum sidebar width",
@@ -25,11 +25,11 @@ func TestCalculateContentDimensions(t *testing.T) {
 			wantHeight: 30 - ContentHeightOffset,                  // 30 - 12 = 18
 		},
 		{
-			name:       "exactly 80 width uses full sidebar",
+			name:       "exactly 80 width uses default sidebar",
 			termWidth:  80,
 			termHeight: 24,
-			wantWidth:  80 - SidebarWidth - ContentWidthOffset, // 80 - 30 - 7 = 43
-			wantHeight: 24 - ContentHeightOffset,               // 24 - 12 = 12
+			wantWidth:  80 - DefaultSidebarWidth - ContentWidthOffset, // 80 - 36 - 7 = 37
+			wantHeight: 24 - ContentHeightOffset,                      // 24 - 12 = 12
 		},
 		{
 			name:       "very narrow terminal",
@@ -53,6 +53,62 @@ func TestCalculateContentDimensions(t *testing.T) {
 	}
 }
 
+func TestCalculateContentDimensionsWithSidebarWidth(t *testing.T) {
+	tests := []struct {
+		name         string
+		termWidth    int
+		termHeight   int
+		sidebarWidth int
+		wantWidth    int
+		wantHeight   int
+	}{
+		{
+			name:         "custom sidebar width 40",
+			termWidth:    120,
+			termHeight:   40,
+			sidebarWidth: 40,
+			wantWidth:    120 - 40 - ContentWidthOffset, // 120 - 40 - 7 = 73
+			wantHeight:   40 - ContentHeightOffset,      // 40 - 12 = 28
+		},
+		{
+			name:         "narrow terminal ignores custom width",
+			termWidth:    79,
+			termHeight:   30,
+			sidebarWidth: 50,
+			wantWidth:    79 - SidebarMinWidth - ContentWidthOffset, // 79 - 20 - 7 = 52
+			wantHeight:   30 - ContentHeightOffset,                  // 30 - 12 = 18
+		},
+		{
+			name:         "custom width clamped to minimum",
+			termWidth:    120,
+			termHeight:   40,
+			sidebarWidth: 10,                                         // Below minimum
+			wantWidth:    120 - SidebarMinWidth - ContentWidthOffset, // 120 - 20 - 7 = 93
+			wantHeight:   40 - ContentHeightOffset,
+		},
+		{
+			name:         "custom width clamped to maximum",
+			termWidth:    120,
+			termHeight:   40,
+			sidebarWidth: 100,                                        // Above maximum
+			wantWidth:    120 - SidebarMaxWidth - ContentWidthOffset, // 120 - 60 - 7 = 53
+			wantHeight:   40 - ContentHeightOffset,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotWidth, gotHeight := CalculateContentDimensionsWithSidebarWidth(tt.termWidth, tt.termHeight, tt.sidebarWidth)
+			if gotWidth != tt.wantWidth {
+				t.Errorf("CalculateContentDimensionsWithSidebarWidth() width = %v, want %v", gotWidth, tt.wantWidth)
+			}
+			if gotHeight != tt.wantHeight {
+				t.Errorf("CalculateContentDimensionsWithSidebarWidth() height = %v, want %v", gotHeight, tt.wantHeight)
+			}
+		})
+	}
+}
+
 func TestCalculateEffectiveSidebarWidth(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -60,9 +116,9 @@ func TestCalculateEffectiveSidebarWidth(t *testing.T) {
 		want      int
 	}{
 		{
-			name:      "standard terminal returns full width",
+			name:      "standard terminal returns default width",
 			termWidth: 120,
-			want:      SidebarWidth,
+			want:      DefaultSidebarWidth,
 		},
 		{
 			name:      "narrow terminal returns minimum width",
@@ -70,9 +126,9 @@ func TestCalculateEffectiveSidebarWidth(t *testing.T) {
 			want:      SidebarMinWidth,
 		},
 		{
-			name:      "exactly 80 returns full width",
+			name:      "exactly 80 returns default width",
 			termWidth: 80,
-			want:      SidebarWidth,
+			want:      DefaultSidebarWidth,
 		},
 		{
 			name:      "very narrow terminal",
@@ -91,13 +147,113 @@ func TestCalculateEffectiveSidebarWidth(t *testing.T) {
 	}
 }
 
+func TestCalculateEffectiveSidebarWidthWithConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		termWidth    int
+		sidebarWidth int
+		want         int
+	}{
+		{
+			name:         "standard terminal with custom width",
+			termWidth:    120,
+			sidebarWidth: 45,
+			want:         45,
+		},
+		{
+			name:         "narrow terminal ignores custom width",
+			termWidth:    79,
+			sidebarWidth: 45,
+			want:         SidebarMinWidth,
+		},
+		{
+			name:         "custom width below minimum gets clamped",
+			termWidth:    120,
+			sidebarWidth: 15,
+			want:         SidebarMinWidth,
+		},
+		{
+			name:         "custom width above maximum gets clamped",
+			termWidth:    120,
+			sidebarWidth: 80,
+			want:         SidebarMaxWidth,
+		},
+		{
+			name:         "exactly 80 width uses custom",
+			termWidth:    80,
+			sidebarWidth: 30,
+			want:         30,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CalculateEffectiveSidebarWidthWithConfig(tt.termWidth, tt.sidebarWidth)
+			if got != tt.want {
+				t.Errorf("CalculateEffectiveSidebarWidthWithConfig(%d, %d) = %v, want %v", tt.termWidth, tt.sidebarWidth, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClampSidebarWidth(t *testing.T) {
+	tests := []struct {
+		name  string
+		width int
+		want  int
+	}{
+		{
+			name:  "within bounds",
+			width: 40,
+			want:  40,
+		},
+		{
+			name:  "at minimum",
+			width: SidebarMinWidth,
+			want:  SidebarMinWidth,
+		},
+		{
+			name:  "at maximum",
+			width: SidebarMaxWidth,
+			want:  SidebarMaxWidth,
+		},
+		{
+			name:  "below minimum",
+			width: 10,
+			want:  SidebarMinWidth,
+		},
+		{
+			name:  "above maximum",
+			width: 100,
+			want:  SidebarMaxWidth,
+		},
+		{
+			name:  "negative value",
+			width: -5,
+			want:  SidebarMinWidth,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClampSidebarWidth(tt.width)
+			if got != tt.want {
+				t.Errorf("ClampSidebarWidth(%d) = %v, want %v", tt.width, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLayoutConstants(t *testing.T) {
 	// Verify constants have expected values to catch accidental changes
-	if SidebarWidth != 30 {
-		t.Errorf("SidebarWidth = %d, want 30", SidebarWidth)
+	if DefaultSidebarWidth != 36 {
+		t.Errorf("DefaultSidebarWidth = %d, want 36", DefaultSidebarWidth)
 	}
 	if SidebarMinWidth != 20 {
 		t.Errorf("SidebarMinWidth = %d, want 20", SidebarMinWidth)
+	}
+	if SidebarMaxWidth != 60 {
+		t.Errorf("SidebarMaxWidth = %d, want 60", SidebarMaxWidth)
 	}
 	if ContentWidthOffset != 7 {
 		t.Errorf("ContentWidthOffset = %d, want 7", ContentWidthOffset)


### PR DESCRIPTION
## Summary

- Add user-configurable sidebar width via the interactive configuration UI (`:config` command)
- Increase default sidebar width from 30 to 36 columns for better readability
- Users can configure widths between 20-60 columns via `tui.sidebar_width`

## Changes

- **Config**: Add `SidebarWidth` field to `TUIConfig` with default value of 36
- **Validation**: Add config validation that rejects out-of-bounds values (min: 20, max: 60)
- **Layout**: Create new `*WithConfig` function variants that accept configured width parameter
- **UI**: Add sidebar width setting to interactive config under TUI category
- **Tests**: Comprehensive test coverage for clamping and validation logic

## Architecture Notes

The implementation follows the project's dependency injection principles:
- Layout functions accept the configured width as a parameter rather than reading from global config
- Original function signatures are maintained for backward compatibility
- Validation is centralized in the config validator following existing patterns

## Test Plan

- [x] All existing tests pass
- [x] New tests cover boundary conditions (min/max bounds)
- [x] New tests cover edge cases (zero value, negative values)
- [x] Manual testing of interactive config UI
- [x] `gofmt -d .` shows no formatting issues
- [x] `go vet ./...` passes
- [x] `go build ./...` succeeds