### PR TITLE
Add adversarial review mode with implementer-reviewer feedback loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Adversarial Review Mode** - New `claudio adversarial` command that creates an iterative feedback loop between an Implementer and a critical Reviewer:
+  - Implementer works on the task and submits work via increment files
+  - Reviewer critically examines the work and provides detailed feedback
+  - Loop continues until Reviewer approves the implementation or max iterations reached
+  - Configurable max iterations with `--max-iterations` flag (default: 10)
+  - Useful for complex implementations that benefit from rigorous code review
+  - **NEW**: Now accessible from the TUI via `:adversarial` or `:adv` command
+  - Supports multiple concurrent adversarial sessions, similar to TripleShot mode
+
 - **Task Chaining by Sidebar Number** - The `:chain`, `:dep`, and `:depends` commands now accept an optional sidebar number argument to specify which instance to chain from (e.g., `:chain 2` or `:chain #2`). This is more user-friendly than using instance IDs, which aren't prominently displayed.
 
 ### Changed

--- a/internal/cmd/planning/adversarial.go
+++ b/internal/cmd/planning/adversarial.go
@@ -1,0 +1,168 @@
+package planning
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Iron-Ham/claudio/internal/config"
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	orchsession "github.com/Iron-Ham/claudio/internal/orchestrator/session"
+	sessutil "github.com/Iron-Ham/claudio/internal/session"
+	"github.com/Iron-Ham/claudio/internal/tui"
+	"github.com/Iron-Ham/claudio/internal/util"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+var adversarialCmd = &cobra.Command{
+	Use:   "adversarial [task]",
+	Short: "Start an adversarial review session with implementer-reviewer feedback loop",
+	Long: `Adversarial review mode creates a feedback loop between an IMPLEMENTER and a REVIEWER:
+
+1. The IMPLEMENTER works on the task and submits their work for review
+2. The REVIEWER critically examines the work and provides detailed feedback
+3. If issues are found, the IMPLEMENTER addresses them and resubmits
+4. This loop continues until the REVIEWER approves the implementation
+
+This approach is useful for:
+- Complex implementations that benefit from critical review
+- Ensuring high code quality through iterative refinement
+- Catching edge cases and issues before code is merged
+- Learning how critical code review can improve implementations
+
+The process continues until:
+- The reviewer approves the work (success)
+- Maximum iterations are reached (configurable)
+- Either instance encounters a fatal error
+
+Examples:
+  # Start adversarial review with a task
+  claudio adversarial "Implement user authentication with JWT"
+
+  # Limit the number of review cycles
+  claudio adversarial --max-iterations 5 "Refactor the database layer"`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runAdversarial,
+}
+
+var (
+	adversarialMaxIterations int
+)
+
+func init() {
+	adversarialCmd.Flags().IntVar(&adversarialMaxIterations, "max-iterations", 10, "Maximum number of implement-review cycles (0 = unlimited)")
+}
+
+// RegisterAdversarialCmd registers the adversarial command with the given parent command.
+func RegisterAdversarialCmd(parent *cobra.Command) {
+	parent.AddCommand(adversarialCmd)
+}
+
+func runAdversarial(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	// Get task from args or prompt
+	var task string
+	if len(args) > 0 {
+		task = args[0]
+	} else {
+		task, err = promptAdversarialTask()
+		if err != nil {
+			return err
+		}
+	}
+
+	// Generate a new session ID for this adversarial session
+	sessionID := orchsession.GenerateID()
+	cfg := config.Get()
+
+	// Create adversarial configuration
+	advConfig := orchestrator.DefaultAdversarialConfig()
+	advConfig.MaxIterations = adversarialMaxIterations
+
+	// Create logger if enabled
+	sessionDir := sessutil.GetSessionDir(cwd, sessionID)
+	logger := createLogger(sessionDir, cfg)
+	defer func() { _ = logger.Close() }()
+
+	// Create orchestrator with multi-session support
+	orch, err := orchestrator.NewWithSession(cwd, sessionID, cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create orchestrator: %w", err)
+	}
+
+	// Set the logger on the orchestrator
+	orch.SetLogger(logger)
+
+	// Start a new session for the adversarial review
+	words := strings.Fields(task)
+	if len(words) > 3 {
+		words = words[:3]
+	}
+	sessionName := "adversarial-" + SlugifyWords(words)
+
+	session, err := orch.StartSession(sessionName)
+	if err != nil {
+		return fmt.Errorf("failed to start session: %w", err)
+	}
+
+	// Log startup
+	logger.Info("adversarial session started",
+		"session_id", sessionID,
+		"task", util.TruncateString(task, 100),
+		"max_iterations", advConfig.MaxIterations,
+	)
+
+	// Create adversarial session
+	advSession := orchestrator.NewAdversarialSession(task, advConfig)
+
+	// Link adversarial session to main session for persistence
+	session.AdversarialSessions = append(session.AdversarialSessions, advSession)
+
+	// Create coordinator with logger
+	coordinator := orchestrator.NewAdversarialCoordinator(orch, session, advSession, logger)
+
+	// Get terminal dimensions
+	if termWidth, termHeight, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+		contentWidth, contentHeight := tui.CalculateContentDimensions(termWidth, termHeight)
+		if contentWidth > 0 && contentHeight > 0 {
+			orch.SetDisplayDimensions(contentWidth, contentHeight)
+		}
+	}
+
+	// Launch TUI with adversarial mode
+	app := tui.NewWithAdversarial(orch, session, coordinator, logger.WithSession(session.ID))
+	if err := app.Run(); err != nil {
+		return fmt.Errorf("TUI error: %w", err)
+	}
+
+	return nil
+}
+
+// promptAdversarialTask prompts the user to enter a task
+func promptAdversarialTask() (string, error) {
+	fmt.Println("\nAdversarial Review Mode")
+	fmt.Println("=======================")
+	fmt.Println("Enter a task for the implementer to complete.")
+	fmt.Println("A critical reviewer will thoroughly examine each increment.")
+	fmt.Println()
+	fmt.Print("Task: ")
+
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("failed to read input: %w", err)
+	}
+
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "", fmt.Errorf("task cannot be empty")
+	}
+
+	return input, nil
+}

--- a/internal/cmd/planning/register.go
+++ b/internal/cmd/planning/register.go
@@ -9,4 +9,5 @@ func Register(parent *cobra.Command) {
 	RegisterPlanCmd(parent)
 	RegisterUltraplanCmd(parent)
 	RegisterTripleshotCmd(parent)
+	RegisterAdversarialCmd(parent)
 }

