### PR TITLE
Fix tmux panel width to respect configured sidebar width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Tmux Panel Width Not Using Configured Sidebar** - Fixed an issue where the tmux panel width was not respecting the user-configured sidebar width (`tui.sidebar_width`). When resizing the terminal, the content area calculation now uses the configured sidebar width instead of the default, ensuring tmux panels are correctly sized to match the visible sidebar. Also removed dead code from `view/dashboard.go` that contained an outdated hardcoded sidebar width constant.
+
 ## [0.9.0] - 2026-01-16
 
 This release brings **Sidebar Customization & Group Dismiss** - allowing users to configure the sidebar width for their workflow preferences and quickly dismiss entire instance groups with a single shortcut.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -278,7 +278,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.ready = true
 
 		// Calculate the content area dimensions and resize tmux sessions
-		contentWidth, contentHeight := CalculateContentDimensions(m.terminalManager.Width(), m.terminalManager.Height())
+		// Use the configured sidebar width to ensure tmux panels match the UI layout
+		cfg := config.Get()
+		contentWidth, contentHeight := CalculateContentDimensionsWithSidebarWidth(
+			m.terminalManager.Width(), m.terminalManager.Height(), cfg.TUI.SidebarWidth)
 		if m.orchestrator != nil && contentWidth > 0 && contentHeight > 0 {
 			m.orchestrator.ResizeAllInstances(contentWidth, contentHeight)
 		}

--- a/internal/tui/view/dashboard.go
+++ b/internal/tui/view/dashboard.go
@@ -15,8 +15,6 @@ import (
 
 // Layout constants for dashboard rendering
 const (
-	SidebarWidth       = 30 // Fixed sidebar width
-	SidebarMinWidth    = 20 // Minimum sidebar width for narrow terminals
 	ExpandedNameMaxLen = 50 // Maximum length for expanded instance names
 )
 
@@ -316,20 +314,6 @@ func (dv *DashboardView) buildConflictMap(conflicts []conflict.FileConflict) map
 		}
 	}
 	return conflictingInstances
-}
-
-// CalculateEffectiveSidebarWidth returns the appropriate sidebar width
-// based on terminal width.
-func CalculateEffectiveSidebarWidth(termWidth int) int {
-	if termWidth < 80 {
-		return SidebarMinWidth
-	}
-	return SidebarWidth
-}
-
-// CalculateMainAreaHeight returns the height available for the main content area.
-func CalculateMainAreaHeight(termHeight int) int {
-	return termHeight - 6 // Header + help bar + margins
 }
 
 // truncate truncates a string to max length, adding ellipsis if needed.


### PR DESCRIPTION
## Summary

- Fixed tmux panel resizing to use the user-configured sidebar width (`tui.sidebar_width`) instead of the default value
- Removed dead code from `view/dashboard.go` that contained outdated hardcoded sidebar width constants

## Problem

When PR #506 added configurable sidebar width, the UI rendering path was updated to use the configured value, but the window resize handler still used `CalculateContentDimensions()` which hardcodes the default width. This meant that when a user configured a custom sidebar width, the tmux content panels would be sized incorrectly.

## Solution

Updated `app.go` to use `CalculateContentDimensionsWithSidebarWidth()` with `cfg.TUI.SidebarWidth` in the window resize handler, ensuring both the visual layout and tmux panel sizing use the same configured width.

Also cleaned up dead code in `view/dashboard.go`:
- `SidebarWidth = 30` (stale value, different from the actual default of 36)
- `SidebarMinWidth = 20` (only used by the dead function below)
- `CalculateEffectiveSidebarWidth()` (never called externally)
- `CalculateMainAreaHeight()` (never called externally)

## Test plan

- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [x] Linting passes (`go vet ./...`)
- [x] Formatting correct (`gofmt -d .` shows no output)
- [x] Verified no external references to removed code