### PR TITLE
Add experimental Ralph Wiggum mode for iterative task completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Ralph Wiggum Mode (Experimental)** - Implements continuous self-referential feedback loops for iterative task completion. Claude works on a task and when it completes an iteration, the same prompt is fed back, allowing iterative improvement until a completion promise (e.g., `<promise>DONE</promise>`) is signaled. Useful for tasks with clear verification criteria like making tests pass. Enable with `experimental.ralph_wiggum: true` and use via `claudio ralph [task]`.
+
 - **Task Chaining by Sidebar Number** - The `:chain`, `:dep`, and `:depends` commands now accept an optional sidebar number argument to specify which instance to chain from (e.g., `:chain 2` or `:chain #2`). This is more user-friendly than using instance IDs, which aren't prominently displayed.
 
 ### Changed

--- a/internal/cmd/planning/ralphwiggum.go
+++ b/internal/cmd/planning/ralphwiggum.go
@@ -1,0 +1,187 @@
+package planning
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Iron-Ham/claudio/internal/config"
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	orchsession "github.com/Iron-Ham/claudio/internal/orchestrator/session"
+	sessutil "github.com/Iron-Ham/claudio/internal/session"
+	"github.com/Iron-Ham/claudio/internal/tui"
+	"github.com/Iron-Ham/claudio/internal/util"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+var ralphCmd = &cobra.Command{
+	Use:   "ralph [task]",
+	Short: "Start a Ralph Wiggum iterative loop session",
+	Long: `Ralph Wiggum mode implements continuous self-referential feedback loops where
+Claude works on a task iteratively until a completion promise is signaled.
+
+EXPERIMENTAL: This feature is experimental and may change or be removed.
+
+How it works:
+1. Claude receives the task and begins working
+2. When Claude completes an iteration, the same prompt is fed back
+3. Claude sees its previous work (files, git history) and continues
+4. The loop continues until Claude outputs: <promise>COMPLETION_PROMISE</promise>
+5. Or until the maximum number of iterations is reached
+
+This is useful for:
+- Tasks with clear verification criteria (tests must pass)
+- Iterative refinement of complex implementations
+- Tasks where multiple attempts may be needed
+
+Examples:
+  # Start Ralph Wiggum with a task (default promise is "DONE")
+  claudio ralph "Fix all failing tests"
+
+  # Use a custom completion promise
+  claudio ralph --promise "ALL_TESTS_PASSING" "Implement the auth module"
+
+  # Set a maximum number of iterations
+  claudio ralph --max-iterations 10 "Optimize the database queries"
+
+  # Require manual confirmation between iterations
+  claudio ralph --no-auto-continue "Refactor the API endpoints"`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runRalphWiggum,
+}
+
+var (
+	ralphCompletionPromise string
+	ralphMaxIterations     int
+	ralphAutoContinue      bool
+)
+
+func init() {
+	ralphCmd.Flags().StringVar(&ralphCompletionPromise, "promise", "DONE", "Completion promise text that signals task completion")
+	ralphCmd.Flags().IntVar(&ralphMaxIterations, "max-iterations", 50, "Maximum number of iterations (0 for unlimited)")
+	ralphCmd.Flags().BoolVar(&ralphAutoContinue, "auto-continue", true, "Automatically continue to next iteration")
+}
+
+// RegisterRalphWiggumCmd registers the ralph command with the given parent command.
+func RegisterRalphWiggumCmd(parent *cobra.Command) {
+	parent.AddCommand(ralphCmd)
+}
+
+func runRalphWiggum(cmd *cobra.Command, args []string) error {
+	// Check if experimental feature is enabled
+	cfg := config.Get()
+	if !cfg.Experimental.RalphWiggum {
+		return fmt.Errorf("ralph wiggum mode is an experimental feature.\nEnable it by setting 'experimental.ralph_wiggum: true' in your config file")
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	// Get task from args or prompt
+	var task string
+	if len(args) > 0 {
+		task = args[0]
+	} else {
+		task, err = promptRalphWiggumTask()
+		if err != nil {
+			return err
+		}
+	}
+
+	// Generate a new session ID for this Ralph Wiggum session
+	sessionID := orchsession.GenerateID()
+
+	// Create Ralph Wiggum configuration
+	ralphConfig := orchestrator.RalphWiggumConfig{
+		CompletionPromise: ralphCompletionPromise,
+		MaxIterations:     ralphMaxIterations,
+		AutoContinue:      ralphAutoContinue,
+	}
+
+	// Create logger if enabled
+	sessionDir := sessutil.GetSessionDir(cwd, sessionID)
+	logger := createLogger(sessionDir, cfg)
+	defer func() { _ = logger.Close() }()
+
+	// Create orchestrator with multi-session support
+	orch, err := orchestrator.NewWithSession(cwd, sessionID, cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create orchestrator: %w", err)
+	}
+
+	// Set the logger on the orchestrator
+	orch.SetLogger(logger)
+
+	// Start a new session for the Ralph Wiggum loop
+	words := strings.Fields(task)
+	if len(words) > 3 {
+		words = words[:3]
+	}
+	sessionName := "ralph-" + SlugifyWords(words)
+
+	session, err := orch.StartSession(sessionName)
+	if err != nil {
+		return fmt.Errorf("failed to start session: %w", err)
+	}
+
+	// Log startup
+	logger.Info("ralph wiggum started",
+		"session_id", sessionID,
+		"task", util.TruncateString(task, 100),
+		"completion_promise", ralphConfig.CompletionPromise,
+		"max_iterations", ralphConfig.MaxIterations,
+		"auto_continue", ralphConfig.AutoContinue,
+	)
+
+	// Create Ralph Wiggum session
+	ralphSession := orchestrator.NewRalphWiggumSession(task, ralphConfig)
+
+	// Link Ralph Wiggum session to main session for persistence
+	session.RalphWiggums = append(session.RalphWiggums, ralphSession)
+
+	// Create coordinator with logger
+	coordinator := orchestrator.NewRalphWiggumCoordinator(orch, session, ralphSession, logger)
+
+	// Get terminal dimensions
+	if termWidth, termHeight, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+		contentWidth, contentHeight := tui.CalculateContentDimensions(termWidth, termHeight)
+		if contentWidth > 0 && contentHeight > 0 {
+			orch.SetDisplayDimensions(contentWidth, contentHeight)
+		}
+	}
+
+	// Launch TUI with Ralph Wiggum mode
+	app := tui.NewWithRalphWiggum(orch, session, coordinator, logger.WithSession(session.ID))
+	if err := app.Run(); err != nil {
+		return fmt.Errorf("TUI error: %w", err)
+	}
+
+	return nil
+}
+
+// promptRalphWiggumTask prompts the user to enter a task
+func promptRalphWiggumTask() (string, error) {
+	fmt.Println("\nRalph Wiggum Mode")
+	fmt.Println("=================")
+	fmt.Println("Enter a task for Claude to work on iteratively.")
+	fmt.Println("Claude will keep working until the completion promise is output.")
+	fmt.Println()
+	fmt.Print("Task: ")
+
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("failed to read input: %w", err)
+	}
+
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "", fmt.Errorf("task cannot be empty")
+	}
+
+	return input, nil
+}

--- a/internal/cmd/planning/register.go
+++ b/internal/cmd/planning/register.go
@@ -9,4 +9,5 @@ func Register(parent *cobra.Command) {
 	RegisterPlanCmd(parent)
 	RegisterUltraplanCmd(parent)
 	RegisterTripleshotCmd(parent)
+	RegisterRalphWiggumCmd(parent)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -282,6 +282,12 @@ type ExperimentalConfig struct {
 	// in the TUI sidebar. Related tasks are organized together, with sub-groups
 	// for dependency chains. (default: false)
 	GroupedInstanceView bool `mapstructure:"grouped_instance_view"`
+
+	// RalphWiggum enables the Ralph Wiggum mode which implements continuous
+	// self-referential feedback loops. Claude works on a task and when it tries
+	// to exit, the same prompt is fed back, allowing iterative improvement until
+	// a completion promise is signaled. (default: false)
+	RalphWiggum bool `mapstructure:"ralph_wiggum"`
 }
 
 // ResolveWorktreeDir returns the resolved worktree directory path.
@@ -407,6 +413,7 @@ func Default() *Config {
 			InlinePlan:          false, // Controls :multiplan only; :plan is always available
 			InlineUltraPlan:     false, // Disabled by default until stable
 			GroupedInstanceView: false, // Disabled by default until stable
+			RalphWiggum:         false, // Disabled by default until stable
 		},
 	}
 }
@@ -513,6 +520,7 @@ func SetDefaults() {
 	viper.SetDefault("experimental.inline_plan", defaults.Experimental.InlinePlan)
 	viper.SetDefault("experimental.inline_ultraplan", defaults.Experimental.InlineUltraPlan)
 	viper.SetDefault("experimental.grouped_instance_view", defaults.Experimental.GroupedInstanceView)
+	viper.SetDefault("experimental.ralph_wiggum", defaults.Experimental.RalphWiggum)
 }
 
 // Load reads the configuration from viper into a Config struct and validates it