--- a/internal/orchestrator/adversarial.go
+++ b/internal/orchestrator/adversarial.go
@@ -1,0 +1,522 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/logging"
+)
+
+// AdversarialPhase represents the current phase of an adversarial review session
+type AdversarialPhase string
+
+const (
+	// PhaseAdversarialImplementing - the implementer is working on the task
+	PhaseAdversarialImplementing AdversarialPhase = "implementing"
+	// PhaseAdversarialReviewing - the reviewer is critically examining the work
+	PhaseAdversarialReviewing AdversarialPhase = "reviewing"
+	// PhaseAdversarialApproved - the reviewer has approved the implementation
+	PhaseAdversarialApproved AdversarialPhase = "approved"
+	// PhaseAdversarialComplete - the session is complete
+	PhaseAdversarialComplete AdversarialPhase = "complete"
+	// PhaseAdversarialFailed - something went wrong
+	PhaseAdversarialFailed AdversarialPhase = "failed"
+)
+
+// AdversarialConfig holds configuration for an adversarial review session
+type AdversarialConfig struct {
+	// MaxIterations limits the number of implement-review cycles (0 = unlimited)
+	MaxIterations int `json:"max_iterations"`
+}
+
+// DefaultAdversarialConfig returns the default configuration
+func DefaultAdversarialConfig() AdversarialConfig {
+	return AdversarialConfig{
+		MaxIterations: 10, // Reasonable default to prevent infinite loops
+	}
+}
+
+// AdversarialSession represents an adversarial review orchestration session
+type AdversarialSession struct {
+	ID            string            `json:"id"`
+	GroupID       string            `json:"group_id,omitempty"` // Link to InstanceGroup for display
+	Task          string            `json:"task"`               // The original task/problem
+	Phase         AdversarialPhase  `json:"phase"`
+	Config        AdversarialConfig `json:"config"`
+	ImplementerID string            `json:"implementer_id,omitempty"` // Instance ID of implementer
+	ReviewerID    string            `json:"reviewer_id,omitempty"`    // Instance ID of reviewer
+	CurrentRound  int               `json:"current_round"`            // Current implement-review cycle (1-based)
+	Created       time.Time         `json:"created"`
+	StartedAt     *time.Time        `json:"started_at,omitempty"`
+	CompletedAt   *time.Time        `json:"completed_at,omitempty"`
+	Error         string            `json:"error,omitempty"` // Error message if failed
+
+	// History tracks all increments and reviews
+	History []AdversarialRound `json:"history,omitempty"`
+}
+
+// AdversarialRound represents one implement-review cycle
+type AdversarialRound struct {
+	Round      int                       `json:"round"`
+	Increment  *AdversarialIncrementFile `json:"increment,omitempty"`
+	Review     *AdversarialReviewFile    `json:"review,omitempty"`
+	StartedAt  time.Time                 `json:"started_at"`
+	ReviewedAt *time.Time                `json:"reviewed_at,omitempty"`
+}
+
+// NewAdversarialSession creates a new adversarial review session
+func NewAdversarialSession(task string, config AdversarialConfig) *AdversarialSession {
+	return &AdversarialSession{
+		ID:           generateID(),
+		Task:         task,
+		Phase:        PhaseAdversarialImplementing,
+		Config:       config,
+		CurrentRound: 1,
+		Created:      time.Now(),
+		History:      make([]AdversarialRound, 0),
+	}
+}
+
+// AdversarialIncrementFileName is the sentinel file the implementer writes when ready for review
+const AdversarialIncrementFileName = ".claudio-adversarial-increment.json"
+
+// AdversarialIncrementFile represents the implementer's work submission
+type AdversarialIncrementFile struct {
+	Round         int      `json:"round"`          // Which iteration this is
+	Status        string   `json:"status"`         // "ready_for_review" or "failed"
+	Summary       string   `json:"summary"`        // Brief summary of changes made
+	FilesModified []string `json:"files_modified"` // Files changed in this increment
+	Approach      string   `json:"approach"`       // Description of the approach taken
+	Notes         string   `json:"notes"`          // Any concerns or questions for reviewer
+}
+
+// AdversarialIncrementFilePath returns the full path to the increment file
+func AdversarialIncrementFilePath(worktreePath string) string {
+	return filepath.Join(worktreePath, AdversarialIncrementFileName)
+}
+
+// ParseAdversarialIncrementFile reads and parses an increment file
+func ParseAdversarialIncrementFile(worktreePath string) (*AdversarialIncrementFile, error) {
+	path := AdversarialIncrementFilePath(worktreePath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var increment AdversarialIncrementFile
+	if err := json.Unmarshal(data, &increment); err != nil {
+		return nil, fmt.Errorf("failed to parse adversarial increment JSON: %w", err)
+	}
+
+	// Validate required fields
+	if increment.Round < 1 {
+		return nil, fmt.Errorf("invalid round number in increment file: %d (must be >= 1)", increment.Round)
+	}
+	if increment.Status != "ready_for_review" && increment.Status != "failed" {
+		return nil, fmt.Errorf("invalid status in increment file: %q (expected 'ready_for_review' or 'failed')", increment.Status)
+	}
+
+	return &increment, nil
+}
+
+// AdversarialReviewFileName is the sentinel file the reviewer writes after review
+const AdversarialReviewFileName = ".claudio-adversarial-review.json"
+
+// AdversarialReviewFile represents the reviewer's feedback
+type AdversarialReviewFile struct {
+	Round           int      `json:"round"`            // Which iteration this review is for
+	Approved        bool     `json:"approved"`         // True if work is satisfactory
+	Score           int      `json:"score"`            // Quality score 1-10
+	Strengths       []string `json:"strengths"`        // What was done well
+	Issues          []string `json:"issues"`           // Critical problems that must be fixed
+	Suggestions     []string `json:"suggestions"`      // Optional improvements
+	Summary         string   `json:"summary"`          // Overall assessment
+	RequiredChanges []string `json:"required_changes"` // Specific changes needed (if not approved)
+}
+
+// AdversarialReviewFilePath returns the full path to the review file
+func AdversarialReviewFilePath(worktreePath string) string {
+	return filepath.Join(worktreePath, AdversarialReviewFileName)
+}
+
+// ParseAdversarialReviewFile reads and parses a review file
+func ParseAdversarialReviewFile(worktreePath string) (*AdversarialReviewFile, error) {
+	path := AdversarialReviewFilePath(worktreePath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var review AdversarialReviewFile
+	if err := json.Unmarshal(data, &review); err != nil {
+		return nil, fmt.Errorf("failed to parse adversarial review JSON: %w", err)
+	}
+
+	// Validate required fields
+	if review.Round < 1 {
+		return nil, fmt.Errorf("invalid round number in review file: %d (must be >= 1)", review.Round)
+	}
+	if review.Score < 1 || review.Score > 10 {
+		return nil, fmt.Errorf("invalid score in review file: %d (must be 1-10)", review.Score)
+	}
+
+	return &review, nil
+}
+
+// AdversarialManager manages the execution of an adversarial review session
+type AdversarialManager struct {
+	session     *AdversarialSession
+	orch        *Orchestrator
+	baseSession *Session
+	logger      *logging.Logger
+
+	// Event handling
+	eventCallback func(AdversarialEvent)
+
+	// Synchronization
+	mu sync.RWMutex
+}
+
+// AdversarialEventType represents the type of adversarial event
+type AdversarialEventType string
+
+const (
+	EventAdversarialImplementerStarted AdversarialEventType = "implementer_started"
+	EventAdversarialIncrementReady     AdversarialEventType = "increment_ready"
+	EventAdversarialReviewerStarted    AdversarialEventType = "reviewer_started"
+	EventAdversarialReviewReady        AdversarialEventType = "review_ready"
+	EventAdversarialApproved           AdversarialEventType = "approved"
+	EventAdversarialRejected           AdversarialEventType = "rejected"
+	EventAdversarialPhaseChange        AdversarialEventType = "phase_change"
+	EventAdversarialComplete           AdversarialEventType = "complete"
+	EventAdversarialFailed             AdversarialEventType = "failed"
+)
+
+// AdversarialEvent represents an event from the adversarial manager
+type AdversarialEvent struct {
+	Type       AdversarialEventType `json:"type"`
+	Round      int                  `json:"round,omitempty"`
+	InstanceID string               `json:"instance_id,omitempty"`
+	Message    string               `json:"message,omitempty"`
+	Timestamp  time.Time            `json:"timestamp"`
+}
+
+// NewAdversarialManager creates a new adversarial manager
+func NewAdversarialManager(orch *Orchestrator, baseSession *Session, advSession *AdversarialSession, logger *logging.Logger) *AdversarialManager {
+	if logger == nil {
+		logger = logging.NopLogger()
+	}
+	return &AdversarialManager{
+		session:     advSession,
+		orch:        orch,
+		baseSession: baseSession,
+		logger:      logger.WithPhase("adversarial"),
+	}
+}
+
+// SetEventCallback sets the callback for adversarial events
+func (m *AdversarialManager) SetEventCallback(cb func(AdversarialEvent)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.eventCallback = cb
+}
+
+// Session returns the adversarial session
+func (m *AdversarialManager) Session() *AdversarialSession {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.session
+}
+
+// emitEvent sends an event to the callback
+func (m *AdversarialManager) emitEvent(event AdversarialEvent) {
+	event.Timestamp = time.Now()
+
+	m.mu.RLock()
+	cb := m.eventCallback
+	m.mu.RUnlock()
+
+	if cb != nil {
+		cb(event)
+	}
+}
+
+// SetPhase updates the session phase and emits an event
+func (m *AdversarialManager) SetPhase(phase AdversarialPhase) {
+	m.mu.Lock()
+	m.session.Phase = phase
+	m.mu.Unlock()
+
+	m.emitEvent(AdversarialEvent{
+		Type:    EventAdversarialPhaseChange,
+		Message: string(phase),
+	})
+}
+
+// StartRound begins a new implement-review round
+func (m *AdversarialManager) StartRound() {
+	m.mu.Lock()
+	round := AdversarialRound{
+		Round:     m.session.CurrentRound,
+		StartedAt: time.Now(),
+	}
+	m.session.History = append(m.session.History, round)
+	m.mu.Unlock()
+
+	m.logger.Info("round started", "round", m.session.CurrentRound)
+}
+
+// RecordIncrement records an increment submission for the current round
+func (m *AdversarialManager) RecordIncrement(increment *AdversarialIncrementFile) {
+	m.mu.Lock()
+	if len(m.session.History) > 0 {
+		m.session.History[len(m.session.History)-1].Increment = increment
+	}
+	m.mu.Unlock()
+
+	m.logger.Info("increment recorded",
+		"round", increment.Round,
+		"files_modified", len(increment.FilesModified),
+	)
+
+	m.emitEvent(AdversarialEvent{
+		Type:    EventAdversarialIncrementReady,
+		Round:   increment.Round,
+		Message: increment.Summary,
+	})
+}
+
+// RecordReview records a review for the current round
+func (m *AdversarialManager) RecordReview(review *AdversarialReviewFile) {
+	m.mu.Lock()
+	now := time.Now()
+	if len(m.session.History) > 0 {
+		m.session.History[len(m.session.History)-1].Review = review
+		m.session.History[len(m.session.History)-1].ReviewedAt = &now
+	}
+	m.mu.Unlock()
+
+	m.logger.Info("review recorded",
+		"round", review.Round,
+		"approved", review.Approved,
+		"score", review.Score,
+	)
+
+	if review.Approved {
+		m.emitEvent(AdversarialEvent{
+			Type:    EventAdversarialApproved,
+			Round:   review.Round,
+			Message: review.Summary,
+		})
+	} else {
+		m.emitEvent(AdversarialEvent{
+			Type:    EventAdversarialRejected,
+			Round:   review.Round,
+			Message: fmt.Sprintf("Issues: %d, Score: %d/10", len(review.Issues), review.Score),
+		})
+	}
+}
+
+// NextRound advances to the next round
+func (m *AdversarialManager) NextRound() {
+	m.mu.Lock()
+	m.session.CurrentRound++
+	m.mu.Unlock()
+
+	m.logger.Info("advancing to next round", "round", m.session.CurrentRound)
+}
+
+// IsMaxIterationsReached checks if the max iterations limit has been reached
+func (m *AdversarialManager) IsMaxIterationsReached() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.session.Config.MaxIterations == 0 {
+		return false // No limit
+	}
+	return m.session.CurrentRound > m.session.Config.MaxIterations
+}
+
+// AdversarialImplementerPromptTemplate is the prompt for the implementer instance
+const AdversarialImplementerPromptTemplate = `You are the IMPLEMENTER in an adversarial review workflow.
+
+## Task
+%s
+
+## Your Role
+You are responsible for implementing the solution. A critical REVIEWER will examine your work thoroughly after each increment. Your goal is to produce high-quality, well-tested code that can withstand rigorous scrutiny.
+
+## Current Round: %d
+
+%s
+
+## Process
+1. Implement the required changes
+2. Ensure your code is complete, tested, and follows best practices
+3. When ready for review, write the increment file (details below)
+4. Wait for reviewer feedback (if not approved, you'll receive specific issues to fix)
+
+## CRITICAL: Increment File Requirement
+
+**YOUR WORK IS NOT READY FOR REVIEW UNTIL YOU WRITE THE INCREMENT FILE.**
+
+The reviewer is waiting for this file. You MUST write it when your implementation is ready.
+
+**File:** ` + "`" + AdversarialIncrementFileName + "`" + ` (in your worktree root)
+
+**Required JSON structure:**
+` + "```json" + `
+{
+  "round": %d,
+  "status": "ready_for_review",
+  "summary": "Brief summary of what you implemented",
+  "files_modified": ["file1.go", "file2.go"],
+  "approach": "Description of the approach you took and why",
+  "notes": "Any concerns or questions for the reviewer"
+}
+` + "```" + `
+
+**Rules:**
+- Set status to "ready_for_review" when your implementation is complete
+- Set status to "failed" if you cannot complete the task
+- Be thorough in your summary - the reviewer will read it before examining code
+- List ALL files you modified
+
+**REMINDER: Write ` + "`" + AdversarialIncrementFileName + "`" + ` when ready for review.**`
+
+// AdversarialReviewerPromptTemplate is the prompt for the reviewer instance
+const AdversarialReviewerPromptTemplate = `You are a CRITICAL REVIEWER in an adversarial review workflow.
+
+## Original Task
+%s
+
+## Your Role
+You must thoroughly and critically examine the implementer's work. Be demanding - your job is to find problems, not to approve work prematurely. Only approve when the implementation truly meets all requirements with high quality.
+
+## Current Round: %d
+
+## Implementer's Submission
+%s
+
+## Review Guidelines
+1. **Examine the code thoroughly** - Read all modified files, understand the approach
+2. **Be critical** - Look for bugs, edge cases, security issues, performance problems
+3. **Check completeness** - Does it fully solve the task? Are there missing pieces?
+4. **Verify quality** - Is the code clean, well-structured, properly tested?
+5. **Consider maintainability** - Will this code be easy to understand and modify?
+
+## What to Look For
+- Logic errors and bugs
+- Missing error handling
+- Security vulnerabilities
+- Performance issues
+- Code style violations
+- Missing or inadequate tests
+- Incomplete implementations
+- Edge cases not handled
+
+## CRITICAL: Review File Requirement
+
+**YOUR REVIEW IS NOT COMPLETE UNTIL YOU WRITE THE REVIEW FILE.**
+
+The system is waiting for this file to continue the workflow.
+
+**File:** ` + "`" + AdversarialReviewFileName + "`" + ` (in your worktree root)
+
+**Required JSON structure:**
+` + "```json" + `
+{
+  "round": %d,
+  "approved": false,
+  "score": 7,
+  "strengths": ["Good error handling", "Clean code structure"],
+  "issues": ["Missing null check in line 42", "No tests for edge case X"],
+  "suggestions": ["Consider adding logging", "Could optimize the loop"],
+  "summary": "Overall assessment of the implementation",
+  "required_changes": ["Fix the null check", "Add tests for edge case X"]
+}
+` + "```" + `
+
+**Rules:**
+- Set approved to true ONLY if the implementation is truly ready (score >= 8, no critical issues)
+- Score from 1-10: 1-4 = major problems, 5-6 = needs work, 7-8 = good, 9-10 = excellent
+- Issues should list specific problems that MUST be fixed
+- Suggestions are optional improvements (not required for approval)
+- required_changes should be specific and actionable
+
+**IMPORTANT:** Do NOT approve work that has any significant issues. The implementer can iterate.
+
+**REMINDER: Write ` + "`" + AdversarialReviewFileName + "`" + ` when your review is complete.**`
+
+// AdversarialPreviousFeedbackTemplate is appended to show previous review feedback
+const AdversarialPreviousFeedbackTemplate = `
+
+## Previous Review Feedback (Round %d)
+The reviewer found the following issues that must be addressed:
+
+**Score:** %d/10
+
+**Issues to Fix:**
+%s
+
+**Required Changes:**
+%s
+
+**Reviewer's Summary:**
+%s
+
+Please address ALL the issues above in this iteration.`
+
+// FormatAdversarialImplementerPrompt creates the full prompt for the implementer
+func FormatAdversarialImplementerPrompt(task string, round int, previousReview *AdversarialReviewFile) string {
+	var previousFeedback string
+	if previousReview != nil {
+		issues := ""
+		for i, issue := range previousReview.Issues {
+			issues += fmt.Sprintf("  %d. %s\n", i+1, issue)
+		}
+		if issues == "" {
+			issues = "  (none specified)\n"
+		}
+
+		changes := ""
+		for i, change := range previousReview.RequiredChanges {
+			changes += fmt.Sprintf("  %d. %s\n", i+1, change)
+		}
+		if changes == "" {
+			changes = "  (none specified)\n"
+		}
+
+		previousFeedback = fmt.Sprintf(AdversarialPreviousFeedbackTemplate,
+			previousReview.Round,
+			previousReview.Score,
+			issues,
+			changes,
+			previousReview.Summary,
+		)
+	}
+
+	return fmt.Sprintf(AdversarialImplementerPromptTemplate, task, round, previousFeedback, round)
+}
+
+// FormatAdversarialReviewerPrompt creates the full prompt for the reviewer
+func FormatAdversarialReviewerPrompt(task string, round int, increment *AdversarialIncrementFile) string {
+	submission := fmt.Sprintf(`**Summary:** %s
+
+**Approach:** %s
+
+**Files Modified:** %v
+
+**Notes from Implementer:** %s`,
+		increment.Summary,
+		increment.Approach,
+		increment.FilesModified,
+		increment.Notes,
+	)
+
+	return fmt.Sprintf(AdversarialReviewerPromptTemplate, task, round, submission, round)
+}

--- a/internal/orchestrator/adversarial_coordinator.go
+++ b/internal/orchestrator/adversarial_coordinator.go
@@ -1,0 +1,506 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/logging"
+	"github.com/Iron-Ham/claudio/internal/util"
+)
+
+// AdversarialCoordinatorCallbacks holds callbacks for coordinator events
+type AdversarialCoordinatorCallbacks struct {
+	// OnPhaseChange is called when the adversarial phase changes
+	OnPhaseChange func(phase AdversarialPhase)
+
+	// OnImplementerStart is called when the implementer begins a round
+	OnImplementerStart func(round int, instanceID string)
+
+	// OnIncrementReady is called when the implementer submits work for review
+	OnIncrementReady func(round int, increment *AdversarialIncrementFile)
+
+	// OnReviewerStart is called when the reviewer begins review
+	OnReviewerStart func(round int, instanceID string)
+
+	// OnReviewReady is called when the reviewer completes review
+	OnReviewReady func(round int, review *AdversarialReviewFile)
+
+	// OnApproved is called when the reviewer approves the implementation
+	OnApproved func(round int, review *AdversarialReviewFile)
+
+	// OnRejected is called when the reviewer rejects and requests changes
+	OnRejected func(round int, review *AdversarialReviewFile)
+
+	// OnComplete is called when the adversarial session completes
+	OnComplete func(success bool, summary string)
+}
+
+// AdversarialCoordinator orchestrates the execution of an adversarial review session
+type AdversarialCoordinator struct {
+	manager     *AdversarialManager
+	orch        *Orchestrator
+	baseSession *Session
+	callbacks   *AdversarialCoordinatorCallbacks
+	logger      *logging.Logger
+
+	// Running state
+	ctx        context.Context
+	cancelFunc context.CancelFunc
+	wg         sync.WaitGroup
+	mu         sync.RWMutex
+
+	// State tracking
+	implementerWorktree string // Worktree path for implementer
+	reviewerWorktree    string // Worktree path for reviewer (same as implementer)
+}
+
+// NewAdversarialCoordinator creates a new coordinator for an adversarial session
+func NewAdversarialCoordinator(orch *Orchestrator, baseSession *Session, advSession *AdversarialSession, logger *logging.Logger) *AdversarialCoordinator {
+	if logger == nil {
+		logger = logging.NopLogger()
+	}
+	manager := NewAdversarialManager(orch, baseSession, advSession, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	sessionLogger := logger.WithSession(advSession.ID).WithPhase("adversarial-coordinator")
+
+	return &AdversarialCoordinator{
+		manager:     manager,
+		orch:        orch,
+		baseSession: baseSession,
+		logger:      sessionLogger,
+		ctx:         ctx,
+		cancelFunc:  cancel,
+	}
+}
+
+// SetCallbacks sets the coordinator callbacks
+func (c *AdversarialCoordinator) SetCallbacks(cb *AdversarialCoordinatorCallbacks) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.callbacks = cb
+}
+
+// Manager returns the underlying adversarial manager
+func (c *AdversarialCoordinator) Manager() *AdversarialManager {
+	return c.manager
+}
+
+// Session returns the adversarial session
+func (c *AdversarialCoordinator) Session() *AdversarialSession {
+	return c.manager.Session()
+}
+
+// notifyPhaseChange notifies callbacks of phase change
+func (c *AdversarialCoordinator) notifyPhaseChange(phase AdversarialPhase) {
+	session := c.Session()
+	fromPhase := session.Phase
+
+	c.manager.SetPhase(phase)
+
+	c.logger.Info("phase changed",
+		"from_phase", string(fromPhase),
+		"to_phase", string(phase),
+		"session_id", session.ID,
+	)
+
+	// Persist the phase change
+	if err := c.orch.SaveSession(); err != nil {
+		c.logger.Error("failed to persist phase change", "error", err)
+	}
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnPhaseChange != nil {
+		cb.OnPhaseChange(phase)
+	}
+}
+
+// notifyImplementerStart notifies callbacks of implementer start
+func (c *AdversarialCoordinator) notifyImplementerStart(round int, instanceID string) {
+	c.logger.Info("implementer started",
+		"round", round,
+		"instance_id", instanceID,
+	)
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnImplementerStart != nil {
+		cb.OnImplementerStart(round, instanceID)
+	}
+}
+
+// notifyIncrementReady notifies callbacks of increment completion
+func (c *AdversarialCoordinator) notifyIncrementReady(round int, increment *AdversarialIncrementFile) {
+	c.manager.RecordIncrement(increment)
+
+	// Persist increment
+	if err := c.orch.SaveSession(); err != nil {
+		c.logger.Error("failed to persist increment", "round", round, "error", err)
+	}
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnIncrementReady != nil {
+		cb.OnIncrementReady(round, increment)
+	}
+}
+
+// notifyReviewerStart notifies callbacks of reviewer start
+func (c *AdversarialCoordinator) notifyReviewerStart(round int, instanceID string) {
+	c.logger.Info("reviewer started",
+		"round", round,
+		"instance_id", instanceID,
+	)
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnReviewerStart != nil {
+		cb.OnReviewerStart(round, instanceID)
+	}
+}
+
+// notifyReviewReady notifies callbacks of review completion
+func (c *AdversarialCoordinator) notifyReviewReady(round int, review *AdversarialReviewFile) {
+	c.manager.RecordReview(review)
+
+	// Persist review
+	if err := c.orch.SaveSession(); err != nil {
+		c.logger.Error("failed to persist review", "round", round, "error", err)
+	}
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnReviewReady != nil {
+		cb.OnReviewReady(round, review)
+	}
+
+	// Also notify approved/rejected
+	if review.Approved {
+		if cb != nil && cb.OnApproved != nil {
+			cb.OnApproved(round, review)
+		}
+	} else {
+		if cb != nil && cb.OnRejected != nil {
+			cb.OnRejected(round, review)
+		}
+	}
+}
+
+// notifyComplete notifies callbacks of completion
+func (c *AdversarialCoordinator) notifyComplete(success bool, summary string) {
+	c.logger.Info("adversarial session complete",
+		"success", success,
+		"summary", summary,
+	)
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnComplete != nil {
+		cb.OnComplete(success, summary)
+	}
+}
+
+// StartImplementer starts the implementer instance for the current round
+func (c *AdversarialCoordinator) StartImplementer() error {
+	session := c.Session()
+	task := session.Task
+	round := session.CurrentRound
+
+	c.logger.Info("starting implementer",
+		"task", util.TruncateString(task, 100),
+		"round", round,
+	)
+
+	// Initialize timing
+	if session.StartedAt == nil {
+		now := time.Now()
+		session.StartedAt = &now
+	}
+
+	// Get previous review feedback if this isn't the first round
+	// Must be done BEFORE StartRound() which appends a new round to History
+	var previousReview *AdversarialReviewFile
+	if round > 1 && len(session.History) > 0 {
+		previousReview = session.History[len(session.History)-1].Review
+	}
+
+	// Start a new round
+	c.manager.StartRound()
+
+	// Build the implementer prompt
+	prompt := FormatAdversarialImplementerPrompt(task, round, previousReview)
+
+	// Find the adversarial group to add instances to
+	var advGroup *InstanceGroup
+	if session.GroupID != "" {
+		advGroup = c.baseSession.GetGroup(session.GroupID)
+	}
+	if advGroup == nil {
+		advGroup = c.baseSession.GetGroupBySessionType(SessionTypeAdversarial)
+	}
+
+	// Create instance for implementer
+	var inst *Instance
+	var err error
+
+	if round == 1 {
+		// First round - create a fresh worktree
+		inst, err = c.orch.AddInstance(c.baseSession, prompt)
+		if err != nil {
+			return fmt.Errorf("failed to create implementer instance: %w", err)
+		}
+		c.implementerWorktree = inst.WorktreePath
+		c.reviewerWorktree = inst.WorktreePath // Reviewer will use same worktree
+	} else {
+		// Subsequent rounds - reuse the same worktree
+		inst, err = c.orch.AddInstanceToWorktree(c.baseSession, prompt, c.implementerWorktree, "")
+		if err != nil {
+			return fmt.Errorf("failed to create implementer instance for round %d: %w", round, err)
+		}
+	}
+
+	// Add instance to the adversarial group for sidebar display
+	if advGroup != nil {
+		advGroup.AddInstance(inst.ID)
+	}
+
+	// Store implementer ID
+	session.ImplementerID = inst.ID
+
+	// Transition to implementing phase
+	c.notifyPhaseChange(PhaseAdversarialImplementing)
+
+	// Start the instance
+	if err := c.orch.StartInstance(inst); err != nil {
+		return fmt.Errorf("failed to start implementer: %w", err)
+	}
+
+	c.notifyImplementerStart(round, inst.ID)
+
+	// Persist session state
+	if err := c.orch.SaveSession(); err != nil {
+		c.logger.Error("failed to persist session after starting implementer", "error", err)
+	}
+
+	return nil
+}
+
+// StartReviewer starts the reviewer instance for the current round
+func (c *AdversarialCoordinator) StartReviewer(increment *AdversarialIncrementFile) error {
+	session := c.Session()
+	task := session.Task
+	round := session.CurrentRound
+
+	c.logger.Info("starting reviewer", "round", round)
+
+	// Build the reviewer prompt
+	prompt := FormatAdversarialReviewerPrompt(task, round, increment)
+
+	// Find the adversarial group
+	var advGroup *InstanceGroup
+	if session.GroupID != "" {
+		advGroup = c.baseSession.GetGroup(session.GroupID)
+	}
+	if advGroup == nil {
+		advGroup = c.baseSession.GetGroupBySessionType(SessionTypeAdversarial)
+	}
+
+	// Create reviewer instance in the same worktree
+	inst, err := c.orch.AddInstanceToWorktree(c.baseSession, prompt, c.reviewerWorktree, "")
+	if err != nil {
+		return fmt.Errorf("failed to create reviewer instance: %w", err)
+	}
+
+	// Add instance to the adversarial group
+	if advGroup != nil {
+		advGroup.AddInstance(inst.ID)
+	}
+
+	// Store reviewer ID
+	session.ReviewerID = inst.ID
+
+	// Transition to reviewing phase
+	c.notifyPhaseChange(PhaseAdversarialReviewing)
+
+	// Start the instance
+	if err := c.orch.StartInstance(inst); err != nil {
+		return fmt.Errorf("failed to start reviewer: %w", err)
+	}
+
+	c.notifyReviewerStart(round, inst.ID)
+
+	// Persist session state
+	if err := c.orch.SaveSession(); err != nil {
+		c.logger.Error("failed to persist session after starting reviewer", "error", err)
+	}
+
+	return nil
+}
+
+// CheckIncrementReady checks if the implementer has written their increment file
+func (c *AdversarialCoordinator) CheckIncrementReady() (bool, error) {
+	if c.implementerWorktree == "" {
+		return false, nil
+	}
+
+	incrementPath := AdversarialIncrementFilePath(c.implementerWorktree)
+	_, err := os.Stat(incrementPath)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("failed to check increment file: %w", err)
+}
+
+// CheckReviewReady checks if the reviewer has written their review file
+func (c *AdversarialCoordinator) CheckReviewReady() (bool, error) {
+	if c.reviewerWorktree == "" {
+		return false, nil
+	}
+
+	reviewPath := AdversarialReviewFilePath(c.reviewerWorktree)
+	_, err := os.Stat(reviewPath)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("failed to check review file: %w", err)
+}
+
+// ProcessIncrementCompletion handles when the implementer completes
+func (c *AdversarialCoordinator) ProcessIncrementCompletion() error {
+	session := c.Session()
+	round := session.CurrentRound
+
+	// Parse the increment file
+	increment, err := ParseAdversarialIncrementFile(c.implementerWorktree)
+	if err != nil {
+		c.notifyPhaseChange(PhaseAdversarialFailed)
+		session.Error = fmt.Sprintf("failed to parse increment file: %v", err)
+		return err
+	}
+
+	// Validate round number
+	if increment.Round != round {
+		c.logger.Warn("increment round mismatch",
+			"expected", round,
+			"got", increment.Round,
+		)
+	}
+
+	// Check for failure status
+	if increment.Status == "failed" {
+		c.notifyPhaseChange(PhaseAdversarialFailed)
+		session.Error = fmt.Sprintf("implementer failed: %s", increment.Summary)
+		return fmt.Errorf("implementer reported failure: %s", increment.Summary)
+	}
+
+	c.notifyIncrementReady(round, increment)
+
+	// Clear the increment file so it's fresh for next round
+	if err := os.Remove(AdversarialIncrementFilePath(c.implementerWorktree)); err != nil && !os.IsNotExist(err) {
+		c.logger.Warn("failed to remove increment file", "error", err)
+	}
+
+	// Start the reviewer
+	return c.StartReviewer(increment)
+}
+
+// ProcessReviewCompletion handles when the reviewer completes
+func (c *AdversarialCoordinator) ProcessReviewCompletion() error {
+	session := c.Session()
+	round := session.CurrentRound
+
+	// Parse the review file
+	review, err := ParseAdversarialReviewFile(c.reviewerWorktree)
+	if err != nil {
+		c.notifyPhaseChange(PhaseAdversarialFailed)
+		session.Error = fmt.Sprintf("failed to parse review file: %v", err)
+		return err
+	}
+
+	// Validate round number
+	if review.Round != round {
+		c.logger.Warn("review round mismatch",
+			"expected", round,
+			"got", review.Round,
+		)
+	}
+
+	c.notifyReviewReady(round, review)
+
+	// Clear the review file so it's fresh for next round
+	if err := os.Remove(AdversarialReviewFilePath(c.reviewerWorktree)); err != nil && !os.IsNotExist(err) {
+		c.logger.Warn("failed to remove review file", "error", err)
+	}
+
+	if review.Approved {
+		// Work approved - complete the session
+		now := time.Now()
+		session.CompletedAt = &now
+		c.notifyPhaseChange(PhaseAdversarialApproved)
+		c.notifyPhaseChange(PhaseAdversarialComplete)
+
+		summary := fmt.Sprintf("Approved after %d round(s). Final score: %d/10. %s",
+			round, review.Score, review.Summary)
+		c.notifyComplete(true, summary)
+	} else {
+		// Work rejected - check if we should continue
+		if c.manager.IsMaxIterationsReached() {
+			c.notifyPhaseChange(PhaseAdversarialFailed)
+			session.Error = fmt.Sprintf("max iterations reached (%d) without approval", session.Config.MaxIterations)
+			c.notifyComplete(false, session.Error)
+			return fmt.Errorf("%s", session.Error)
+		}
+
+		// Advance to next round
+		c.manager.NextRound()
+
+		// Start implementer again with the review feedback
+		return c.StartImplementer()
+	}
+
+	return nil
+}
+
+// Stop stops the adversarial execution
+func (c *AdversarialCoordinator) Stop() {
+	c.cancelFunc()
+	c.wg.Wait()
+}
+
+// GetImplementerWorktree returns the implementer's worktree path
+func (c *AdversarialCoordinator) GetImplementerWorktree() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.implementerWorktree
+}
+
+// SetWorktrees sets the worktree paths (used when restoring session)
+func (c *AdversarialCoordinator) SetWorktrees(worktree string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.implementerWorktree = worktree
+	c.reviewerWorktree = worktree
+}

