### PR TITLE
Fix frozen output when tmux status query times out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Frozen Output During Tmux Timeout** - Fixed a critical bug where tmux output would freeze completely when the tmux status query timed out. Previously, when `getSessionStatus()` took longer than 2 seconds (due to heavy system load or many tmux sessions), the capture loop would skip output capture entirely, causing the TUI to display stale content indefinitely. Now output capture continues even when the status query fails, using a full pane capture as fallback.
+
+- **Ring Buffer Race Condition** - Fixed a race condition between `Reset()` and `Write()` operations in the ring buffer that could cause brief display flickering. Added new atomic `ReplaceWith()` method that performs both operations under a single lock acquisition, preventing concurrent `GetOutput()` calls from seeing an empty buffer.
+
 ## [0.9.1] - 2026-01-16
 
 This patch release focuses on **Bug Fixes & UI Polish** - improving completion file detection reliability, fixing sidebar width configuration consistency, and enhancing task status readability in the sidebar.

--- a/internal/instance/prworkflow.go
+++ b/internal/instance/prworkflow.go
@@ -335,9 +335,14 @@ func (p *PRWorkflow) monitorLoop() {
 				"-E", "-",
 			)
 			output, err := captureCmd.Output()
-			if err == nil {
-				p.outputBuf.Reset()
-				_, _ = p.outputBuf.Write(output)
+			if err != nil {
+				p.logDebug("capture failed in PR workflow",
+					"session_name", sessionName,
+					"error", err.Error())
+			} else {
+				// Use ReplaceWith for atomic reset+write to prevent race condition where
+				// concurrent GetOutput() calls could see an empty buffer between Reset and Write.
+				p.outputBuf.ReplaceWith(output)
 			}
 
 			// Check if the session is still running


### PR DESCRIPTION
## Summary

Fixes a critical bug where tmux output would freeze completely when the tmux status query (`getSessionStatus()`) timed out. This was causing instances to appear frozen/halted even though they were still running.

### Root Cause

In `captureLoop()` at `manager.go:630-633`, when `getSessionStatus()` timed out (returning `historySize == -1`), the code was doing `continue` which **skipped output capture entirely**:

```go
// Original problematic code
if status.historySize == -1 {
    continue  // SKIPS OUTPUT CAPTURE!
}
```

When tmux is under load (many sessions, heavy system activity), the status query can consistently time out, causing the TUI to display stale content indefinitely.

### Changes

1. **Status Query Fix** (`manager.go`):
   - Remove the early `continue` when status query fails
   - Force a full pane capture as fallback when differential capture optimization is unavailable
   - Preserve `lastHistorySize` when query fails to avoid invalid comparisons

2. **Ring Buffer Race Condition** (`buffer.go`):
   - Add atomic `ReplaceWith()` method that performs `Reset()` + `Write()` under a single lock
   - Prevents concurrent `GetOutput()` calls from seeing an empty buffer between operations

3. **PR Workflow Logging** (`prworkflow.go`):
   - Add debug logging for capture failures (was silently ignored)

## Test plan

- [x] All existing tests pass (`go test ./internal/instance/...`)
- [x] New `ReplaceWith` tests added including atomicity test
- [x] Build succeeds (`go build ./...`)
- [x] Formatting verified (`gofmt -d .`)