--- a/internal/orchestrator/ralphwiggum.go
+++ b/internal/orchestrator/ralphwiggum.go
@@ -1,0 +1,330 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/logging"
+)
+
+// RalphWiggumPhase represents the current phase of a Ralph Wiggum session
+type RalphWiggumPhase string
+
+const (
+	// PhaseRalphWiggumIterating - instance is working through iterations
+	PhaseRalphWiggumIterating RalphWiggumPhase = "iterating"
+	// PhaseRalphWiggumComplete - completion promise was found
+	PhaseRalphWiggumComplete RalphWiggumPhase = "complete"
+	// PhaseRalphWiggumMaxIterations - maximum iterations reached without completion
+	PhaseRalphWiggumMaxIterations RalphWiggumPhase = "max_iterations"
+	// PhaseRalphWiggumFailed - something went wrong
+	PhaseRalphWiggumFailed RalphWiggumPhase = "failed"
+	// PhaseRalphWiggumPaused - iteration paused by user
+	PhaseRalphWiggumPaused RalphWiggumPhase = "paused"
+)
+
+// RalphWiggumConfig holds configuration for a Ralph Wiggum session
+type RalphWiggumConfig struct {
+	// CompletionPromise is the text that signals task completion (e.g., "DONE", "COMPLETE")
+	// The instance should output <promise>COMPLETION_TEXT</promise> when done
+	CompletionPromise string `json:"completion_promise"`
+
+	// MaxIterations is the maximum number of iterations before stopping (0 = unlimited)
+	MaxIterations int `json:"max_iterations"`
+
+	// AutoContinue determines whether to automatically continue after each iteration
+	// When false, the user will be prompted between iterations
+	AutoContinue bool `json:"auto_continue"`
+}
+
+// DefaultRalphWiggumConfig returns the default configuration
+func DefaultRalphWiggumConfig() RalphWiggumConfig {
+	return RalphWiggumConfig{
+		CompletionPromise: "DONE",
+		MaxIterations:     50,
+		AutoContinue:      true,
+	}
+}
+
+// RalphWiggumIteration represents a single iteration of the loop
+type RalphWiggumIteration struct {
+	Index       int        `json:"index"`
+	StartedAt   time.Time  `json:"started_at"`
+	CompletedAt *time.Time `json:"completed_at,omitempty"`
+	HasCommits  bool       `json:"has_commits"` // Whether this iteration produced commits
+}
+
+// RalphWiggumSession represents a Ralph Wiggum iterative loop session
+type RalphWiggumSession struct {
+	ID          string                 `json:"id"`
+	GroupID     string                 `json:"group_id,omitempty"`
+	Task        string                 `json:"task"`  // The original task/problem
+	Phase       RalphWiggumPhase       `json:"phase"` // Current phase
+	Config      RalphWiggumConfig      `json:"config"`
+	InstanceID  string                 `json:"instance_id,omitempty"` // The single instance doing the work
+	Created     time.Time              `json:"created"`
+	StartedAt   *time.Time             `json:"started_at,omitempty"`
+	CompletedAt *time.Time             `json:"completed_at,omitempty"`
+	Iterations  []RalphWiggumIteration `json:"iterations"` // Track each iteration
+	Error       string                 `json:"error,omitempty"`
+}
+
+// NewRalphWiggumSession creates a new Ralph Wiggum session
+func NewRalphWiggumSession(task string, config RalphWiggumConfig) *RalphWiggumSession {
+	return &RalphWiggumSession{
+		ID:         generateID(),
+		Task:       task,
+		Phase:      PhaseRalphWiggumIterating,
+		Config:     config,
+		Created:    time.Now(),
+		Iterations: make([]RalphWiggumIteration, 0),
+	}
+}
+
+// CurrentIteration returns the current iteration number (1-indexed for display)
+func (s *RalphWiggumSession) CurrentIteration() int {
+	return len(s.Iterations)
+}
+
+// IsComplete returns true if the session has completed (success or max iterations)
+func (s *RalphWiggumSession) IsComplete() bool {
+	return s.Phase == PhaseRalphWiggumComplete ||
+		s.Phase == PhaseRalphWiggumMaxIterations ||
+		s.Phase == PhaseRalphWiggumFailed
+}
+
+// ShouldContinue returns true if another iteration should be started
+func (s *RalphWiggumSession) ShouldContinue() bool {
+	if s.Phase != PhaseRalphWiggumIterating {
+		return false
+	}
+	if s.Config.MaxIterations > 0 && len(s.Iterations) >= s.Config.MaxIterations {
+		return false
+	}
+	return true
+}
+
+// RalphWiggumStatusFileName is the file that tracks iteration status
+const RalphWiggumStatusFileName = ".claudio-ralph-status.json"
+
+// RalphWiggumStatusFile represents the status file written/read during iterations
+type RalphWiggumStatusFile struct {
+	Iteration     int       `json:"iteration"`
+	Phase         string    `json:"phase"`
+	PromiseFound  bool      `json:"promise_found"`
+	LastActivity  time.Time `json:"last_activity"`
+	CommitCount   int       `json:"commit_count"`
+	FilesModified []string  `json:"files_modified,omitempty"`
+}
+
+// RalphWiggumStatusFilePath returns the full path to the status file
+func RalphWiggumStatusFilePath(worktreePath string) string {
+	return filepath.Join(worktreePath, RalphWiggumStatusFileName)
+}
+
+// ParseRalphWiggumStatusFile reads and parses the status file
+func ParseRalphWiggumStatusFile(worktreePath string) (*RalphWiggumStatusFile, error) {
+	statusPath := RalphWiggumStatusFilePath(worktreePath)
+	data, err := os.ReadFile(statusPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var status RalphWiggumStatusFile
+	if err := json.Unmarshal(data, &status); err != nil {
+		return nil, fmt.Errorf("failed to parse Ralph Wiggum status JSON: %w", err)
+	}
+
+	return &status, nil
+}
+
+// CheckOutputForCompletionPromise checks if the output contains the completion promise
+func CheckOutputForCompletionPromise(output, promise string) bool {
+	if promise == "" {
+		return false
+	}
+	// Look for <promise>PROMISE_TEXT</promise> pattern
+	pattern := fmt.Sprintf(`<promise>\s*%s\s*</promise>`, regexp.QuoteMeta(promise))
+	re := regexp.MustCompile("(?i)" + pattern)
+	return re.MatchString(output)
+}
+
+// ExtractPromiseFromOutput extracts any promise text from the output
+func ExtractPromiseFromOutput(output string) string {
+	re := regexp.MustCompile(`(?i)<promise>\s*(.*?)\s*</promise>`)
+	matches := re.FindStringSubmatch(output)
+	if len(matches) >= 2 {
+		return strings.TrimSpace(matches[1])
+	}
+	return ""
+}
+
+// RalphWiggumManager manages the execution of a Ralph Wiggum session
+type RalphWiggumManager struct {
+	session     *RalphWiggumSession
+	orch        *Orchestrator
+	baseSession *Session
+	logger      *logging.Logger
+
+	// Event handling
+	eventCallback func(RalphWiggumEvent)
+
+	// Synchronization
+	mu sync.RWMutex
+}
+
+// RalphWiggumEventType represents the type of Ralph Wiggum event
+type RalphWiggumEventType string
+
+const (
+	EventRalphWiggumIterationStart    RalphWiggumEventType = "iteration_start"
+	EventRalphWiggumIterationComplete RalphWiggumEventType = "iteration_complete"
+	EventRalphWiggumPromiseFound      RalphWiggumEventType = "promise_found"
+	EventRalphWiggumMaxIterations     RalphWiggumEventType = "max_iterations"
+	EventRalphWiggumPhaseChange       RalphWiggumEventType = "phase_change"
+	EventRalphWiggumError             RalphWiggumEventType = "error"
+)
+
+// RalphWiggumEvent represents an event from the Ralph Wiggum manager
+type RalphWiggumEvent struct {
+	Type       RalphWiggumEventType `json:"type"`
+	Iteration  int                  `json:"iteration,omitempty"`
+	InstanceID string               `json:"instance_id,omitempty"`
+	Message    string               `json:"message,omitempty"`
+	Timestamp  time.Time            `json:"timestamp"`
+}
+
+// NewRalphWiggumManager creates a new Ralph Wiggum manager
+func NewRalphWiggumManager(orch *Orchestrator, baseSession *Session, ralphSession *RalphWiggumSession, logger *logging.Logger) *RalphWiggumManager {
+	if logger == nil {
+		logger = logging.NopLogger()
+	}
+	return &RalphWiggumManager{
+		session:     ralphSession,
+		orch:        orch,
+		baseSession: baseSession,
+		logger:      logger.WithPhase("ralphwiggum"),
+	}
+}
+
+// SetEventCallback sets the callback for Ralph Wiggum events
+func (m *RalphWiggumManager) SetEventCallback(cb func(RalphWiggumEvent)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.eventCallback = cb
+}
+
+// Session returns the Ralph Wiggum session
+func (m *RalphWiggumManager) Session() *RalphWiggumSession {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.session
+}
+
+// emitEvent sends an event to the callback
+func (m *RalphWiggumManager) emitEvent(event RalphWiggumEvent) {
+	event.Timestamp = time.Now()
+
+	m.mu.RLock()
+	cb := m.eventCallback
+	m.mu.RUnlock()
+
+	if cb != nil {
+		cb(event)
+	}
+}
+
+// SetPhase updates the session phase and emits an event
+func (m *RalphWiggumManager) SetPhase(phase RalphWiggumPhase) {
+	m.mu.Lock()
+	m.session.Phase = phase
+	m.mu.Unlock()
+
+	m.emitEvent(RalphWiggumEvent{
+		Type:    EventRalphWiggumPhaseChange,
+		Message: string(phase),
+	})
+}
+
+// StartIteration marks the start of a new iteration
+func (m *RalphWiggumManager) StartIteration() {
+	m.mu.Lock()
+	iteration := RalphWiggumIteration{
+		Index:     len(m.session.Iterations),
+		StartedAt: time.Now(),
+	}
+	m.session.Iterations = append(m.session.Iterations, iteration)
+	iterationNum := len(m.session.Iterations)
+	m.mu.Unlock()
+
+	m.logger.Info("iteration started", "iteration", iterationNum)
+
+	m.emitEvent(RalphWiggumEvent{
+		Type:      EventRalphWiggumIterationStart,
+		Iteration: iterationNum,
+	})
+}
+
+// CompleteIteration marks the current iteration as complete
+func (m *RalphWiggumManager) CompleteIteration(hasCommits bool) {
+	m.mu.Lock()
+	if len(m.session.Iterations) > 0 {
+		idx := len(m.session.Iterations) - 1
+		now := time.Now()
+		m.session.Iterations[idx].CompletedAt = &now
+		m.session.Iterations[idx].HasCommits = hasCommits
+	}
+	iterationNum := len(m.session.Iterations)
+	m.mu.Unlock()
+
+	m.logger.Info("iteration completed",
+		"iteration", iterationNum,
+		"has_commits", hasCommits,
+	)
+
+	m.emitEvent(RalphWiggumEvent{
+		Type:      EventRalphWiggumIterationComplete,
+		Iteration: iterationNum,
+	})
+}
+
+// RalphWiggumPromptTemplate is the prompt template for Ralph Wiggum iterations
+const RalphWiggumPromptTemplate = `## Task
+%s
+
+## Completion Promise
+
+When you have FULLY completed the task, output the following to signal completion:
+
+<promise>%s</promise>
+
+**Rules:**
+- Only output the promise when the task is COMPLETELY done
+- If tests exist, they must pass before outputting the promise
+- If you encounter errors, fix them before outputting the promise
+- Each iteration, you can see your previous work in the files and git history
+
+## Current Status
+
+This is iteration %d of your work on this task.
+%s
+
+Continue working on the task. Review your previous changes, check for issues, and make progress.
+When the task is fully complete with all requirements met, output the completion promise.`
+
+// RalphWiggumFirstIterationExtra is appended to the first iteration
+const RalphWiggumFirstIterationExtra = `
+This is the FIRST iteration. Start by understanding the task and beginning implementation.`
+
+// RalphWiggumContinueIterationExtra is appended to subsequent iterations
+const RalphWiggumContinueIterationExtra = `
+Review your previous work:
+- Check git log for recent commits
+- Review any test failures or errors
+- Continue making progress toward completion`

--- a/internal/orchestrator/ralphwiggum_coordinator.go
+++ b/internal/orchestrator/ralphwiggum_coordinator.go
@@ -1,0 +1,439 @@
+package orchestrator
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/logging"
+	"github.com/Iron-Ham/claudio/internal/util"
+)
+
+// RalphWiggumCoordinatorCallbacks holds callbacks for coordinator events
+type RalphWiggumCoordinatorCallbacks struct {
+	// OnPhaseChange is called when the phase changes
+	OnPhaseChange func(phase RalphWiggumPhase)
+
+	// OnIterationStart is called when a new iteration begins
+	OnIterationStart func(iteration int)
+
+	// OnIterationComplete is called when an iteration completes
+	OnIterationComplete func(iteration int, hasCommits bool)
+
+	// OnPromiseFound is called when the completion promise is detected
+	OnPromiseFound func(promise string)
+
+	// OnMaxIterations is called when max iterations is reached
+	OnMaxIterations func(iteration int)
+
+	// OnComplete is called when the session completes
+	OnComplete func(success bool, summary string)
+}
+
+// RalphWiggumCoordinator orchestrates the execution of a Ralph Wiggum session
+type RalphWiggumCoordinator struct {
+	manager     *RalphWiggumManager
+	orch        *Orchestrator
+	baseSession *Session
+	callbacks   *RalphWiggumCoordinatorCallbacks
+	logger      *logging.Logger
+
+	// Running state
+	mu      sync.RWMutex
+	stopped bool
+
+	// Instance tracking
+	instanceID string
+
+	// Iteration control
+	pendingContinue bool   // Set when iteration completes and waiting to continue
+	lastOutputCheck string // Last output checked for promise
+}
+
+// NewRalphWiggumCoordinator creates a new coordinator for a Ralph Wiggum session
+func NewRalphWiggumCoordinator(orch *Orchestrator, baseSession *Session, ralphSession *RalphWiggumSession, logger *logging.Logger) *RalphWiggumCoordinator {
+	if logger == nil {
+		logger = logging.NopLogger()
+	}
+	manager := NewRalphWiggumManager(orch, baseSession, ralphSession, logger)
+
+	sessionLogger := logger.WithSession(ralphSession.ID).WithPhase("ralphwiggum-coordinator")
+
+	return &RalphWiggumCoordinator{
+		manager:     manager,
+		orch:        orch,
+		baseSession: baseSession,
+		logger:      sessionLogger,
+	}
+}
+
+// SetCallbacks sets the coordinator callbacks
+func (c *RalphWiggumCoordinator) SetCallbacks(cb *RalphWiggumCoordinatorCallbacks) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.callbacks = cb
+}
+
+// Manager returns the underlying Ralph Wiggum manager
+func (c *RalphWiggumCoordinator) Manager() *RalphWiggumManager {
+	return c.manager
+}
+
+// Session returns the Ralph Wiggum session
+func (c *RalphWiggumCoordinator) Session() *RalphWiggumSession {
+	return c.manager.Session()
+}
+
+// notifyPhaseChange notifies callbacks of phase change
+func (c *RalphWiggumCoordinator) notifyPhaseChange(phase RalphWiggumPhase) {
+	session := c.Session()
+	fromPhase := session.Phase
+
+	c.manager.SetPhase(phase)
+
+	c.logger.Info("phase changed",
+		"from_phase", string(fromPhase),
+		"to_phase", string(phase),
+		"session_id", session.ID,
+	)
+
+	// Persist the phase change
+	if err := c.orch.SaveSession(); err != nil {
+		c.logger.Error("failed to persist phase change", "error", err)
+	}
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnPhaseChange != nil {
+		cb.OnPhaseChange(phase)
+	}
+}
+
+// notifyIterationStart notifies callbacks of iteration start
+func (c *RalphWiggumCoordinator) notifyIterationStart(iteration int) {
+	c.manager.StartIteration()
+
+	c.logger.Info("iteration started", "iteration", iteration)
+
+	// Persist iteration start
+	if err := c.orch.SaveSession(); err != nil {
+		c.logger.Error("failed to persist iteration start", "error", err)
+	}
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnIterationStart != nil {
+		cb.OnIterationStart(iteration)
+	}
+}
+
+// notifyIterationComplete notifies callbacks of iteration completion
+func (c *RalphWiggumCoordinator) notifyIterationComplete(iteration int, hasCommits bool) {
+	c.manager.CompleteIteration(hasCommits)
+
+	// Persist iteration completion
+	if err := c.orch.SaveSession(); err != nil {
+		c.logger.Error("failed to persist iteration completion", "error", err)
+	}
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnIterationComplete != nil {
+		cb.OnIterationComplete(iteration, hasCommits)
+	}
+}
+
+// notifyPromiseFound notifies callbacks when completion promise is found
+func (c *RalphWiggumCoordinator) notifyPromiseFound(promise string) {
+	c.logger.Info("completion promise found", "promise", promise)
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnPromiseFound != nil {
+		cb.OnPromiseFound(promise)
+	}
+}
+
+// notifyMaxIterations notifies callbacks when max iterations reached
+func (c *RalphWiggumCoordinator) notifyMaxIterations(iteration int) {
+	c.logger.Info("max iterations reached", "iteration", iteration)
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnMaxIterations != nil {
+		cb.OnMaxIterations(iteration)
+	}
+}
+
+// notifyComplete notifies callbacks of completion
+func (c *RalphWiggumCoordinator) notifyComplete(success bool, summary string) {
+	c.logger.Info("ralph wiggum complete",
+		"success", success,
+		"summary", summary,
+	)
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnComplete != nil {
+		cb.OnComplete(success, summary)
+	}
+}
+
+// StartFirstIteration starts the first iteration of the Ralph Wiggum loop
+func (c *RalphWiggumCoordinator) StartFirstIteration() error {
+	session := c.Session()
+	task := session.Task
+	config := session.Config
+
+	c.logger.Info("starting ralph wiggum loop",
+		"task", util.TruncateString(task, 100),
+		"completion_promise", config.CompletionPromise,
+		"max_iterations", config.MaxIterations,
+	)
+
+	now := time.Now()
+	session.StartedAt = &now
+
+	// Find the Ralph Wiggum group to add the instance to
+	var ralphGroup *InstanceGroup
+	if session.GroupID != "" {
+		ralphGroup = c.baseSession.GetGroup(session.GroupID)
+	}
+
+	// Build the first iteration prompt
+	prompt := c.buildIterationPrompt(1)
+
+	// Create instance for the loop
+	inst, err := c.orch.AddInstance(c.baseSession, prompt)
+	if err != nil {
+		return fmt.Errorf("failed to create ralph wiggum instance: %w", err)
+	}
+
+	// Add instance to the group for sidebar display
+	if ralphGroup != nil {
+		ralphGroup.AddInstance(inst.ID)
+	}
+
+	session.InstanceID = inst.ID
+
+	c.mu.Lock()
+	c.instanceID = inst.ID
+	c.mu.Unlock()
+
+	// Start the instance
+	if err := c.orch.StartInstance(inst); err != nil {
+		return fmt.Errorf("failed to start ralph wiggum instance: %w", err)
+	}
+
+	c.notifyIterationStart(1)
+
+	// Persist session state
+	if err := c.orch.SaveSession(); err != nil {
+		c.logger.Error("failed to persist session after starting", "error", err)
+	}
+
+	return nil
+}
+
+// buildIterationPrompt builds the prompt for a specific iteration
+func (c *RalphWiggumCoordinator) buildIterationPrompt(iteration int) string {
+	session := c.Session()
+
+	var extra string
+	if iteration == 1 {
+		extra = RalphWiggumFirstIterationExtra
+	} else {
+		extra = RalphWiggumContinueIterationExtra
+	}
+
+	return fmt.Sprintf(RalphWiggumPromptTemplate,
+		session.Task,
+		session.Config.CompletionPromise,
+		iteration,
+		extra,
+	)
+}
+
+// CheckInstanceCompletion checks if the instance has completed and whether the promise was found
+// Returns (instanceComplete, promiseFound, error)
+func (c *RalphWiggumCoordinator) CheckInstanceCompletion() (bool, bool, error) {
+	session := c.Session()
+	if session.InstanceID == "" {
+		return false, false, nil
+	}
+
+	// Get the instance
+	inst := c.baseSession.GetInstance(session.InstanceID)
+	if inst == nil {
+		return false, false, fmt.Errorf("instance %s not found", session.InstanceID)
+	}
+
+	// Check if instance has completed
+	if inst.Status != StatusCompleted && inst.Status != StatusError {
+		return false, false, nil
+	}
+
+	// Get instance output and check for completion promise
+	mgr := c.orch.GetInstanceManager(inst.ID)
+	if mgr == nil {
+		return true, false, nil // Instance complete but can't check output
+	}
+
+	output := string(mgr.GetOutput())
+
+	// Only check new output since last check
+	c.mu.Lock()
+	lastCheck := c.lastOutputCheck
+	c.lastOutputCheck = output
+	c.mu.Unlock()
+
+	if output == lastCheck {
+		// No new output, instance is complete
+		return true, false, nil
+	}
+
+	// Check for completion promise in output
+	promiseFound := CheckOutputForCompletionPromise(output, session.Config.CompletionPromise)
+
+	return true, promiseFound, nil
+}
+
+// ProcessIterationComplete handles when an iteration completes
+func (c *RalphWiggumCoordinator) ProcessIterationComplete(promiseFound bool) error {
+	session := c.Session()
+	currentIteration := session.CurrentIteration()
+
+	// Check if instance made commits (simplified - could be enhanced)
+	hasCommits := false // Would need to check git log
+
+	c.notifyIterationComplete(currentIteration, hasCommits)
+
+	if promiseFound {
+		// Task complete!
+		c.notifyPromiseFound(session.Config.CompletionPromise)
+		c.notifyPhaseChange(PhaseRalphWiggumComplete)
+
+		now := time.Now()
+		session.CompletedAt = &now
+
+		summary := fmt.Sprintf("Completed after %d iterations", currentIteration)
+		c.notifyComplete(true, summary)
+
+		return nil
+	}
+
+	// Check if we've hit max iterations
+	if session.Config.MaxIterations > 0 && currentIteration >= session.Config.MaxIterations {
+		c.notifyMaxIterations(currentIteration)
+		c.notifyPhaseChange(PhaseRalphWiggumMaxIterations)
+
+		now := time.Now()
+		session.CompletedAt = &now
+
+		summary := fmt.Sprintf("Reached maximum iterations (%d) without completion", currentIteration)
+		c.notifyComplete(false, summary)
+
+		return nil
+	}
+
+	// Mark that we're ready for another iteration
+	c.mu.Lock()
+	c.pendingContinue = true
+	c.mu.Unlock()
+
+	return nil
+}
+
+// ContinueIteration starts the next iteration of the loop
+func (c *RalphWiggumCoordinator) ContinueIteration() error {
+	session := c.Session()
+	if session.IsComplete() {
+		return fmt.Errorf("session is already complete")
+	}
+
+	nextIteration := session.CurrentIteration() + 1
+
+	c.logger.Info("continuing to next iteration", "iteration", nextIteration)
+
+	// Build the prompt for this iteration
+	prompt := c.buildIterationPrompt(nextIteration)
+
+	// Get the existing instance and send the prompt
+	inst := c.baseSession.GetInstance(session.InstanceID)
+	if inst == nil {
+		return fmt.Errorf("instance %s not found", session.InstanceID)
+	}
+
+	// Send the prompt to the instance via tmux
+	mgr := c.orch.GetInstanceManager(inst.ID)
+	if mgr == nil {
+		return fmt.Errorf("instance manager not found for %s", inst.ID)
+	}
+
+	// Reset the instance status to working
+	inst.Status = StatusWorking
+
+	// Send the prompt as input to continue
+	mgr.SendInput([]byte(prompt + "\n"))
+
+	c.mu.Lock()
+	c.pendingContinue = false
+	c.mu.Unlock()
+
+	c.notifyIterationStart(nextIteration)
+
+	// Persist session state
+	if err := c.orch.SaveSession(); err != nil {
+		c.logger.Error("failed to persist session after continuing", "error", err)
+	}
+
+	return nil
+}
+
+// IsPendingContinue returns true if waiting for user to continue
+func (c *RalphWiggumCoordinator) IsPendingContinue() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.pendingContinue
+}
+
+// Pause pauses the Ralph Wiggum loop
+func (c *RalphWiggumCoordinator) Pause() {
+	c.notifyPhaseChange(PhaseRalphWiggumPaused)
+}
+
+// Resume resumes a paused Ralph Wiggum loop
+func (c *RalphWiggumCoordinator) Resume() error {
+	session := c.Session()
+	if session.Phase != PhaseRalphWiggumPaused {
+		return fmt.Errorf("session is not paused")
+	}
+	c.notifyPhaseChange(PhaseRalphWiggumIterating)
+	return nil
+}
+
+// Stop stops the Ralph Wiggum execution
+func (c *RalphWiggumCoordinator) Stop() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.stopped = true
+}
+
+// GetInstanceID returns the instance ID for the Ralph Wiggum loop
+func (c *RalphWiggumCoordinator) GetInstanceID() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.instanceID
+}