--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -139,6 +139,10 @@ type Session struct {
 	// Each tripleshot has its own group and coordinator.
 	TripleShots []*TripleShotSession `json:"triple_shots,omitempty"`
 
+	// AdversarialSessions holds multiple concurrent adversarial review sessions.
+	// Each adversarial session has its own group and coordinator.
+	AdversarialSessions []*AdversarialSession `json:"adversarial_sessions,omitempty"`
+
 	// Recovery state tracking - helps detect and recover interrupted sessions
 	RecoveryState   RecoveryState `json:"recovery_state,omitempty"`   // Current recovery state
 	LastActiveAt    *time.Time    `json:"last_active_at,omitempty"`   // Last time any instance had activity

--- a/internal/orchestrator/session_type.go
+++ b/internal/orchestrator/session_type.go
@@ -19,6 +19,10 @@ const (
 
 	// SessionTypeTripleShot represents a :tripleshot competing solutions session.
 	SessionTypeTripleShot SessionType = "tripleshot"
+
+	// SessionTypeAdversarial represents an adversarial review session with
+	// implementer-reviewer feedback loop.
+	SessionTypeAdversarial SessionType = "adversarial"
 )
 
 // Icon returns the display icon for this session type.
@@ -32,6 +36,8 @@ func (t SessionType) Icon() string {
 		return "\u26a1" // ⚡ lightning
 	case SessionTypeTripleShot:
 		return "\u25b3" // △ triangle
+	case SessionTypeAdversarial:
+		return "\u2694" // ⚔ crossed swords
 	default:
 		return "\u25cf" // ● filled circle (standard)
 	}
@@ -46,7 +52,7 @@ func (t SessionType) GroupingMode() string {
 	switch t {
 	case SessionTypePlan:
 		return "shared"
-	case SessionTypePlanMulti, SessionTypeUltraPlan, SessionTypeTripleShot:
+	case SessionTypePlanMulti, SessionTypeUltraPlan, SessionTypeTripleShot, SessionTypeAdversarial:
 		return "own"
 	default:
 		return "none"
@@ -57,7 +63,7 @@ func (t SessionType) GroupingMode() string {
 // (multiple instances coordinated together).
 func (t SessionType) IsOrchestratedType() bool {
 	switch t {
-	case SessionTypeUltraPlan, SessionTypeTripleShot, SessionTypePlanMulti:
+	case SessionTypeUltraPlan, SessionTypeTripleShot, SessionTypePlanMulti, SessionTypeAdversarial:
 		return true
 	default:
 		return false

--- a/internal/tui/adversarial.go
+++ b/internal/tui/adversarial.go
@@ -1,0 +1,252 @@
+package tui
+
+import (
+	"fmt"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	tuimsg "github.com/Iron-Ham/claudio/internal/tui/msg"
+	"github.com/Iron-Ham/claudio/internal/tui/view"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// AdversarialState is an alias to the view package's AdversarialState.
+// This allows the main tui package to use the state without importing view.
+type AdversarialState = view.AdversarialState
+
+// dispatchAdversarialCompletionChecks returns commands to check adversarial completion
+// files asynchronously. This avoids blocking the UI event loop with file I/O.
+func (m *Model) dispatchAdversarialCompletionChecks() []tea.Cmd {
+	if m.adversarial == nil || !m.adversarial.HasActiveCoordinators() {
+		return nil
+	}
+
+	var cmds []tea.Cmd
+
+	// Dispatch async check for each coordinator
+	for groupID, coordinator := range m.adversarial.Coordinators {
+		session := coordinator.Session()
+		if session == nil {
+			continue
+		}
+
+		// Only check if in a phase that requires polling
+		switch session.Phase {
+		case orchestrator.PhaseAdversarialImplementing, orchestrator.PhaseAdversarialReviewing:
+			cmds = append(cmds, tuimsg.CheckAdversarialCompletionAsync(coordinator, groupID))
+		}
+	}
+
+	return cmds
+}
+
+// handleAdversarialCheckResult processes the async completion check results.
+// This is called when a CheckAdversarialCompletionAsync command completes.
+func (m *Model) handleAdversarialCheckResult(msg tuimsg.AdversarialCheckResultMsg) (tea.Model, tea.Cmd) {
+	if m.adversarial == nil {
+		return m, nil
+	}
+
+	// Find the coordinator for this result
+	coordinator := m.adversarial.GetCoordinatorForGroup(msg.GroupID)
+	if coordinator == nil {
+		if m.logger != nil {
+			m.logger.Warn("adversarial check result for unknown coordinator",
+				"group_id", msg.GroupID,
+				"phase", msg.Phase,
+			)
+		}
+		return m, nil
+	}
+
+	session := coordinator.Session()
+	if session == nil {
+		if m.logger != nil {
+			m.logger.Warn("adversarial coordinator has nil session",
+				"group_id", msg.GroupID,
+			)
+		}
+		return m, nil
+	}
+
+	switch msg.Phase {
+	case orchestrator.PhaseAdversarialImplementing:
+		return m.processAdversarialIncrementCheck(coordinator, msg)
+
+	case orchestrator.PhaseAdversarialReviewing:
+		return m.processAdversarialReviewCheck(coordinator, msg)
+
+	case orchestrator.PhaseAdversarialFailed:
+		// Show error message for failed adversarial session
+		if session.Error != "" && m.errorMessage == "" {
+			m.errorMessage = "Adversarial review failed: " + session.Error
+		}
+		return m, nil
+	}
+
+	return m, nil
+}
+
+// processAdversarialIncrementCheck handles completion check results for the increment file.
+// Returns async command to process the increment file if ready.
+func (m *Model) processAdversarialIncrementCheck(
+	coordinator *orchestrator.AdversarialCoordinator,
+	msg tuimsg.AdversarialCheckResultMsg,
+) (tea.Model, tea.Cmd) {
+	if msg.IncrementError != nil {
+		if m.logger != nil {
+			m.logger.Warn("failed to check increment completion",
+				"error", msg.IncrementError,
+				"group_id", msg.GroupID,
+			)
+		}
+		return m, nil
+	}
+
+	if msg.IncrementReady {
+		// Dispatch async command to process the increment file
+		return m, tuimsg.ProcessAdversarialIncrementAsync(coordinator, msg.GroupID)
+	}
+
+	return m, nil
+}
+
+// processAdversarialReviewCheck handles completion check results for the review file.
+// Returns async command to process the review file if ready.
+func (m *Model) processAdversarialReviewCheck(
+	coordinator *orchestrator.AdversarialCoordinator,
+	msg tuimsg.AdversarialCheckResultMsg,
+) (tea.Model, tea.Cmd) {
+	if msg.ReviewError != nil {
+		if m.logger != nil {
+			m.logger.Warn("failed to check review completion",
+				"error", msg.ReviewError,
+				"group_id", msg.GroupID,
+			)
+		}
+		return m, nil
+	}
+
+	if msg.ReviewReady {
+		// Dispatch async command to process the review file
+		return m, tuimsg.ProcessAdversarialReviewAsync(coordinator, msg.GroupID)
+	}
+
+	return m, nil
+}
+
+// handleAdversarialIncrementProcessed handles the result of async increment file processing.
+func (m *Model) handleAdversarialIncrementProcessed(msg tuimsg.AdversarialIncrementProcessedMsg) (tea.Model, tea.Cmd) {
+	if m.adversarial == nil {
+		return m, nil
+	}
+
+	// Find the coordinator for this result
+	coordinator := m.adversarial.GetCoordinatorForGroup(msg.GroupID)
+	if coordinator == nil {
+		if m.logger != nil {
+			m.logger.Warn("adversarial increment processed for unknown coordinator",
+				"group_id", msg.GroupID,
+			)
+		}
+		return m, nil
+	}
+
+	if msg.Err != nil {
+		if m.logger != nil {
+			m.logger.Error("failed to process increment file",
+				"error", msg.Err,
+				"group_id", msg.GroupID,
+			)
+		}
+		m.errorMessage = "Failed to process implementer submission"
+		return m, nil
+	}
+
+	// The coordinator's ProcessIncrementCompletion automatically starts the reviewer
+	session := coordinator.Session()
+	if session != nil {
+		m.infoMessage = fmt.Sprintf("Round %d: Implementation submitted, reviewer starting...", session.CurrentRound)
+	}
+
+	return m, nil
+}
+
+// handleAdversarialReviewProcessed handles the result of async review file processing.
+func (m *Model) handleAdversarialReviewProcessed(msg tuimsg.AdversarialReviewProcessedMsg) (tea.Model, tea.Cmd) {
+	if m.adversarial == nil {
+		return m, nil
+	}
+
+	// Find the coordinator for this result
+	coordinator := m.adversarial.GetCoordinatorForGroup(msg.GroupID)
+	if coordinator == nil {
+		if m.logger != nil {
+			m.logger.Warn("adversarial review processed for unknown coordinator",
+				"group_id", msg.GroupID,
+			)
+		}
+		return m, nil
+	}
+
+	if msg.Err != nil {
+		if m.logger != nil {
+			m.logger.Error("failed to process review file",
+				"error", msg.Err,
+				"group_id", msg.GroupID,
+			)
+		}
+		m.errorMessage = "Failed to process review"
+		return m, nil
+	}
+
+	session := coordinator.Session()
+	if session == nil {
+		if m.logger != nil {
+			m.logger.Warn("adversarial coordinator has nil session after review",
+				"group_id", msg.GroupID,
+			)
+		}
+		return m, nil
+	}
+
+	if msg.Approved {
+		m.infoMessage = fmt.Sprintf("Adversarial review complete! Approved after %d round(s) with score %d/10",
+			session.CurrentRound, msg.Score)
+		m.adversarial.NeedsNotification = true
+	} else {
+		m.infoMessage = fmt.Sprintf("Round %d review: Score %d/10 - Changes requested, starting next round...",
+			session.CurrentRound-1, msg.Score) // -1 because NextRound was already called
+	}
+
+	return m, nil
+}
+
+// cleanupAdversarial stops all adversarial coordinators and clears the adversarial state.
+func (m *Model) cleanupAdversarial() {
+	if m.adversarial == nil {
+		return
+	}
+
+	// Stop all coordinators to cancel their contexts
+	for _, coordinator := range m.adversarial.Coordinators {
+		if coordinator != nil {
+			coordinator.Stop()
+		}
+	}
+
+	// Clear TUI-level state
+	m.adversarial = nil
+
+	// Clear session-level adversarial state
+	if m.session != nil {
+		m.session.AdversarialSessions = nil
+	}
+}
+
+// GetAdversarialCoordinators returns all active adversarial coordinators.
+func (m Model) GetAdversarialCoordinators() []*orchestrator.AdversarialCoordinator {
+	if m.adversarial == nil {
+		return nil
+	}
+	return m.adversarial.GetAllCoordinators()
+}

--- a/internal/tui/keyhandler.go
+++ b/internal/tui/keyhandler.go
@@ -227,6 +227,7 @@ func (m Model) cancelTaskInput() Model {
 	m.addingDependentTask = false
 	m.dependentOnInstanceID = ""
 	m.startingTripleShot = false
+	m.startingAdversarial = false
 	m.taskInput = ""
 	m.taskInputCursor = 0
 	m.templateSuffix = ""        // Clear suffix on cancel
@@ -246,6 +247,7 @@ func (m Model) submitTaskInput() (tea.Model, tea.Cmd) {
 		dependsOn := m.dependentOnInstanceID
 		baseBranch := m.selectedBaseBranch
 		isTripleShot := m.startingTripleShot
+		isAdversarial := m.startingAdversarial
 		m = m.cancelTaskInput()
 
 		// Handle inline plan/ultraplan/multiplan objective submission
@@ -269,6 +271,11 @@ func (m Model) submitTaskInput() (tea.Model, tea.Cmd) {
 		// Handle triple-shot mode initiation
 		if isTripleShot {
 			return m.initiateTripleShotMode(task)
+		}
+
+		// Handle adversarial mode initiation
+		if isAdversarial {
+			return m.initiateAdversarialMode(task)
 		}
 
 		// Add instance asynchronously to avoid blocking UI during git worktree creation

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -248,6 +248,9 @@ type Model struct {
 	// Triple-shot mode (nil if not in triple-shot mode)
 	tripleShot *TripleShotState
 
+	// Adversarial review mode (nil if not in adversarial mode)
+	adversarial *view.AdversarialState
+
 	// Plan editor mode (nil if not in plan editor mode)
 	planEditor *PlanEditorState
 
@@ -278,6 +281,9 @@ type Model struct {
 
 	// Triple-shot task state (for :tripleshot command)
 	startingTripleShot bool // When true, taskInput will start a triple-shot session
+
+	// Adversarial task state (for :adversarial command)
+	startingAdversarial bool // When true, taskInput will start an adversarial session
 
 	errorMessage   string
 	infoMessage    string    // Non-error status message
@@ -348,6 +354,11 @@ func (m Model) IsUltraPlanMode() bool {
 // IsTripleShotMode returns true if there are any active tripleshot sessions.
 func (m Model) IsTripleShotMode() bool {
 	return m.tripleShot != nil && m.tripleShot.HasActiveCoordinators()
+}
+
+// IsAdversarialMode returns true if there are any active adversarial sessions.
+func (m Model) IsAdversarialMode() bool {
+	return m.adversarial != nil && m.adversarial.HasActiveCoordinators()
 }
 
 // IsInlinePlanMode returns true if there are any active inline plan sessions.

--- a/internal/tui/msg/types.go
+++ b/internal/tui/msg/types.go
@@ -145,3 +145,50 @@ type InlineMultiPlanFileCheckResultMsg struct {
 	StrategyName string
 	GroupID      string // Session group ID for matching to correct session
 }
+
+// AdversarialStartedMsg indicates adversarial session has started.
+type AdversarialStartedMsg struct{}
+
+// AdversarialErrorMsg indicates an error during adversarial operation.
+type AdversarialErrorMsg struct {
+	Err error
+}
+
+// AdversarialCheckResultMsg contains results from async completion file checks.
+// This allows the tick handler to dispatch async I/O and receive results
+// without blocking the UI event loop.
+type AdversarialCheckResultMsg struct {
+	// GroupID identifies which adversarial coordinator this result is for
+	GroupID string
+
+	// IncrementReady indicates whether the increment file exists
+	IncrementReady bool
+
+	// IncrementError is any error encountered checking the increment file
+	IncrementError error
+
+	// ReviewReady indicates whether the review file exists
+	ReviewReady bool
+
+	// ReviewError is any error encountered checking the review file
+	ReviewError error
+
+	// Phase is the current phase of the adversarial session
+	Phase orchestrator.AdversarialPhase
+}
+
+// AdversarialIncrementProcessedMsg contains the result of processing an increment file.
+// This is returned by processIncrementCompletionAsync after reading and parsing the file.
+type AdversarialIncrementProcessedMsg struct {
+	GroupID string
+	Err     error
+}
+
+// AdversarialReviewProcessedMsg contains the result of processing a review file.
+// This is returned by processReviewCompletionAsync after reading and parsing the file.
+type AdversarialReviewProcessedMsg struct {
+	GroupID  string
+	Approved bool
+	Score    int
+	Err      error
+}

--- a/internal/tui/panel/help.go
+++ b/internal/tui/panel/help.go
@@ -179,6 +179,12 @@ func DefaultHelpSections() []HelpSection {
 			},
 		},
 		{
+			Title: "Adversarial Mode",
+			Items: []HelpItem{
+				{Key: ":adversarial  :adv", Description: "Start implementer + reviewer feedback loop"},
+			},
+		},
+		{
 			Title: "Planning Modes (experimental)",
 			Items: []HelpItem{
 				{Key: ":plan", Description: "Start inline plan mode"},

--- a/internal/tui/panel/help_test.go
+++ b/internal/tui/panel/help_test.go
@@ -18,7 +18,7 @@ func TestHelpPanel_Render(t *testing.T) {
 			name: "renders with default sections",
 			state: &RenderState{
 				Width:  80,
-				Height: 100, // Large enough to show all sections
+				Height: 120, // Large enough to show all sections (increased for Adversarial Mode)
 			},
 			contains: []string{
 				"Claudio Help",
@@ -26,6 +26,7 @@ func TestHelpPanel_Render(t *testing.T) {
 				"Navigation",
 				"Instance Control",
 				"Instance Management",
+				"Adversarial Mode",
 				"View Commands",
 				"Terminal Pane",
 				"Input Mode",
@@ -188,6 +189,7 @@ func TestDefaultHelpSections(t *testing.T) {
 		"Instance Control",
 		"Instance Management",
 		"Triple-Shot Mode",
+		"Adversarial Mode",
 		"Planning Modes (experimental)",
 		"Group Management",
 		"View Commands",

--- a/internal/tui/view/adversarial.go
+++ b/internal/tui/view/adversarial.go
@@ -1,0 +1,397 @@
+package view
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/tui/styles"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Adversarial-specific style aliases for better readability
+var (
+	advHighlight = styles.Primary
+	advSuccess   = styles.Secondary
+	advWarning   = styles.Warning
+	advError     = styles.Error
+	advSubtle    = styles.Muted
+)
+
+// AdversarialState holds the state for adversarial review mode
+type AdversarialState struct {
+	// Coordinators maps group IDs to their adversarial coordinators.
+	// This enables multiple concurrent adversarial sessions.
+	Coordinators map[string]*orchestrator.AdversarialCoordinator
+
+	NeedsNotification bool // Set when user input is needed (checked on tick)
+}
+
+// GetCoordinatorForGroup returns the coordinator for a specific group ID.
+func (s *AdversarialState) GetCoordinatorForGroup(groupID string) *orchestrator.AdversarialCoordinator {
+	if s == nil || s.Coordinators == nil {
+		return nil
+	}
+	return s.Coordinators[groupID]
+}
+
+// GetAllCoordinators returns all active adversarial coordinators.
+// Results are sorted by group ID for deterministic ordering.
+func (s *AdversarialState) GetAllCoordinators() []*orchestrator.AdversarialCoordinator {
+	if s == nil || len(s.Coordinators) == 0 {
+		return nil
+	}
+
+	// Sort keys for deterministic iteration order
+	keys := make([]string, 0, len(s.Coordinators))
+	for k := range s.Coordinators {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	coords := make([]*orchestrator.AdversarialCoordinator, 0, len(s.Coordinators))
+	for _, k := range keys {
+		coords = append(coords, s.Coordinators[k])
+	}
+	return coords
+}
+
+// HasActiveCoordinators returns true if there are any active adversarial coordinators.
+func (s *AdversarialState) HasActiveCoordinators() bool {
+	if s == nil {
+		return false
+	}
+	return len(s.Coordinators) > 0
+}
+
+// AdversarialRenderContext provides the necessary context for rendering adversarial views
+type AdversarialRenderContext struct {
+	Orchestrator *orchestrator.Orchestrator
+	Session      *orchestrator.Session
+	Adversarial  *AdversarialState
+	ActiveTab    int
+	Width        int
+	Height       int
+}
+
+// RenderAdversarialHeader renders a compact header showing adversarial review status.
+// For multiple sessions, shows a summary count.
+func RenderAdversarialHeader(ctx AdversarialRenderContext) string {
+	if ctx.Adversarial == nil || !ctx.Adversarial.HasActiveCoordinators() {
+		return ""
+	}
+
+	coordinators := ctx.Adversarial.GetAllCoordinators()
+	if len(coordinators) == 0 {
+		return ""
+	}
+
+	// For multiple sessions, show a summary
+	if len(coordinators) > 1 {
+		implementing := 0
+		reviewing := 0
+		complete := 0
+		failed := 0
+		for _, coord := range coordinators {
+			session := coord.Session()
+			if session == nil {
+				continue
+			}
+			switch session.Phase {
+			case orchestrator.PhaseAdversarialImplementing:
+				implementing++
+			case orchestrator.PhaseAdversarialReviewing:
+				reviewing++
+			case orchestrator.PhaseAdversarialComplete, orchestrator.PhaseAdversarialApproved:
+				complete++
+			case orchestrator.PhaseAdversarialFailed:
+				failed++
+			}
+		}
+		summary := fmt.Sprintf("%d active", len(coordinators))
+		if complete > 0 {
+			summary += fmt.Sprintf(", %d approved", complete)
+		}
+		if failed > 0 {
+			summary += fmt.Sprintf(", %d failed", failed)
+		}
+		return advSubtle.Render("Adversarial Reviews: ") + summary
+	}
+
+	// Single session - show detailed status
+	session := coordinators[0].Session()
+	if session == nil {
+		return ""
+	}
+
+	// Build phase indicator
+	var phaseIcon string
+	var phaseText string
+	var phaseStyle lipgloss.Style
+
+	switch session.Phase {
+	case orchestrator.PhaseAdversarialImplementing:
+		phaseIcon = "🔨"
+		phaseText = "Implementing"
+		phaseStyle = advHighlight
+	case orchestrator.PhaseAdversarialReviewing:
+		phaseIcon = "🔍"
+		phaseText = "Reviewing"
+		phaseStyle = advWarning
+	case orchestrator.PhaseAdversarialApproved, orchestrator.PhaseAdversarialComplete:
+		phaseIcon = "✓"
+		phaseText = "Approved"
+		phaseStyle = advSuccess
+	case orchestrator.PhaseAdversarialFailed:
+		phaseIcon = "✗"
+		phaseText = "Failed"
+		phaseStyle = advError
+	}
+
+	// Build the header line
+	header := fmt.Sprintf("%s %s | Round %d",
+		phaseIcon,
+		phaseStyle.Render(phaseText),
+		session.CurrentRound,
+	)
+
+	// Add max iterations if set
+	if session.Config.MaxIterations > 0 {
+		header += fmt.Sprintf("/%d", session.Config.MaxIterations)
+	}
+
+	return advSubtle.Render("Adversarial: ") + header
+}
+
+// RenderAdversarialSidebarSection renders a sidebar section for adversarial mode.
+// For multiple sessions, iterates through all adversarial groups.
+func RenderAdversarialSidebarSection(ctx AdversarialRenderContext, width int) string {
+	if ctx.Adversarial == nil || !ctx.Adversarial.HasActiveCoordinators() {
+		return ""
+	}
+
+	var lines []string
+
+	// Title - show count if multiple
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(styles.PurpleColor)
+	coordinators := ctx.Adversarial.GetAllCoordinators()
+	if len(coordinators) > 1 {
+		lines = append(lines, titleStyle.Render(fmt.Sprintf("Adversarial Reviews (%d)", len(coordinators))))
+	} else {
+		lines = append(lines, titleStyle.Render("Adversarial Review"))
+	}
+	lines = append(lines, "")
+
+	// Render each adversarial session
+	for idx, coord := range coordinators {
+		session := coord.Session()
+		if session == nil {
+			continue
+		}
+
+		// Add separator between sessions
+		if idx > 0 {
+			lines = append(lines, "")
+			lines = append(lines, strings.Repeat("─", width-4))
+			lines = append(lines, "")
+		}
+
+		lines = append(lines, renderSingleAdversarialSection(ctx, session, width, idx+1, len(coordinators) > 1)...)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// renderSingleAdversarialSection renders a single adversarial session's status.
+func renderSingleAdversarialSection(ctx AdversarialRenderContext, session *orchestrator.AdversarialSession, width int, index int, showIndex bool) []string {
+	var lines []string
+
+	// Task preview with optional index
+	task := session.Task
+	maxTaskLen := width - 10
+	if showIndex {
+		maxTaskLen -= 4 // Account for "#N: " prefix
+	}
+	if len(task) > maxTaskLen {
+		task = task[:maxTaskLen-3] + "..."
+	}
+	if showIndex {
+		lines = append(lines, advSubtle.Render(fmt.Sprintf("#%d: ", index))+task)
+	} else {
+		lines = append(lines, advSubtle.Render("Task: ")+task)
+	}
+	lines = append(lines, "")
+
+	// Phase and round status
+	var phaseStyle lipgloss.Style
+	var phaseText string
+
+	switch session.Phase {
+	case orchestrator.PhaseAdversarialImplementing:
+		phaseStyle = advHighlight
+		phaseText = "implementing"
+	case orchestrator.PhaseAdversarialReviewing:
+		phaseStyle = advWarning
+		phaseText = "reviewing"
+	case orchestrator.PhaseAdversarialApproved, orchestrator.PhaseAdversarialComplete:
+		phaseStyle = advSuccess
+		phaseText = "approved"
+	case orchestrator.PhaseAdversarialFailed:
+		phaseStyle = advError
+		phaseText = "failed"
+	default:
+		phaseStyle = advSubtle
+		phaseText = "pending"
+	}
+
+	roundInfo := fmt.Sprintf("Round %d", session.CurrentRound)
+	if session.Config.MaxIterations > 0 {
+		roundInfo += fmt.Sprintf("/%d", session.Config.MaxIterations)
+	}
+	lines = append(lines, advSubtle.Render("Status: ")+phaseStyle.Render(phaseText)+" "+advSubtle.Render("("+roundInfo+")"))
+	lines = append(lines, "")
+
+	// Implementer status
+	lines = append(lines, advSubtle.Render("Implementer:"))
+	if session.ImplementerID != "" {
+		var prefix string
+		if ctx.Session != nil && ctx.ActiveTab < len(ctx.Session.Instances) {
+			activeInst := ctx.Session.Instances[ctx.ActiveTab]
+			if activeInst != nil && activeInst.ID == session.ImplementerID {
+				prefix = "▶ "
+			} else {
+				prefix = "  "
+			}
+		} else {
+			prefix = "  "
+		}
+
+		implStatus := "working"
+		implStyle := advHighlight
+		if session.Phase == orchestrator.PhaseAdversarialReviewing ||
+			session.Phase == orchestrator.PhaseAdversarialApproved ||
+			session.Phase == orchestrator.PhaseAdversarialComplete {
+			implStatus = "done"
+			implStyle = advSuccess
+		}
+		lines = append(lines, prefix+implStyle.Render(implStatus))
+	} else {
+		lines = append(lines, "  "+advSubtle.Render("pending"))
+	}
+
+	// Reviewer status
+	lines = append(lines, "")
+	lines = append(lines, advSubtle.Render("Reviewer:"))
+	if session.ReviewerID != "" {
+		var prefix string
+		if ctx.Session != nil && ctx.ActiveTab < len(ctx.Session.Instances) {
+			activeInst := ctx.Session.Instances[ctx.ActiveTab]
+			if activeInst != nil && activeInst.ID == session.ReviewerID {
+				prefix = "▶ "
+			} else {
+				prefix = "  "
+			}
+		} else {
+			prefix = "  "
+		}
+
+		var revStatus string
+		var revStyle lipgloss.Style
+		switch session.Phase {
+		case orchestrator.PhaseAdversarialApproved, orchestrator.PhaseAdversarialComplete:
+			revStatus = "approved"
+			revStyle = advSuccess
+		case orchestrator.PhaseAdversarialImplementing:
+			revStatus = "waiting"
+			revStyle = advSubtle
+		default:
+			revStatus = "reviewing"
+			revStyle = advWarning
+		}
+		lines = append(lines, prefix+revStyle.Render(revStatus))
+	} else if session.Phase != orchestrator.PhaseAdversarialImplementing {
+		lines = append(lines, "  "+advSubtle.Render("pending"))
+	} else {
+		lines = append(lines, "  "+advSubtle.Render("waiting for implementation"))
+	}
+
+	// History summary if any rounds completed
+	if len(session.History) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, advSubtle.Render("History:"))
+		for _, round := range session.History {
+			if round.Review != nil {
+				var scoreStyle lipgloss.Style
+				switch {
+				case round.Review.Score >= 8:
+					scoreStyle = advSuccess
+				case round.Review.Score >= 5:
+					scoreStyle = advWarning
+				default:
+					scoreStyle = advError
+				}
+				status := "✗"
+				if round.Review.Approved {
+					status = "✓"
+				}
+				lines = append(lines, fmt.Sprintf("  R%d: %s %s",
+					round.Round,
+					scoreStyle.Render(fmt.Sprintf("%d/10", round.Review.Score)),
+					advSubtle.Render(status),
+				))
+			}
+		}
+	}
+
+	return lines
+}
+
+// RenderAdversarialHelp renders help text for adversarial mode.
+func RenderAdversarialHelp(state *HelpBarState) string {
+	var items []string
+
+	items = append(items, styles.HelpKey.Render("[j/k]")+" "+advSubtle.Render("nav"))
+	items = append(items, styles.HelpKey.Render("[:]")+" "+advSubtle.Render("cmd"))
+	items = append(items, styles.HelpKey.Render("[?]")+" "+advSubtle.Render("help"))
+	items = append(items, styles.HelpKey.Render("[q]")+" "+advSubtle.Render("quit"))
+
+	return strings.Join(items, "  ")
+}
+
+// FindAdversarialForActiveInstance finds the adversarial session that contains
+// the currently active instance (based on activeTab).
+func FindAdversarialForActiveInstance(ctx AdversarialRenderContext) *orchestrator.AdversarialSession {
+	if ctx.Session == nil || ctx.ActiveTab >= len(ctx.Session.Instances) {
+		return nil
+	}
+
+	if ctx.Adversarial == nil {
+		return nil
+	}
+
+	activeInst := ctx.Session.Instances[ctx.ActiveTab]
+	if activeInst == nil {
+		return nil
+	}
+
+	// Search through all coordinators to find which session owns this instance
+	for _, coord := range ctx.Adversarial.GetAllCoordinators() {
+		session := coord.Session()
+		if session == nil {
+			continue
+		}
+
+		// Check if active instance is the implementer
+		if session.ImplementerID == activeInst.ID {
+			return session
+		}
+
+		// Check if active instance is the reviewer
+		if session.ReviewerID == activeInst.ID {
+			return session
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds a new `claudio adversarial` command that creates an iterative feedback loop between two Claude instances:

- **Implementer**: Works on the task and submits increments for review via JSON sentinel files
- **Reviewer**: Critically examines the work and provides detailed feedback with scores (1-10), issues, and suggestions

The loop continues until the Reviewer approves the implementation or the maximum iterations limit is reached.

### Key Features

- File-based IPC using JSON sentinel files for coordination (increment, review, completion)
- Configurable max iterations via `--max-iterations` flag (default: 10)
- Rich review feedback structure with score, strengths, issues, suggestions, and required changes
- Round history tracking for audit trail
- Async file polling to avoid blocking UI
- Full TUI integration with sidebar display showing current phase and round

### TUI Integration

Adversarial mode is now accessible directly from the TUI:

- **`:adversarial`** or **`:adv`** - Start an adversarial review session from within the TUI
- Supports multiple concurrent adversarial sessions (similar to TripleShot mode)
- Context-aware messaging: shows different prompt when already in adversarial mode
- Adversarial-specific header and help bar rendering
- Integrated help panel with "Adversarial Mode" section

### Bug Fixes Applied

During review, the following issues were identified and fixed:

- **Off-by-one bug**: Fixed issue where `previousReview` was retrieved after `StartRound()` appended a new empty round to history
- **Nil pointer dereference**: Added nil check for `ctx.Adversarial` in `FindAdversarialForActiveInstance`
- **Silent error handling**: Added logging for missing coordinator cases and error messages to user
- **Missing validation**: Added validation to parse functions for required fields (round >= 1, valid status, score 1-10)
- **Async nil return**: Fixed `CheckAdversarialCompletionAsync` to return error message instead of nil on nil session
- **Defensive nil checks**: Added validation for session and orchestrator in `initiateAdversarialMode`

## Test plan

- [ ] Run `claudio adversarial "Implement a simple hello world function"` and verify the iterative loop works
- [ ] Verify the reviewer provides feedback and the implementer addresses it
- [ ] Test max iterations limit with `--max-iterations 2`
- [ ] Verify sidebar displays correct phase (implementing/reviewing/approved/complete)
- [ ] Start adversarial mode from TUI with `:adversarial` command
- [ ] Verify `:adv` alias works
- [ ] Test starting multiple adversarial sessions from TUI
- [ ] Run `go test ./...` to ensure no regressions