--- a/internal/orchestrator/ralphwiggum_test.go
+++ b/internal/orchestrator/ralphwiggum_test.go
@@ -1,0 +1,288 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewRalphWiggumSession(t *testing.T) {
+	task := "Fix all failing tests"
+	config := DefaultRalphWiggumConfig()
+	config.MaxIterations = 10
+
+	session := NewRalphWiggumSession(task, config)
+
+	if session.ID == "" {
+		t.Error("expected non-empty session ID")
+	}
+	if session.Task != task {
+		t.Errorf("expected task %q, got %q", task, session.Task)
+	}
+	if session.Phase != PhaseRalphWiggumIterating {
+		t.Errorf("expected phase %q, got %q", PhaseRalphWiggumIterating, session.Phase)
+	}
+	if session.Config.MaxIterations != 10 {
+		t.Errorf("expected max iterations 10, got %d", session.Config.MaxIterations)
+	}
+	if len(session.Iterations) != 0 {
+		t.Errorf("expected 0 iterations, got %d", len(session.Iterations))
+	}
+}
+
+func TestDefaultRalphWiggumConfig(t *testing.T) {
+	config := DefaultRalphWiggumConfig()
+
+	if config.CompletionPromise != "DONE" {
+		t.Errorf("expected completion promise %q, got %q", "DONE", config.CompletionPromise)
+	}
+	if config.MaxIterations != 50 {
+		t.Errorf("expected max iterations 50, got %d", config.MaxIterations)
+	}
+	if !config.AutoContinue {
+		t.Error("expected auto continue to be true")
+	}
+}
+
+func TestRalphWiggumSession_CurrentIteration(t *testing.T) {
+	session := NewRalphWiggumSession("test", DefaultRalphWiggumConfig())
+
+	if session.CurrentIteration() != 0 {
+		t.Errorf("expected current iteration 0, got %d", session.CurrentIteration())
+	}
+
+	// Add iterations
+	session.Iterations = append(session.Iterations, RalphWiggumIteration{Index: 0})
+	if session.CurrentIteration() != 1 {
+		t.Errorf("expected current iteration 1, got %d", session.CurrentIteration())
+	}
+
+	session.Iterations = append(session.Iterations, RalphWiggumIteration{Index: 1})
+	if session.CurrentIteration() != 2 {
+		t.Errorf("expected current iteration 2, got %d", session.CurrentIteration())
+	}
+}
+
+func TestRalphWiggumSession_IsComplete(t *testing.T) {
+	tests := []struct {
+		name     string
+		phase    RalphWiggumPhase
+		expected bool
+	}{
+		{"iterating", PhaseRalphWiggumIterating, false},
+		{"paused", PhaseRalphWiggumPaused, false},
+		{"complete", PhaseRalphWiggumComplete, true},
+		{"max iterations", PhaseRalphWiggumMaxIterations, true},
+		{"failed", PhaseRalphWiggumFailed, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := NewRalphWiggumSession("test", DefaultRalphWiggumConfig())
+			session.Phase = tt.phase
+
+			if session.IsComplete() != tt.expected {
+				t.Errorf("expected IsComplete() = %v for phase %q", tt.expected, tt.phase)
+			}
+		})
+	}
+}
+
+func TestRalphWiggumSession_ShouldContinue(t *testing.T) {
+	tests := []struct {
+		name          string
+		phase         RalphWiggumPhase
+		iterations    int
+		maxIterations int
+		expected      bool
+	}{
+		{"iterating with room", PhaseRalphWiggumIterating, 5, 10, true},
+		{"iterating at max", PhaseRalphWiggumIterating, 10, 10, false},
+		{"iterating unlimited", PhaseRalphWiggumIterating, 100, 0, true},
+		{"paused", PhaseRalphWiggumPaused, 5, 10, false},
+		{"complete", PhaseRalphWiggumComplete, 5, 10, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := DefaultRalphWiggumConfig()
+			config.MaxIterations = tt.maxIterations
+
+			session := NewRalphWiggumSession("test", config)
+			session.Phase = tt.phase
+			for i := 0; i < tt.iterations; i++ {
+				session.Iterations = append(session.Iterations, RalphWiggumIteration{Index: i})
+			}
+
+			if session.ShouldContinue() != tt.expected {
+				t.Errorf("expected ShouldContinue() = %v", tt.expected)
+			}
+		})
+	}
+}
+
+func TestCheckOutputForCompletionPromise(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   string
+		promise  string
+		expected bool
+	}{
+		{
+			name:     "simple match",
+			output:   "Working on task...\n<promise>DONE</promise>\nTask complete.",
+			promise:  "DONE",
+			expected: true,
+		},
+		{
+			name:     "case insensitive",
+			output:   "Working on task...\n<Promise>done</Promise>",
+			promise:  "DONE",
+			expected: true,
+		},
+		{
+			name:     "with whitespace",
+			output:   "<promise>  COMPLETE  </promise>",
+			promise:  "COMPLETE",
+			expected: true,
+		},
+		{
+			name:     "no match",
+			output:   "Still working...",
+			promise:  "DONE",
+			expected: false,
+		},
+		{
+			name:     "wrong promise",
+			output:   "<promise>NOT_DONE</promise>",
+			promise:  "DONE",
+			expected: false,
+		},
+		{
+			name:     "empty promise",
+			output:   "<promise>DONE</promise>",
+			promise:  "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckOutputForCompletionPromise(tt.output, tt.promise)
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestExtractPromiseFromOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   string
+		expected string
+	}{
+		{
+			name:     "simple extraction",
+			output:   "<promise>DONE</promise>",
+			expected: "DONE",
+		},
+		{
+			name:     "with surrounding text",
+			output:   "Some text\n<promise>COMPLETE</promise>\nMore text",
+			expected: "COMPLETE",
+		},
+		{
+			name:     "with whitespace",
+			output:   "<promise>  ALL_TESTS_PASSING  </promise>",
+			expected: "ALL_TESTS_PASSING",
+		},
+		{
+			name:     "no promise",
+			output:   "Just regular text",
+			expected: "",
+		},
+		{
+			name:     "case variations",
+			output:   "<PROMISE>Test</PROMISE>",
+			expected: "Test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractPromiseFromOutput(tt.output)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestRalphWiggumManager_SetPhase(t *testing.T) {
+	session := NewRalphWiggumSession("test", DefaultRalphWiggumConfig())
+	manager := NewRalphWiggumManager(nil, nil, session, nil)
+
+	if session.Phase != PhaseRalphWiggumIterating {
+		t.Errorf("expected initial phase %q", PhaseRalphWiggumIterating)
+	}
+
+	manager.SetPhase(PhaseRalphWiggumPaused)
+	if session.Phase != PhaseRalphWiggumPaused {
+		t.Errorf("expected phase %q after SetPhase", PhaseRalphWiggumPaused)
+	}
+}
+
+func TestRalphWiggumManager_StartIteration(t *testing.T) {
+	session := NewRalphWiggumSession("test", DefaultRalphWiggumConfig())
+	manager := NewRalphWiggumManager(nil, nil, session, nil)
+
+	if len(session.Iterations) != 0 {
+		t.Errorf("expected 0 iterations initially")
+	}
+
+	manager.StartIteration()
+
+	if len(session.Iterations) != 1 {
+		t.Errorf("expected 1 iteration after StartIteration")
+	}
+	if session.Iterations[0].Index != 0 {
+		t.Errorf("expected iteration index 0, got %d", session.Iterations[0].Index)
+	}
+}
+
+func TestRalphWiggumManager_CompleteIteration(t *testing.T) {
+	session := NewRalphWiggumSession("test", DefaultRalphWiggumConfig())
+	manager := NewRalphWiggumManager(nil, nil, session, nil)
+
+	manager.StartIteration()
+	manager.CompleteIteration(true)
+
+	if session.Iterations[0].CompletedAt == nil {
+		t.Error("expected CompletedAt to be set")
+	}
+	if !session.Iterations[0].HasCommits {
+		t.Error("expected HasCommits to be true")
+	}
+}
+
+func TestRalphWiggumManager_EventCallback(t *testing.T) {
+	session := NewRalphWiggumSession("test", DefaultRalphWiggumConfig())
+	manager := NewRalphWiggumManager(nil, nil, session, nil)
+
+	var receivedEvent RalphWiggumEvent
+	manager.SetEventCallback(func(event RalphWiggumEvent) {
+		receivedEvent = event
+	})
+
+	manager.SetPhase(PhaseRalphWiggumComplete)
+
+	// Give the event time to be processed (synchronous in this implementation)
+	time.Sleep(10 * time.Millisecond)
+
+	if receivedEvent.Type != EventRalphWiggumPhaseChange {
+		t.Errorf("expected event type %q, got %q", EventRalphWiggumPhaseChange, receivedEvent.Type)
+	}
+	if receivedEvent.Message != string(PhaseRalphWiggumComplete) {
+		t.Errorf("expected event message %q, got %q", PhaseRalphWiggumComplete, receivedEvent.Message)
+	}
+}

--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -139,6 +139,10 @@ type Session struct {
 	// Each tripleshot has its own group and coordinator.
 	TripleShots []*TripleShotSession `json:"triple_shots,omitempty"`
 
+	// RalphWiggums holds multiple concurrent Ralph Wiggum iterative loop sessions.
+	// Each Ralph Wiggum session has its own group and coordinator.
+	RalphWiggums []*RalphWiggumSession `json:"ralph_wiggums,omitempty"`
+
 	// Recovery state tracking - helps detect and recover interrupted sessions
 	RecoveryState   RecoveryState `json:"recovery_state,omitempty"`   // Current recovery state
 	LastActiveAt    *time.Time    `json:"last_active_at,omitempty"`   // Last time any instance had activity

--- a/internal/orchestrator/session_type.go
+++ b/internal/orchestrator/session_type.go
@@ -19,6 +19,9 @@ const (
 
 	// SessionTypeTripleShot represents a :tripleshot competing solutions session.
 	SessionTypeTripleShot SessionType = "tripleshot"
+
+	// SessionTypeRalphWiggum represents a :ralph iterative loop session.
+	SessionTypeRalphWiggum SessionType = "ralphwiggum"
 )
 
 // Icon returns the display icon for this session type.
@@ -32,6 +35,8 @@ func (t SessionType) Icon() string {
 		return "\u26a1" // ⚡ lightning
 	case SessionTypeTripleShot:
 		return "\u25b3" // △ triangle
+	case SessionTypeRalphWiggum:
+		return "\u221e" // ∞ infinity (represents iterative loop)
 	default:
 		return "\u25cf" // ● filled circle (standard)
 	}
@@ -46,7 +51,7 @@ func (t SessionType) GroupingMode() string {
 	switch t {
 	case SessionTypePlan:
 		return "shared"
-	case SessionTypePlanMulti, SessionTypeUltraPlan, SessionTypeTripleShot:
+	case SessionTypePlanMulti, SessionTypeUltraPlan, SessionTypeTripleShot, SessionTypeRalphWiggum:
 		return "own"
 	default:
 		return "none"

--- a/internal/tui/config/config_test.go
+++ b/internal/tui/config/config_test.go
@@ -300,8 +300,9 @@ func TestTUIConfigCoversAllConfigFields(t *testing.T) {
 	// KEEP THIS LIST MINIMAL - only truly uneditable types belong here.
 	excludedKeys := map[string]string{
 		// Complex types that cannot be edited with the simple TUI editor
-		"pr.template":          "multi-line template requires a full text editor",
-		"pr.reviewers.by_path": "nested map type requires structured editor",
+		"pr.template":               "multi-line template requires a full text editor",
+		"pr.reviewers.by_path":      "nested map type requires structured editor",
+		"experimental.ralph_wiggum": "experimental feature that is CLI-only for now",
 	}
 
 	// Get all keys from the TUI config

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -227,6 +227,9 @@ func (s *InlinePlanState) GetPlanGroupIDs() []string {
 	return ids
 }
 
+// RalphWiggumState is an alias to the view package type for convenience
+type RalphWiggumState = view.RalphWiggumState
+
 // Model holds the TUI application state
 type Model struct {
 	// Core components
@@ -247,6 +250,9 @@ type Model struct {
 
 	// Triple-shot mode (nil if not in triple-shot mode)
 	tripleShot *TripleShotState
+
+	// Ralph Wiggum mode (nil if not in ralph wiggum mode)
+	ralphWiggum *RalphWiggumState
 
 	// Plan editor mode (nil if not in plan editor mode)
 	planEditor *PlanEditorState
@@ -348,6 +354,11 @@ func (m Model) IsUltraPlanMode() bool {
 // IsTripleShotMode returns true if there are any active tripleshot sessions.
 func (m Model) IsTripleShotMode() bool {
 	return m.tripleShot != nil && m.tripleShot.HasActiveCoordinators()
+}
+
+// IsRalphWiggumMode returns true if there are any active Ralph Wiggum sessions.
+func (m Model) IsRalphWiggumMode() bool {
+	return m.ralphWiggum != nil && m.ralphWiggum.HasActiveCoordinators()
 }
 
 // IsInlinePlanMode returns true if there are any active inline plan sessions.

--- a/internal/tui/msg/types.go
+++ b/internal/tui/msg/types.go
@@ -145,3 +145,33 @@ type InlineMultiPlanFileCheckResultMsg struct {
 	StrategyName string
 	GroupID      string // Session group ID for matching to correct session
 }
+
+// RalphWiggumInitMsg signals that Ralph Wiggum mode should initialize and start the first iteration.
+type RalphWiggumInitMsg struct{}
+
+// RalphWiggumIterationStartedMsg indicates a new iteration has started.
+type RalphWiggumIterationStartedMsg struct {
+	GroupID   string
+	Iteration int
+}
+
+// RalphWiggumIterationCompleteMsg indicates an iteration has completed.
+type RalphWiggumIterationCompleteMsg struct {
+	GroupID      string
+	Iteration    int
+	PromiseFound bool
+}
+
+// RalphWiggumErrorMsg indicates an error during Ralph Wiggum operation.
+type RalphWiggumErrorMsg struct {
+	GroupID string
+	Err     error
+}
+
+// RalphWiggumCheckResultMsg contains results from async output checking.
+type RalphWiggumCheckResultMsg struct {
+	GroupID          string
+	InstanceComplete bool
+	PromiseFound     bool
+	Err              error
+}

--- a/internal/tui/ralphwiggum.go
+++ b/internal/tui/ralphwiggum.go
@@ -1,0 +1,202 @@
+package tui
+
+import (
+	"fmt"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	tuimsg "github.com/Iron-Ham/claudio/internal/tui/msg"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// handleRalphWiggumInit initializes Ralph Wiggum mode by starting the first iteration.
+func (m Model) handleRalphWiggumInit() (tea.Model, tea.Cmd) {
+	if m.ralphWiggum == nil || !m.ralphWiggum.HasActiveCoordinators() {
+		return m, nil
+	}
+
+	// Start first iteration for each coordinator that hasn't started
+	var cmds []tea.Cmd
+	for _, coordinator := range m.ralphWiggum.GetAllCoordinators() {
+		session := coordinator.Session()
+		if session == nil {
+			continue
+		}
+
+		// Only start if no instance yet
+		if session.Phase == orchestrator.PhaseRalphWiggumIterating && session.InstanceID == "" {
+			// Capture loop variables for closure
+			coord := coordinator
+			groupID := session.GroupID
+			cmds = append(cmds, func() tea.Msg {
+				if err := coord.StartFirstIteration(); err != nil {
+					return tuimsg.RalphWiggumErrorMsg{Err: err}
+				}
+				return tuimsg.RalphWiggumIterationStartedMsg{
+					GroupID:   groupID,
+					Iteration: 1,
+				}
+			})
+		}
+	}
+
+	if len(cmds) > 0 {
+		m.infoMessage = "Ralph Wiggum starting..."
+		return m, tea.Batch(cmds...)
+	}
+
+	return m, nil
+}
+
+// handleRalphWiggumIterationComplete handles when an iteration completes.
+func (m Model) handleRalphWiggumIterationComplete(msg tuimsg.RalphWiggumIterationCompleteMsg) (tea.Model, tea.Cmd) {
+	if m.ralphWiggum == nil {
+		return m, nil
+	}
+
+	coordinator := m.ralphWiggum.GetCoordinatorForGroup(msg.GroupID)
+	if coordinator == nil {
+		return m, nil
+	}
+
+	session := coordinator.Session()
+	if session == nil {
+		return m, nil
+	}
+
+	if msg.PromiseFound {
+		m.infoMessage = fmt.Sprintf("Ralph Wiggum complete! Promise found after %d iterations.", msg.Iteration)
+		m.ralphWiggum.NeedsNotification = true
+		return m, nil
+	}
+
+	// Check if we should continue
+	if session.ShouldContinue() {
+		if session.Config.AutoContinue {
+			// Capture values before creating closure
+			nextIteration := session.CurrentIteration() + 1
+			// Auto-continue to next iteration
+			return m, func() tea.Msg {
+				if err := coordinator.ContinueIteration(); err != nil {
+					return tuimsg.RalphWiggumErrorMsg{GroupID: msg.GroupID, Err: err}
+				}
+				return tuimsg.RalphWiggumIterationStartedMsg{
+					GroupID:   msg.GroupID,
+					Iteration: nextIteration,
+				}
+			}
+		}
+		// Waiting for user to continue
+		m.infoMessage = fmt.Sprintf("Iteration %d complete. Press [c] to continue.", msg.Iteration)
+	} else {
+		// Max iterations reached
+		m.infoMessage = fmt.Sprintf("Ralph Wiggum stopped: max iterations (%d) reached.", session.Config.MaxIterations)
+	}
+
+	return m, nil
+}
+
+// handleRalphWiggumCheckResult processes async completion check results.
+func (m Model) handleRalphWiggumCheckResult(msg tuimsg.RalphWiggumCheckResultMsg) (tea.Model, tea.Cmd) {
+	if m.ralphWiggum == nil {
+		return m, nil
+	}
+
+	coordinator := m.ralphWiggum.GetCoordinatorForGroup(msg.GroupID)
+	if coordinator == nil {
+		return m, nil
+	}
+
+	if msg.Err != nil {
+		if m.logger != nil {
+			m.logger.Warn("ralph wiggum check error", "group_id", msg.GroupID, "error", msg.Err)
+		}
+		return m, nil
+	}
+
+	// If instance complete, process the iteration
+	if msg.InstanceComplete {
+		session := coordinator.Session()
+		if session == nil {
+			return m, nil
+		}
+
+		// Process the iteration completion
+		if err := coordinator.ProcessIterationComplete(msg.PromiseFound); err != nil {
+			if m.logger != nil {
+				m.logger.Error("failed to process iteration completion", "error", err)
+			}
+		}
+
+		// Capture iteration count before creating closure
+		currentIteration := session.CurrentIteration()
+		return m, func() tea.Msg {
+			return tuimsg.RalphWiggumIterationCompleteMsg{
+				GroupID:      msg.GroupID,
+				Iteration:    currentIteration,
+				PromiseFound: msg.PromiseFound,
+			}
+		}
+	}
+
+	return m, nil
+}
+
+// dispatchRalphWiggumCompletionChecks returns commands to check Ralph Wiggum instance
+// status asynchronously. This avoids blocking the UI event loop.
+func (m *Model) dispatchRalphWiggumCompletionChecks() []tea.Cmd {
+	if m.ralphWiggum == nil || !m.ralphWiggum.HasActiveCoordinators() {
+		return nil
+	}
+
+	var cmds []tea.Cmd
+
+	// Dispatch async check for each coordinator
+	for groupID, coordinator := range m.ralphWiggum.Coordinators {
+		session := coordinator.Session()
+		if session == nil {
+			continue
+		}
+
+		// Only check if in an active phase
+		if session.Phase == orchestrator.PhaseRalphWiggumIterating {
+			// Capture for closure
+			gid := groupID
+			coord := coordinator
+
+			cmds = append(cmds, func() tea.Msg {
+				complete, promiseFound, err := coord.CheckInstanceCompletion()
+				return tuimsg.RalphWiggumCheckResultMsg{
+					GroupID:          gid,
+					InstanceComplete: complete,
+					PromiseFound:     promiseFound,
+					Err:              err,
+				}
+			})
+		}
+	}
+
+	return cmds
+}
+
+// CleanupRalphWiggum stops all Ralph Wiggum coordinators and clears the state.
+// Exported for use by the command handler when stopping sessions.
+func (m *Model) CleanupRalphWiggum() {
+	if m.ralphWiggum == nil {
+		return
+	}
+
+	// Stop all coordinators
+	for _, coordinator := range m.ralphWiggum.Coordinators {
+		if coordinator != nil {
+			coordinator.Stop()
+		}
+	}
+
+	// Clear TUI-level state
+	m.ralphWiggum = nil
+
+	// Clear session-level state
+	if m.session != nil {
+		m.session.RalphWiggums = nil
+	}
+}

--- a/internal/tui/view/ralphwiggum.go
+++ b/internal/tui/view/ralphwiggum.go
@@ -1,0 +1,325 @@
+package view
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/tui/styles"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Ralph Wiggum specific style aliases for better readability
+var (
+	rwHighlight = styles.Primary
+	rwSuccess   = styles.Secondary
+	rwWarning   = styles.Warning
+	rwError     = styles.Error
+	rwSubtle    = styles.Muted
+)
+
+// RalphWiggumState holds the state for Ralph Wiggum mode
+type RalphWiggumState struct {
+	// Coordinators maps group IDs to their Ralph Wiggum coordinators.
+	// This enables multiple concurrent Ralph Wiggum sessions.
+	Coordinators map[string]*orchestrator.RalphWiggumCoordinator
+
+	NeedsNotification bool // Set when user input is needed (checked on tick)
+}
+
+// GetCoordinatorForGroup returns the coordinator for a specific group ID.
+func (s *RalphWiggumState) GetCoordinatorForGroup(groupID string) *orchestrator.RalphWiggumCoordinator {
+	if s == nil || s.Coordinators == nil {
+		return nil
+	}
+	return s.Coordinators[groupID]
+}
+
+// GetAllCoordinators returns all active Ralph Wiggum coordinators.
+// Results are sorted by group ID for deterministic ordering.
+func (s *RalphWiggumState) GetAllCoordinators() []*orchestrator.RalphWiggumCoordinator {
+	if s == nil || len(s.Coordinators) == 0 {
+		return nil
+	}
+
+	// Sort keys for deterministic iteration order
+	keys := make([]string, 0, len(s.Coordinators))
+	for k := range s.Coordinators {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	coords := make([]*orchestrator.RalphWiggumCoordinator, 0, len(s.Coordinators))
+	for _, k := range keys {
+		coords = append(coords, s.Coordinators[k])
+	}
+	return coords
+}
+
+// HasActiveCoordinators returns true if there are any active Ralph Wiggum coordinators.
+func (s *RalphWiggumState) HasActiveCoordinators() bool {
+	if s == nil {
+		return false
+	}
+	return len(s.Coordinators) > 0
+}
+
+// RalphWiggumRenderContext provides the necessary context for rendering Ralph Wiggum views
+type RalphWiggumRenderContext struct {
+	Orchestrator *orchestrator.Orchestrator
+	Session      *orchestrator.Session
+	RalphWiggum  *RalphWiggumState
+	ActiveTab    int
+	Width        int
+	Height       int
+}
+
+// RenderRalphWiggumHeader renders a compact header showing Ralph Wiggum status.
+// For multiple sessions, shows a summary count.
+func RenderRalphWiggumHeader(ctx RalphWiggumRenderContext) string {
+	if ctx.RalphWiggum == nil || !ctx.RalphWiggum.HasActiveCoordinators() {
+		return ""
+	}
+
+	coordinators := ctx.RalphWiggum.GetAllCoordinators()
+	if len(coordinators) == 0 {
+		return ""
+	}
+
+	// For multiple sessions, show a summary
+	if len(coordinators) > 1 {
+		iterating := 0
+		complete := 0
+		failed := 0
+		for _, coord := range coordinators {
+			session := coord.Session()
+			if session == nil {
+				continue
+			}
+			switch session.Phase {
+			case orchestrator.PhaseRalphWiggumIterating:
+				iterating++
+			case orchestrator.PhaseRalphWiggumComplete:
+				complete++
+			case orchestrator.PhaseRalphWiggumFailed, orchestrator.PhaseRalphWiggumMaxIterations:
+				failed++
+			}
+		}
+		summary := fmt.Sprintf("%d active", len(coordinators))
+		if complete > 0 {
+			summary += fmt.Sprintf(", %d complete", complete)
+		}
+		if failed > 0 {
+			summary += fmt.Sprintf(", %d stopped", failed)
+		}
+		return rwSubtle.Render("Ralph Wiggum: ") + summary
+	}
+
+	// Single session - show detailed status
+	session := coordinators[0].Session()
+	if session == nil {
+		return ""
+	}
+
+	// Build phase indicator
+	var phaseIcon string
+	var phaseText string
+	var phaseStyle lipgloss.Style
+
+	switch session.Phase {
+	case orchestrator.PhaseRalphWiggumIterating:
+		phaseIcon = "∞"
+		phaseText = "Iterating"
+		phaseStyle = rwHighlight
+	case orchestrator.PhaseRalphWiggumPaused:
+		phaseIcon = "⏸"
+		phaseText = "Paused"
+		phaseStyle = rwWarning
+	case orchestrator.PhaseRalphWiggumComplete:
+		phaseIcon = "✓"
+		phaseText = "Complete"
+		phaseStyle = rwSuccess
+	case orchestrator.PhaseRalphWiggumMaxIterations:
+		phaseIcon = "⚠"
+		phaseText = "Max Iterations"
+		phaseStyle = rwWarning
+	case orchestrator.PhaseRalphWiggumFailed:
+		phaseIcon = "✗"
+		phaseText = "Failed"
+		phaseStyle = rwError
+	}
+
+	// Build iteration info
+	iterInfo := fmt.Sprintf("Iteration %d", session.CurrentIteration())
+	if session.Config.MaxIterations > 0 {
+		iterInfo += fmt.Sprintf("/%d", session.Config.MaxIterations)
+	}
+
+	// Build the header line
+	header := fmt.Sprintf("%s %s | %s | Promise: %s",
+		phaseIcon,
+		phaseStyle.Render(phaseText),
+		iterInfo,
+		session.Config.CompletionPromise,
+	)
+
+	return rwSubtle.Render("Ralph Wiggum: ") + header
+}
+
+// RenderRalphWiggumSidebarSection renders a sidebar section for Ralph Wiggum mode.
+func RenderRalphWiggumSidebarSection(ctx RalphWiggumRenderContext, width int) string {
+	if ctx.RalphWiggum == nil || !ctx.RalphWiggum.HasActiveCoordinators() {
+		return ""
+	}
+
+	var lines []string
+
+	// Title - show count if multiple
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(styles.BlueColor)
+	coordinators := ctx.RalphWiggum.GetAllCoordinators()
+	if len(coordinators) > 1 {
+		lines = append(lines, titleStyle.Render(fmt.Sprintf("Ralph Wiggum (%d)", len(coordinators))))
+	} else {
+		lines = append(lines, titleStyle.Render("Ralph Wiggum"))
+	}
+	lines = append(lines, "")
+
+	// Render each Ralph Wiggum session
+	for idx, coord := range coordinators {
+		session := coord.Session()
+		if session == nil {
+			continue
+		}
+
+		// Add separator between sessions
+		if idx > 0 {
+			lines = append(lines, "")
+			lines = append(lines, strings.Repeat("─", width-4))
+			lines = append(lines, "")
+		}
+
+		lines = append(lines, renderSingleRalphWiggumSection(ctx, session, coord, width, idx+1, len(coordinators) > 1)...)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// renderSingleRalphWiggumSection renders a single Ralph Wiggum session's status.
+func renderSingleRalphWiggumSection(ctx RalphWiggumRenderContext, session *orchestrator.RalphWiggumSession, coord *orchestrator.RalphWiggumCoordinator, width int, index int, showIndex bool) []string {
+	var lines []string
+
+	// Task preview with optional index
+	task := session.Task
+	maxTaskLen := width - 10
+	if showIndex {
+		maxTaskLen -= 4 // Account for "#N: " prefix
+	}
+	if len(task) > maxTaskLen {
+		task = task[:maxTaskLen-3] + "..."
+	}
+	if showIndex {
+		lines = append(lines, rwSubtle.Render(fmt.Sprintf("#%d: ", index))+task)
+	} else {
+		lines = append(lines, rwSubtle.Render("Task: ")+task)
+	}
+	lines = append(lines, "")
+
+	// Phase status
+	var phaseStyle lipgloss.Style
+	var phaseText string
+	switch session.Phase {
+	case orchestrator.PhaseRalphWiggumIterating:
+		phaseStyle = rwHighlight
+		phaseText = "∞ Iterating"
+	case orchestrator.PhaseRalphWiggumPaused:
+		phaseStyle = rwWarning
+		phaseText = "⏸ Paused"
+	case orchestrator.PhaseRalphWiggumComplete:
+		phaseStyle = rwSuccess
+		phaseText = "✓ Complete"
+	case orchestrator.PhaseRalphWiggumMaxIterations:
+		phaseStyle = rwWarning
+		phaseText = "⚠ Max Iterations"
+	case orchestrator.PhaseRalphWiggumFailed:
+		phaseStyle = rwError
+		phaseText = "✗ Failed"
+	}
+	lines = append(lines, rwSubtle.Render("Status: ")+phaseStyle.Render(phaseText))
+	lines = append(lines, "")
+
+	// Iteration info
+	iterInfo := fmt.Sprintf("Iteration: %d", session.CurrentIteration())
+	if session.Config.MaxIterations > 0 {
+		iterInfo += fmt.Sprintf(" of %d", session.Config.MaxIterations)
+	}
+	lines = append(lines, rwSubtle.Render(iterInfo))
+
+	// Promise info
+	lines = append(lines, rwSubtle.Render("Promise: ")+session.Config.CompletionPromise)
+
+	// Instance indicator
+	if session.InstanceID != "" {
+		// Check if this instance is active
+		prefix := "  "
+		if ctx.Session != nil && ctx.ActiveTab < len(ctx.Session.Instances) {
+			activeInst := ctx.Session.Instances[ctx.ActiveTab]
+			if activeInst != nil && activeInst.ID == session.InstanceID {
+				prefix = "▶ "
+			}
+		}
+		lines = append(lines, "")
+		lines = append(lines, prefix+rwSubtle.Render("Instance: ")+session.InstanceID[:8])
+	}
+
+	// Pending continue indicator
+	if coord.IsPendingContinue() {
+		lines = append(lines, "")
+		lines = append(lines, rwWarning.Render("  Press [c] to continue"))
+	}
+
+	return lines
+}
+
+// RenderRalphWiggumHelp renders the help bar for Ralph Wiggum mode.
+func RenderRalphWiggumHelp(state *HelpBarState) string {
+	var parts []string
+
+	// Mode-specific keys
+	parts = append(parts, styles.HelpKey.Render("[c]")+" continue")
+	parts = append(parts, styles.HelpKey.Render("[p]")+" pause")
+	parts = append(parts, styles.HelpKey.Render("[x]")+" stop")
+	parts = append(parts, styles.HelpKey.Render("[:]")+" command")
+	parts = append(parts, styles.HelpKey.Render("[?]")+" help")
+	parts = append(parts, styles.HelpKey.Render("[q]")+" quit")
+
+	return strings.Join(parts, "  ")
+}
+
+// FindRalphWiggumForActiveInstance finds the Ralph Wiggum session that contains
+// the currently active instance (based on activeTab).
+// Exported for potential use by other view components.
+func FindRalphWiggumForActiveInstance(ctx RalphWiggumRenderContext) *orchestrator.RalphWiggumSession {
+	if ctx.Session == nil || ctx.ActiveTab >= len(ctx.Session.Instances) {
+		return nil
+	}
+
+	activeInst := ctx.Session.Instances[ctx.ActiveTab]
+	if activeInst == nil {
+		return nil
+	}
+
+	// Search through all coordinators to find which session owns this instance
+	for _, coord := range ctx.RalphWiggum.GetAllCoordinators() {
+		session := coord.Session()
+		if session == nil {
+			continue
+		}
+
+		if session.InstanceID == activeInst.ID {
+			return session
+		}
+	}
+
+	return nil
+}

--- a/internal/tui/view/ralphwiggum_test.go
+++ b/internal/tui/view/ralphwiggum_test.go
@@ -1,0 +1,275 @@
+package view
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+)
+
+func TestRalphWiggumState_HasActiveCoordinators(t *testing.T) {
+	t.Run("nil state returns false", func(t *testing.T) {
+		var state *RalphWiggumState
+		if state.HasActiveCoordinators() {
+			t.Error("expected false for nil state")
+		}
+	})
+
+	t.Run("empty state returns false", func(t *testing.T) {
+		state := &RalphWiggumState{}
+		if state.HasActiveCoordinators() {
+			t.Error("expected false for empty state")
+		}
+	})
+
+	t.Run("state with empty Coordinators map returns false", func(t *testing.T) {
+		state := &RalphWiggumState{
+			Coordinators: make(map[string]*orchestrator.RalphWiggumCoordinator),
+		}
+		if state.HasActiveCoordinators() {
+			t.Error("expected false for empty coordinators map")
+		}
+	})
+
+	t.Run("state with coordinators in map returns true", func(t *testing.T) {
+		state := &RalphWiggumState{
+			Coordinators: map[string]*orchestrator.RalphWiggumCoordinator{
+				"group-1": nil, // Even nil coordinator counts as entry
+			},
+		}
+		if !state.HasActiveCoordinators() {
+			t.Error("expected true when coordinators map has entries")
+		}
+	})
+}
+
+func TestRalphWiggumState_GetAllCoordinators(t *testing.T) {
+	t.Run("nil state returns nil", func(t *testing.T) {
+		var state *RalphWiggumState
+		if state.GetAllCoordinators() != nil {
+			t.Error("expected nil for nil state")
+		}
+	})
+
+	t.Run("empty state returns nil", func(t *testing.T) {
+		state := &RalphWiggumState{}
+		if state.GetAllCoordinators() != nil {
+			t.Error("expected nil for empty state")
+		}
+	})
+
+	t.Run("returns coordinators from map", func(t *testing.T) {
+		coord1 := &orchestrator.RalphWiggumCoordinator{}
+		coord2 := &orchestrator.RalphWiggumCoordinator{}
+		state := &RalphWiggumState{
+			Coordinators: map[string]*orchestrator.RalphWiggumCoordinator{
+				"group-1": coord1,
+				"group-2": coord2,
+			},
+		}
+
+		result := state.GetAllCoordinators()
+		if len(result) != 2 {
+			t.Errorf("expected 2 coordinators, got %d", len(result))
+		}
+	})
+
+	t.Run("returns deterministic order by group ID", func(t *testing.T) {
+		coord1 := &orchestrator.RalphWiggumCoordinator{}
+		coord2 := &orchestrator.RalphWiggumCoordinator{}
+		coord3 := &orchestrator.RalphWiggumCoordinator{}
+		state := &RalphWiggumState{
+			Coordinators: map[string]*orchestrator.RalphWiggumCoordinator{
+				"z-group": coord1,
+				"a-group": coord2,
+				"m-group": coord3,
+			},
+		}
+
+		// Call multiple times to verify order is deterministic
+		for i := 0; i < 10; i++ {
+			result := state.GetAllCoordinators()
+			// Should be sorted alphabetically: a-group, m-group, z-group
+			if result[0] != coord2 || result[1] != coord3 || result[2] != coord1 {
+				t.Error("expected coordinators to be returned in sorted key order")
+			}
+		}
+	})
+
+	t.Run("returns nil when map empty", func(t *testing.T) {
+		state := &RalphWiggumState{
+			Coordinators: make(map[string]*orchestrator.RalphWiggumCoordinator),
+		}
+
+		result := state.GetAllCoordinators()
+		if result != nil {
+			t.Errorf("expected nil for empty map, got %d coordinators", len(result))
+		}
+	})
+}
+
+func TestRalphWiggumState_GetCoordinatorForGroup(t *testing.T) {
+	t.Run("returns coordinator from map when found", func(t *testing.T) {
+		coord := &orchestrator.RalphWiggumCoordinator{}
+		state := &RalphWiggumState{
+			Coordinators: map[string]*orchestrator.RalphWiggumCoordinator{
+				"target-group": coord,
+			},
+		}
+
+		result := state.GetCoordinatorForGroup("target-group")
+		if result != coord {
+			t.Error("expected to find coordinator by group ID")
+		}
+	})
+
+	t.Run("returns nil when not found", func(t *testing.T) {
+		state := &RalphWiggumState{
+			Coordinators: map[string]*orchestrator.RalphWiggumCoordinator{
+				"other-group": &orchestrator.RalphWiggumCoordinator{},
+			},
+		}
+
+		result := state.GetCoordinatorForGroup("missing-group")
+		if result != nil {
+			t.Error("expected nil for missing group")
+		}
+	})
+
+	t.Run("returns nil when coordinators map is nil", func(t *testing.T) {
+		state := &RalphWiggumState{}
+
+		result := state.GetCoordinatorForGroup("any-group")
+		if result != nil {
+			t.Error("expected nil when coordinators map is nil")
+		}
+	})
+
+	t.Run("nil state returns nil", func(t *testing.T) {
+		var state *RalphWiggumState
+		result := state.GetCoordinatorForGroup("any-group")
+		if result != nil {
+			t.Error("expected nil for nil state")
+		}
+	})
+}
+
+func TestRenderRalphWiggumHeader(t *testing.T) {
+	t.Run("returns empty for nil state", func(t *testing.T) {
+		ctx := RalphWiggumRenderContext{
+			RalphWiggum: nil,
+		}
+		result := RenderRalphWiggumHeader(ctx)
+		if result != "" {
+			t.Errorf("expected empty string for nil state, got: %q", result)
+		}
+	})
+
+	t.Run("returns empty for empty coordinators", func(t *testing.T) {
+		ctx := RalphWiggumRenderContext{
+			RalphWiggum: &RalphWiggumState{
+				Coordinators: make(map[string]*orchestrator.RalphWiggumCoordinator),
+			},
+		}
+		result := RenderRalphWiggumHeader(ctx)
+		if result != "" {
+			t.Errorf("expected empty string for empty coordinators, got: %q", result)
+		}
+	})
+}
+
+func TestRenderRalphWiggumSidebarSection(t *testing.T) {
+	t.Run("returns empty for nil state", func(t *testing.T) {
+		ctx := RalphWiggumRenderContext{
+			RalphWiggum: nil,
+		}
+		result := RenderRalphWiggumSidebarSection(ctx, 40)
+		if result != "" {
+			t.Errorf("expected empty string for nil state, got: %q", result)
+		}
+	})
+
+	t.Run("returns empty for empty coordinators", func(t *testing.T) {
+		ctx := RalphWiggumRenderContext{
+			RalphWiggum: &RalphWiggumState{
+				Coordinators: make(map[string]*orchestrator.RalphWiggumCoordinator),
+			},
+		}
+		result := RenderRalphWiggumSidebarSection(ctx, 40)
+		if result != "" {
+			t.Errorf("expected empty string for empty coordinators, got: %q", result)
+		}
+	})
+}
+
+func TestRenderRalphWiggumHelp(t *testing.T) {
+	t.Run("renders help bar with expected keys", func(t *testing.T) {
+		state := &HelpBarState{}
+		result := RenderRalphWiggumHelp(state)
+
+		// Check for expected help keys
+		if !strings.Contains(result, "c") {
+			t.Error("expected 'c' key in help")
+		}
+		if !strings.Contains(result, "continue") {
+			t.Error("expected 'continue' action in help")
+		}
+		if !strings.Contains(result, "p") {
+			t.Error("expected 'p' key in help")
+		}
+		if !strings.Contains(result, "pause") {
+			t.Error("expected 'pause' action in help")
+		}
+		if !strings.Contains(result, "x") {
+			t.Error("expected 'x' key in help")
+		}
+		if !strings.Contains(result, "stop") {
+			t.Error("expected 'stop' action in help")
+		}
+	})
+}
+
+func TestFindRalphWiggumForActiveInstance(t *testing.T) {
+	t.Run("returns nil for nil session", func(t *testing.T) {
+		ctx := RalphWiggumRenderContext{
+			Session:     nil,
+			RalphWiggum: &RalphWiggumState{},
+		}
+		result := FindRalphWiggumForActiveInstance(ctx)
+		if result != nil {
+			t.Error("expected nil for nil session")
+		}
+	})
+
+	t.Run("returns nil when activeTab out of bounds", func(t *testing.T) {
+		ctx := RalphWiggumRenderContext{
+			Session: &orchestrator.Session{
+				Instances: []*orchestrator.Instance{},
+			},
+			ActiveTab:   5,
+			RalphWiggum: &RalphWiggumState{},
+		}
+		result := FindRalphWiggumForActiveInstance(ctx)
+		if result != nil {
+			t.Error("expected nil when activeTab out of bounds")
+		}
+	})
+
+	t.Run("returns nil when no matching ralph wiggum session", func(t *testing.T) {
+		ctx := RalphWiggumRenderContext{
+			Session: &orchestrator.Session{
+				Instances: []*orchestrator.Instance{
+					{ID: "inst-1"},
+				},
+			},
+			ActiveTab: 0,
+			RalphWiggum: &RalphWiggumState{
+				Coordinators: make(map[string]*orchestrator.RalphWiggumCoordinator),
+			},
+		}
+		result := FindRalphWiggumForActiveInstance(ctx)
+		if result != nil {
+			t.Error("expected nil when no matching ralph wiggum session")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Adds Ralph Wiggum mode - an iterative self-improvement loop where Claude repeatedly works on a task until a completion promise is detected in the output
- Implements continuous self-referential feedback loops: Claude works on a task, and when it completes an iteration, the same prompt is fed back, allowing iterative improvement
- Useful for tasks with clear verification criteria (e.g., "make all tests pass")

## Key Features

- CLI command: `claudio ralph [task]`
- TUI support via model state
- Configurable completion promise (default: "DONE") - Claude signals completion with `<promise>DONE</promise>`
- Configurable max iterations (default: 50)
- Auto-continue option for unattended iteration
- Promise detection via regex matching in Claude's output
- Iteration history tracking

## Implementation Details

- Follows the existing TripleShot architecture pattern with orchestrator-level types
- `RalphWiggumSession` - tracks session state, iterations, and config
- `RalphWiggumManager` - handles session state transitions
- `RalphWiggumCoordinator` - orchestrates iteration lifecycle with callbacks
- View layer integration for sidebar and header rendering
- Gated behind `experimental.ralph_wiggum: true` config flag

## Test Plan

- [x] All existing tests pass
- [x] New unit tests for RalphWiggumSession, RalphWiggumManager, and view state
- [x] go vet passes
- [x] gofmt passes
- [ ] Manual testing of `claudio ralph "fix failing tests"` workflow