### PR TITLE
Integrate extracted packages for unified type handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Unified Group Types** - Refactored the `group`, `orchestrator`, and `session` packages to use a shared `grouptypes.InstanceGroup` type, eliminating type duplication and ~80 lines of conversion code. This also prevents data loss (SessionType and Objective fields) when using the group manager.
+
+- **TimeoutType Consolidation** - Made `state.TimeoutType` and `instance.TimeoutType` type aliases for `detect.TimeoutType`, eliminating duplicate type definitions and removing unnecessary type conversion code in the orchestrator.
+
 - **TripleShot Mode Graduated** - TripleShot is now a permanent feature. The `experimental.triple_shot` configuration option has been removed; the `:tripleshot` command is always available.
 
 - **Documentation Overhaul** - Comprehensive update to all documentation to reflect current features and capabilities:

--- a/internal/instance/manager.go
+++ b/internal/instance/manager.go
@@ -23,13 +23,16 @@ import (
 // StateChangeCallback is called when the detected waiting state changes
 type StateChangeCallback func(instanceID string, state detect.WaitingState)
 
-// TimeoutType represents the type of timeout that occurred
-type TimeoutType int
+// TimeoutType is an alias for detect.TimeoutType for backwards compatibility.
+// New code should import detect.TimeoutType directly.
+type TimeoutType = detect.TimeoutType
 
+// Re-export timeout type constants for backwards compatibility.
+// New code should import these from detect package directly.
 const (
-	TimeoutActivity   TimeoutType = iota // No activity for configured period
-	TimeoutCompletion                    // Total runtime exceeded limit
-	TimeoutStale                         // Repeated output detected (stuck in loop)
+	TimeoutActivity   = detect.TimeoutActivity
+	TimeoutCompletion = detect.TimeoutCompletion
+	TimeoutStale      = detect.TimeoutStale
 )
 
 // fullRefreshInterval is the number of capture ticks between full scrollback captures.
@@ -44,20 +47,6 @@ const pausedHeartbeatInterval = 50
 // tmuxCommandTimeout is the maximum time to wait for tmux subprocess commands.
 // This prevents the capture loop from hanging indefinitely if tmux becomes unresponsive.
 const tmuxCommandTimeout = 2 * time.Second
-
-// String returns a human-readable name for a timeout type
-func (t TimeoutType) String() string {
-	switch t {
-	case TimeoutActivity:
-		return "activity"
-	case TimeoutCompletion:
-		return "completion"
-	case TimeoutStale:
-		return "stale"
-	default:
-		return "unknown"
-	}
-}
 
 // TimeoutCallback is called when a timeout condition is detected
 type TimeoutCallback func(instanceID string, timeoutType TimeoutType)
@@ -300,8 +289,8 @@ func (m *Manager) CurrentState() detect.WaitingState {
 // Delegates to the StateMonitor for centralized timeout tracking.
 func (m *Manager) TimedOut() (bool, TimeoutType) {
 	timedOut, timeoutType := m.stateMonitor.GetTimedOut(m.id)
-	// Convert state.TimeoutType to instance.TimeoutType
-	return timedOut, TimeoutType(timeoutType)
+	// state.TimeoutType and instance.TimeoutType are both aliases for detect.TimeoutType
+	return timedOut, timeoutType
 }
 
 // LastActivityTime returns when the instance last had output activity.

--- a/internal/instance/state/monitor.go
+++ b/internal/instance/state/monitor.go
@@ -38,31 +38,17 @@ func DefaultMonitorConfig() MonitorConfig {
 	}
 }
 
-// TimeoutType represents the type of timeout that occurred.
-type TimeoutType int
+// TimeoutType is an alias for detect.TimeoutType for backwards compatibility.
+// New code should import detect.TimeoutType directly.
+type TimeoutType = detect.TimeoutType
 
+// Re-export timeout type constants for backwards compatibility.
+// New code should import these from detect package directly.
 const (
-	// TimeoutActivity indicates no output activity for the configured period.
-	TimeoutActivity TimeoutType = iota
-	// TimeoutCompletion indicates total runtime exceeded the configured limit.
-	TimeoutCompletion
-	// TimeoutStale indicates repeated identical output (stuck in a loop).
-	TimeoutStale
+	TimeoutActivity   = detect.TimeoutActivity
+	TimeoutCompletion = detect.TimeoutCompletion
+	TimeoutStale      = detect.TimeoutStale
 )
-
-// String returns a human-readable name for the timeout type.
-func (t TimeoutType) String() string {
-	switch t {
-	case TimeoutActivity:
-		return "activity"
-	case TimeoutCompletion:
-		return "completion"
-	case TimeoutStale:
-		return "stale"
-	default:
-		return "unknown"
-	}
-}
 
 // StateChangeCallback is called when an instance's detected state changes.
 type StateChangeCallback func(instanceID string, oldState, newState detect.WaitingState)

--- a/internal/orchestrator/grouptypes/types.go
+++ b/internal/orchestrator/grouptypes/types.go
@@ -1,0 +1,192 @@
+// Package grouptypes provides shared types for instance grouping across packages.
+// This package exists to break circular dependencies between orchestrator, group,
+// and session packages that all need to work with instance groups.
+package grouptypes
+
+import (
+	"slices"
+	"time"
+)
+
+// GroupPhase represents the current phase of an instance group.
+type GroupPhase string
+
+const (
+	GroupPhasePending   GroupPhase = "pending"
+	GroupPhaseExecuting GroupPhase = "executing"
+	GroupPhaseCompleted GroupPhase = "completed"
+	GroupPhaseFailed    GroupPhase = "failed"
+)
+
+// InstanceGroup represents a visual grouping of instances in the TUI.
+// Groups enable users to organize related tasks together, particularly useful
+// for Plan and UltraPlan workflows where tasks have natural dependencies.
+type InstanceGroup struct {
+	ID             string           `json:"id"`
+	Name           string           `json:"name"`            // e.g., "Group 1: Foundation" or auto-generated
+	Phase          GroupPhase       `json:"phase"`           // Current group status
+	Instances      []string         `json:"instances"`       // Instance IDs in this group
+	SubGroups      []*InstanceGroup `json:"sub_groups"`      // For nested dependencies
+	ParentID       string           `json:"parent_id"`       // If this is a sub-group
+	ExecutionOrder int              `json:"execution_order"` // Order of execution (0 = first)
+	DependsOn      []string         `json:"depends_on"`      // Group IDs this group depends on
+	Created        time.Time        `json:"created"`
+
+	// SessionType identifies the type of session that created this group.
+	// Used for displaying appropriate icons and determining grouping behavior.
+	// This is stored as a string to avoid importing the orchestrator package.
+	SessionType string `json:"session_type,omitempty"`
+
+	// Objective is the original user prompt/objective for this group.
+	// Used for LLM-based name generation and display purposes.
+	Objective string `json:"objective,omitempty"`
+}
+
+// NewInstanceGroup creates a new instance group with the given ID and name.
+// The caller is responsible for generating a unique ID.
+func NewInstanceGroup(id, name string) *InstanceGroup {
+	return &InstanceGroup{
+		ID:        id,
+		Name:      name,
+		Phase:     GroupPhasePending,
+		Instances: make([]string, 0),
+		SubGroups: make([]*InstanceGroup, 0),
+		DependsOn: make([]string, 0),
+		Created:   time.Now(),
+	}
+}
+
+// NewInstanceGroupWithType creates a new instance group with a session type and objective.
+// The objective is used for LLM-based name generation.
+func NewInstanceGroupWithType(id, name, sessionType, objective string) *InstanceGroup {
+	return &InstanceGroup{
+		ID:          id,
+		Name:        name,
+		Phase:       GroupPhasePending,
+		Instances:   make([]string, 0),
+		SubGroups:   make([]*InstanceGroup, 0),
+		DependsOn:   make([]string, 0),
+		Created:     time.Now(),
+		SessionType: sessionType,
+		Objective:   objective,
+	}
+}
+
+// AddInstance adds an instance ID to the group.
+func (g *InstanceGroup) AddInstance(instanceID string) {
+	g.Instances = append(g.Instances, instanceID)
+}
+
+// RemoveInstance removes an instance ID from the group.
+func (g *InstanceGroup) RemoveInstance(instanceID string) {
+	for i, id := range g.Instances {
+		if id == instanceID {
+			g.Instances = append(g.Instances[:i], g.Instances[i+1:]...)
+			return
+		}
+	}
+}
+
+// HasInstance checks if an instance ID is in this group.
+func (g *InstanceGroup) HasInstance(instanceID string) bool {
+	return slices.Contains(g.Instances, instanceID)
+}
+
+// AddSubGroup adds a sub-group to this group.
+func (g *InstanceGroup) AddSubGroup(subGroup *InstanceGroup) {
+	subGroup.ParentID = g.ID
+	g.SubGroups = append(g.SubGroups, subGroup)
+}
+
+// GetSubGroup returns a sub-group by ID.
+func (g *InstanceGroup) GetSubGroup(id string) *InstanceGroup {
+	for _, sg := range g.SubGroups {
+		if sg.ID == id {
+			return sg
+		}
+	}
+	return nil
+}
+
+// AllInstanceIDs returns all instance IDs in this group and all sub-groups (recursively).
+func (g *InstanceGroup) AllInstanceIDs() []string {
+	ids := make([]string, len(g.Instances))
+	copy(ids, g.Instances)
+
+	for _, sg := range g.SubGroups {
+		ids = append(ids, sg.AllInstanceIDs()...)
+	}
+	return ids
+}
+
+// InstanceCount returns the total number of instances in this group and all sub-groups.
+func (g *InstanceGroup) InstanceCount() int {
+	count := len(g.Instances)
+	for _, sg := range g.SubGroups {
+		count += sg.InstanceCount()
+	}
+	return count
+}
+
+// IsEmpty returns true if this group has no instances and no sub-groups with instances.
+func (g *InstanceGroup) IsEmpty() bool {
+	return g.InstanceCount() == 0
+}
+
+// IsTopLevel returns true if this group has no parent (is not a sub-group).
+func (g *InstanceGroup) IsTopLevel() bool {
+	return g.ParentID == ""
+}
+
+// FindGroup searches for a group by ID within this group and its sub-groups.
+func (g *InstanceGroup) FindGroup(id string) *InstanceGroup {
+	if g.ID == id {
+		return g
+	}
+	for _, sg := range g.SubGroups {
+		if found := sg.FindGroup(id); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// FindGroupContainingInstance returns the group (or sub-group) containing the given instance ID.
+func (g *InstanceGroup) FindGroupContainingInstance(instanceID string) *InstanceGroup {
+	if g.HasInstance(instanceID) {
+		return g
+	}
+	for _, sg := range g.SubGroups {
+		if found := sg.FindGroupContainingInstance(instanceID); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// Clone creates a deep copy of the instance group.
+func (g *InstanceGroup) Clone() *InstanceGroup {
+	if g == nil {
+		return nil
+	}
+	clone := &InstanceGroup{
+		ID:             g.ID,
+		Name:           g.Name,
+		Phase:          g.Phase,
+		Instances:      make([]string, len(g.Instances)),
+		ParentID:       g.ParentID,
+		ExecutionOrder: g.ExecutionOrder,
+		DependsOn:      make([]string, len(g.DependsOn)),
+		Created:        g.Created,
+		SessionType:    g.SessionType,
+		Objective:      g.Objective,
+	}
+	copy(clone.Instances, g.Instances)
+	copy(clone.DependsOn, g.DependsOn)
+
+	clone.SubGroups = make([]*InstanceGroup, len(g.SubGroups))
+	for i, sg := range g.SubGroups {
+		clone.SubGroups[i] = sg.Clone()
+	}
+	return clone
+}

--- a/internal/orchestrator/grouptypes/types_test.go
+++ b/internal/orchestrator/grouptypes/types_test.go
@@ -1,0 +1,358 @@
+package grouptypes
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewInstanceGroup(t *testing.T) {
+	g := NewInstanceGroup("test-id", "Test Group")
+
+	if g.ID != "test-id" {
+		t.Errorf("ID = %q, want %q", g.ID, "test-id")
+	}
+	if g.Name != "Test Group" {
+		t.Errorf("Name = %q, want %q", g.Name, "Test Group")
+	}
+	if g.Phase != GroupPhasePending {
+		t.Errorf("Phase = %q, want %q", g.Phase, GroupPhasePending)
+	}
+	if len(g.Instances) != 0 {
+		t.Errorf("Instances should be empty, got %d", len(g.Instances))
+	}
+	if len(g.SubGroups) != 0 {
+		t.Errorf("SubGroups should be empty, got %d", len(g.SubGroups))
+	}
+	if len(g.DependsOn) != 0 {
+		t.Errorf("DependsOn should be empty, got %d", len(g.DependsOn))
+	}
+	if g.Created.IsZero() {
+		t.Error("Created should not be zero")
+	}
+}
+
+func TestNewInstanceGroupWithType(t *testing.T) {
+	g := NewInstanceGroupWithType("test-id", "Test Group", "ultraplan", "Build a feature")
+
+	if g.ID != "test-id" {
+		t.Errorf("ID = %q, want %q", g.ID, "test-id")
+	}
+	if g.SessionType != "ultraplan" {
+		t.Errorf("SessionType = %q, want %q", g.SessionType, "ultraplan")
+	}
+	if g.Objective != "Build a feature" {
+		t.Errorf("Objective = %q, want %q", g.Objective, "Build a feature")
+	}
+}
+
+func TestInstanceGroup_AddInstance(t *testing.T) {
+	g := NewInstanceGroup("test-id", "Test")
+	g.AddInstance("inst-1")
+	g.AddInstance("inst-2")
+
+	if len(g.Instances) != 2 {
+		t.Errorf("Instances length = %d, want 2", len(g.Instances))
+	}
+	if g.Instances[0] != "inst-1" || g.Instances[1] != "inst-2" {
+		t.Errorf("Instances = %v, want [inst-1, inst-2]", g.Instances)
+	}
+}
+
+func TestInstanceGroup_RemoveInstance(t *testing.T) {
+	g := NewInstanceGroup("test-id", "Test")
+	g.AddInstance("inst-1")
+	g.AddInstance("inst-2")
+	g.AddInstance("inst-3")
+
+	g.RemoveInstance("inst-2")
+
+	if len(g.Instances) != 2 {
+		t.Errorf("Instances length = %d, want 2", len(g.Instances))
+	}
+	if g.Instances[0] != "inst-1" || g.Instances[1] != "inst-3" {
+		t.Errorf("Instances = %v, want [inst-1, inst-3]", g.Instances)
+	}
+
+	// Remove non-existent should be a no-op
+	g.RemoveInstance("inst-999")
+	if len(g.Instances) != 2 {
+		t.Errorf("Instances length = %d, want 2", len(g.Instances))
+	}
+}
+
+func TestInstanceGroup_HasInstance(t *testing.T) {
+	g := NewInstanceGroup("test-id", "Test")
+	g.AddInstance("inst-1")
+
+	if !g.HasInstance("inst-1") {
+		t.Error("HasInstance(inst-1) = false, want true")
+	}
+	if g.HasInstance("inst-2") {
+		t.Error("HasInstance(inst-2) = true, want false")
+	}
+}
+
+func TestInstanceGroup_AddSubGroup(t *testing.T) {
+	parent := NewInstanceGroup("parent", "Parent")
+	child := NewInstanceGroup("child", "Child")
+
+	parent.AddSubGroup(child)
+
+	if len(parent.SubGroups) != 1 {
+		t.Errorf("SubGroups length = %d, want 1", len(parent.SubGroups))
+	}
+	if child.ParentID != "parent" {
+		t.Errorf("Child ParentID = %q, want %q", child.ParentID, "parent")
+	}
+}
+
+func TestInstanceGroup_GetSubGroup(t *testing.T) {
+	parent := NewInstanceGroup("parent", "Parent")
+	child1 := NewInstanceGroup("child1", "Child 1")
+	child2 := NewInstanceGroup("child2", "Child 2")
+
+	parent.AddSubGroup(child1)
+	parent.AddSubGroup(child2)
+
+	got := parent.GetSubGroup("child1")
+	if got != child1 {
+		t.Error("GetSubGroup(child1) returned wrong group")
+	}
+
+	got = parent.GetSubGroup("child2")
+	if got != child2 {
+		t.Error("GetSubGroup(child2) returned wrong group")
+	}
+
+	got = parent.GetSubGroup("nonexistent")
+	if got != nil {
+		t.Error("GetSubGroup(nonexistent) should return nil")
+	}
+}
+
+func TestInstanceGroup_AllInstanceIDs(t *testing.T) {
+	parent := NewInstanceGroup("parent", "Parent")
+	parent.AddInstance("inst-1")
+	parent.AddInstance("inst-2")
+
+	child := NewInstanceGroup("child", "Child")
+	child.AddInstance("inst-3")
+	child.AddInstance("inst-4")
+
+	parent.AddSubGroup(child)
+
+	ids := parent.AllInstanceIDs()
+	if len(ids) != 4 {
+		t.Errorf("AllInstanceIDs length = %d, want 4", len(ids))
+	}
+
+	expected := map[string]bool{"inst-1": true, "inst-2": true, "inst-3": true, "inst-4": true}
+	for _, id := range ids {
+		if !expected[id] {
+			t.Errorf("Unexpected instance ID: %s", id)
+		}
+	}
+}
+
+func TestInstanceGroup_InstanceCount(t *testing.T) {
+	parent := NewInstanceGroup("parent", "Parent")
+	parent.AddInstance("inst-1")
+
+	child := NewInstanceGroup("child", "Child")
+	child.AddInstance("inst-2")
+	child.AddInstance("inst-3")
+
+	parent.AddSubGroup(child)
+
+	if parent.InstanceCount() != 3 {
+		t.Errorf("InstanceCount = %d, want 3", parent.InstanceCount())
+	}
+	if child.InstanceCount() != 2 {
+		t.Errorf("Child InstanceCount = %d, want 2", child.InstanceCount())
+	}
+}
+
+func TestInstanceGroup_IsEmpty(t *testing.T) {
+	g := NewInstanceGroup("test", "Test")
+	if !g.IsEmpty() {
+		t.Error("Empty group should return true for IsEmpty()")
+	}
+
+	g.AddInstance("inst-1")
+	if g.IsEmpty() {
+		t.Error("Group with instance should return false for IsEmpty()")
+	}
+
+	// Test with sub-groups
+	parent := NewInstanceGroup("parent", "Parent")
+	child := NewInstanceGroup("child", "Child")
+	parent.AddSubGroup(child)
+
+	if !parent.IsEmpty() {
+		t.Error("Parent with empty child should be empty")
+	}
+
+	child.AddInstance("inst-1")
+	if parent.IsEmpty() {
+		t.Error("Parent with non-empty child should not be empty")
+	}
+}
+
+func TestInstanceGroup_IsTopLevel(t *testing.T) {
+	parent := NewInstanceGroup("parent", "Parent")
+	child := NewInstanceGroup("child", "Child")
+
+	if !parent.IsTopLevel() {
+		t.Error("Parent should be top-level")
+	}
+
+	parent.AddSubGroup(child)
+
+	if child.IsTopLevel() {
+		t.Error("Child should not be top-level")
+	}
+}
+
+func TestInstanceGroup_FindGroup(t *testing.T) {
+	parent := NewInstanceGroup("parent", "Parent")
+	child := NewInstanceGroup("child", "Child")
+	grandchild := NewInstanceGroup("grandchild", "Grandchild")
+
+	parent.AddSubGroup(child)
+	child.AddSubGroup(grandchild)
+
+	// Find self
+	if parent.FindGroup("parent") != parent {
+		t.Error("FindGroup should find parent itself")
+	}
+
+	// Find direct child
+	if parent.FindGroup("child") != child {
+		t.Error("FindGroup should find direct child")
+	}
+
+	// Find grandchild
+	if parent.FindGroup("grandchild") != grandchild {
+		t.Error("FindGroup should find grandchild")
+	}
+
+	// Not found
+	if parent.FindGroup("nonexistent") != nil {
+		t.Error("FindGroup should return nil for nonexistent group")
+	}
+}
+
+func TestInstanceGroup_FindGroupContainingInstance(t *testing.T) {
+	parent := NewInstanceGroup("parent", "Parent")
+	parent.AddInstance("inst-parent")
+
+	child := NewInstanceGroup("child", "Child")
+	child.AddInstance("inst-child")
+
+	parent.AddSubGroup(child)
+
+	// Find in parent
+	if parent.FindGroupContainingInstance("inst-parent") != parent {
+		t.Error("Should find instance in parent")
+	}
+
+	// Find in child
+	if parent.FindGroupContainingInstance("inst-child") != child {
+		t.Error("Should find instance in child")
+	}
+
+	// Not found
+	if parent.FindGroupContainingInstance("nonexistent") != nil {
+		t.Error("Should return nil for nonexistent instance")
+	}
+}
+
+func TestInstanceGroup_Clone(t *testing.T) {
+	original := NewInstanceGroupWithType("test-id", "Test Group", "ultraplan", "Build feature")
+	original.Phase = GroupPhaseExecuting
+	original.ExecutionOrder = 5
+	original.AddInstance("inst-1")
+	original.AddInstance("inst-2")
+	original.DependsOn = []string{"dep-1", "dep-2"}
+
+	child := NewInstanceGroup("child", "Child")
+	child.AddInstance("child-inst")
+	original.AddSubGroup(child)
+
+	clone := original.Clone()
+
+	// Verify clone has same values
+	if clone.ID != original.ID {
+		t.Errorf("Clone ID = %q, want %q", clone.ID, original.ID)
+	}
+	if clone.Name != original.Name {
+		t.Errorf("Clone Name = %q, want %q", clone.Name, original.Name)
+	}
+	if clone.Phase != original.Phase {
+		t.Errorf("Clone Phase = %q, want %q", clone.Phase, original.Phase)
+	}
+	if clone.SessionType != original.SessionType {
+		t.Errorf("Clone SessionType = %q, want %q", clone.SessionType, original.SessionType)
+	}
+	if clone.Objective != original.Objective {
+		t.Errorf("Clone Objective = %q, want %q", clone.Objective, original.Objective)
+	}
+	if clone.ExecutionOrder != original.ExecutionOrder {
+		t.Errorf("Clone ExecutionOrder = %d, want %d", clone.ExecutionOrder, original.ExecutionOrder)
+	}
+	if len(clone.Instances) != len(original.Instances) {
+		t.Errorf("Clone Instances length = %d, want %d", len(clone.Instances), len(original.Instances))
+	}
+	if len(clone.DependsOn) != len(original.DependsOn) {
+		t.Errorf("Clone DependsOn length = %d, want %d", len(clone.DependsOn), len(original.DependsOn))
+	}
+	if len(clone.SubGroups) != len(original.SubGroups) {
+		t.Errorf("Clone SubGroups length = %d, want %d", len(clone.SubGroups), len(original.SubGroups))
+	}
+
+	// Verify deep copy - modifying original shouldn't affect clone
+	original.Instances[0] = "modified"
+	if clone.Instances[0] == "modified" {
+		t.Error("Clone Instances should be independent of original")
+	}
+
+	original.SubGroups[0].Name = "Modified Child"
+	if clone.SubGroups[0].Name == "Modified Child" {
+		t.Error("Clone SubGroups should be independent of original")
+	}
+
+	// Test nil clone
+	var nilGroup *InstanceGroup
+	if nilGroup.Clone() != nil {
+		t.Error("Clone of nil should return nil")
+	}
+}
+
+func TestGroupPhaseConstants(t *testing.T) {
+	// Verify phase constants have expected values
+	tests := []struct {
+		phase GroupPhase
+		want  string
+	}{
+		{GroupPhasePending, "pending"},
+		{GroupPhaseExecuting, "executing"},
+		{GroupPhaseCompleted, "completed"},
+		{GroupPhaseFailed, "failed"},
+	}
+
+	for _, tt := range tests {
+		if string(tt.phase) != tt.want {
+			t.Errorf("GroupPhase %v = %q, want %q", tt.phase, string(tt.phase), tt.want)
+		}
+	}
+}
+
+func TestInstanceGroup_CreatedTime(t *testing.T) {
+	before := time.Now()
+	g := NewInstanceGroup("test", "Test")
+	after := time.Now()
+
+	if g.Created.Before(before) || g.Created.After(after) {
+		t.Error("Created time should be between test start and end")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1432,21 +1432,10 @@ func (o *Orchestrator) wireStateMonitorCallbacks() {
 		}
 	})
 
-	// Wire timeout callback - converts state.TimeoutType to instance.TimeoutType
+	// Wire timeout callback - state.TimeoutType is an alias for detect.TimeoutType,
+	// same as instance.TimeoutType, so no conversion needed.
 	o.stateMonitor.OnTimeout(func(instanceID string, timeoutType instancestate.TimeoutType) {
-		// Convert state.TimeoutType to instance.TimeoutType
-		var instTimeoutType instance.TimeoutType
-		switch timeoutType {
-		case instancestate.TimeoutActivity:
-			instTimeoutType = instance.TimeoutActivity
-		case instancestate.TimeoutCompletion:
-			instTimeoutType = instance.TimeoutCompletion
-		case instancestate.TimeoutStale:
-			instTimeoutType = instance.TimeoutStale
-		default:
-			instTimeoutType = instance.TimeoutActivity
-		}
-		o.handleInstanceTimeout(instanceID, instTimeoutType)
+		o.handleInstanceTimeout(instanceID, timeoutType)
 	})
 
 	// Wire bell callback - forwards bell events directly

--- a/internal/orchestrator/session_type_test.go
+++ b/internal/orchestrator/session_type_test.go
@@ -100,14 +100,40 @@ func TestNewInstanceGroupWithType(t *testing.T) {
 	if group.Name != "Test Group" {
 		t.Errorf("Name = %q, want %q", group.Name, "Test Group")
 	}
-	if group.SessionType != SessionTypeUltraPlan {
-		t.Errorf("SessionType = %q, want %q", group.SessionType, SessionTypeUltraPlan)
+	if GetSessionType(group) != SessionTypeUltraPlan {
+		t.Errorf("SessionType = %q, want %q", GetSessionType(group), SessionTypeUltraPlan)
 	}
 	if group.Objective != "Test objective" {
 		t.Errorf("Objective = %q, want %q", group.Objective, "Test objective")
 	}
 	if group.Phase != GroupPhasePending {
 		t.Errorf("Phase = %q, want %q", group.Phase, GroupPhasePending)
+	}
+}
+
+func TestSetSessionType(t *testing.T) {
+	group := NewInstanceGroup("Test Group")
+
+	// Initially should have no session type
+	if GetSessionType(group) != "" {
+		t.Errorf("Expected empty SessionType initially, got %q", GetSessionType(group))
+	}
+
+	// Set to TripleShot
+	SetSessionType(group, SessionTypeTripleShot)
+	if GetSessionType(group) != SessionTypeTripleShot {
+		t.Errorf("SessionType = %q, want %q", GetSessionType(group), SessionTypeTripleShot)
+	}
+
+	// Change to UltraPlan
+	SetSessionType(group, SessionTypeUltraPlan)
+	if GetSessionType(group) != SessionTypeUltraPlan {
+		t.Errorf("SessionType = %q, want %q", GetSessionType(group), SessionTypeUltraPlan)
+	}
+
+	// Verify the underlying string value is correct
+	if group.SessionType != string(SessionTypeUltraPlan) {
+		t.Errorf("Underlying SessionType = %q, want %q", group.SessionType, string(SessionTypeUltraPlan))
 	}
 }
 
@@ -123,8 +149,8 @@ func TestSession_GetOrCreateSharedGroup(t *testing.T) {
 		if group == nil {
 			t.Fatal("Expected group to be created")
 		}
-		if group.SessionType != SessionTypePlan {
-			t.Errorf("SessionType = %q, want %q", group.SessionType, SessionTypePlan)
+		if GetSessionType(group) != SessionTypePlan {
+			t.Errorf("SessionType = %q, want %q", GetSessionType(group), SessionTypePlan)
 		}
 		if group.Name != "Plans" {
 			t.Errorf("Name = %q, want %q", group.Name, "Plans")

--- a/internal/orchestrator/tripleshot_coordinator.go
+++ b/internal/orchestrator/tripleshot_coordinator.go
@@ -332,7 +332,7 @@ func (c *TripleShotCoordinator) StartJudge() error {
 	if tripleGroup != nil {
 		// Create a sub-group for the implementers
 		implementersGroup := NewInstanceGroup("Implementers")
-		implementersGroup.SessionType = SessionTypeTripleShot
+		SetSessionType(implementersGroup, SessionTypeTripleShot)
 
 		// Move existing instances (the 3 implementers) to the sub-group
 		for _, instID := range tripleGroup.Instances {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -133,8 +133,8 @@ func TestNewInstanceGroupWithType_CreatesCorrectSessionType(t *testing.T) {
 				tt.objective,
 			)
 
-			if group.SessionType != tt.wantType {
-				t.Errorf("SessionType = %v, want %v", group.SessionType, tt.wantType)
+			if orchestrator.GetSessionType(group) != tt.wantType {
+				t.Errorf("SessionType = %v, want %v", orchestrator.GetSessionType(group), tt.wantType)
 			}
 			if group.Objective != tt.objective {
 				t.Errorf("Objective = %q, want %q", group.Objective, tt.objective)
@@ -217,7 +217,7 @@ func TestUltraPlanGroupID_MustBeSetOnCreation(t *testing.T) {
 	if retrievedGroup == nil {
 		t.Fatal("session.GetGroup(ultraSession.GroupID) should return the group")
 	}
-	if retrievedGroup.SessionType != orchestrator.SessionTypeUltraPlan {
-		t.Errorf("group.SessionType = %v, want %v", retrievedGroup.SessionType, orchestrator.SessionTypeUltraPlan)
+	if orchestrator.GetSessionType(retrievedGroup) != orchestrator.SessionTypeUltraPlan {
+		t.Errorf("group.SessionType = %v, want %v", orchestrator.GetSessionType(retrievedGroup), orchestrator.SessionTypeUltraPlan)
 	}
 }

--- a/internal/tui/view/coexist_test.go
+++ b/internal/tui/view/coexist_test.go
@@ -48,8 +48,8 @@ func TestUltraplanCoexistenceWithStandardInstances(t *testing.T) {
 	if len(data.Groups) != 1 {
 		t.Errorf("Expected 1 group (ultraplan), got %d", len(data.Groups))
 	}
-	if data.Groups[0].SessionType != orchestrator.SessionTypeUltraPlan {
-		t.Errorf("Expected ultraplan group, got %s", data.Groups[0].SessionType)
+	if orchestrator.GetSessionType(data.Groups[0]) != orchestrator.SessionTypeUltraPlan {
+		t.Errorf("Expected ultraplan group, got %s", orchestrator.GetSessionType(data.Groups[0]))
 	}
 
 	// Test FlattenGroupsForDisplay

--- a/internal/tui/view/group.go
+++ b/internal/tui/view/group.go
@@ -159,16 +159,17 @@ func RenderGroupHeaderWrapped(group *orchestrator.InstanceGroup, progress GroupP
 		collapseChar = styles.IconGroupCollapse // right-pointing triangle (collapsed)
 	}
 
-	// Session type icon
-	sessionIcon := group.SessionType.Icon()
-	hasIcon := group.SessionType != "" && group.SessionType != orchestrator.SessionTypeStandard
+	// Session type icon - use GetSessionType to get the typed SessionType with methods
+	sessionType := orchestrator.GetSessionType(group)
+	sessionIcon := sessionType.Icon()
+	hasIcon := group.SessionType != "" && sessionType != orchestrator.SessionTypeStandard
 
 	// Phase styling
 	phaseColor := PhaseColor(group.Phase)
 	phaseIndicator := PhaseIndicator(group.Phase)
 
 	// Session type color (use for the icon)
-	sessionColor := styles.SessionTypeColor(string(group.SessionType))
+	sessionColor := styles.SessionTypeColor(group.SessionType)
 
 	// Build the header components
 	progressStr := fmt.Sprintf("[%d/%d]", progress.Completed, progress.Total)

--- a/internal/tui/view/group_builder.go
+++ b/internal/tui/view/group_builder.go
@@ -52,7 +52,8 @@ func BuildGroupedSidebarData(session *orchestrator.Session) *GroupedSidebarData 
 
 	// Categorize groups by type
 	for _, group := range groups {
-		if group.SessionType.GroupingMode() == "shared" {
+		sessionType := orchestrator.GetSessionType(group)
+		if sessionType.GroupingMode() == "shared" {
 			data.SharedGroups = append(data.SharedGroups, group)
 		} else {
 			data.Groups = append(data.Groups, group)
@@ -117,7 +118,7 @@ func BuildSidebarSections(session *orchestrator.Session) []SidebarSection {
 		sections = append(sections, SidebarSection{
 			Type:  SectionTypeGroup,
 			Title: group.Name,
-			Icon:  group.SessionType.Icon(),
+			Icon:  orchestrator.GetSessionType(group).Icon(),
 			Group: group,
 		})
 	}
@@ -127,7 +128,7 @@ func BuildSidebarSections(session *orchestrator.Session) []SidebarSection {
 		sections = append(sections, SidebarSection{
 			Type:  SectionTypeSharedGroup,
 			Title: group.Name,
-			Icon:  group.SessionType.Icon(),
+			Icon:  orchestrator.GetSessionType(group).Icon(),
 			Group: group,
 		})
 	}

--- a/internal/tui/view/group_builder_test.go
+++ b/internal/tui/view/group_builder_test.go
@@ -72,16 +72,16 @@ func TestBuildGroupedSidebarData_WithGroups(t *testing.T) {
 	if len(data.Groups) != 1 {
 		t.Errorf("Expected 1 own group, got %d", len(data.Groups))
 	}
-	if data.Groups[0].SessionType != orchestrator.SessionTypeUltraPlan {
-		t.Errorf("Expected SessionTypeUltraPlan, got %s", data.Groups[0].SessionType)
+	if orchestrator.GetSessionType(data.Groups[0]) != orchestrator.SessionTypeUltraPlan {
+		t.Errorf("Expected SessionTypeUltraPlan, got %s", orchestrator.GetSessionType(data.Groups[0]))
 	}
 
 	// plan should be in SharedGroups (shared type)
 	if len(data.SharedGroups) != 1 {
 		t.Errorf("Expected 1 shared group, got %d", len(data.SharedGroups))
 	}
-	if data.SharedGroups[0].SessionType != orchestrator.SessionTypePlan {
-		t.Errorf("Expected SessionTypePlan, got %s", data.SharedGroups[0].SessionType)
+	if orchestrator.GetSessionType(data.SharedGroups[0]) != orchestrator.SessionTypePlan {
+		t.Errorf("Expected SessionTypePlan, got %s", orchestrator.GetSessionType(data.SharedGroups[0]))
 	}
 }
 

--- a/internal/tui/view/group_test.go
+++ b/internal/tui/view/group_test.go
@@ -190,7 +190,7 @@ func TestRenderGroupHeaderWrapped(t *testing.T) {
 				ID:          "test-1",
 				Name:        "Short",
 				Phase:       orchestrator.GroupPhasePending,
-				SessionType: orchestrator.SessionTypeTripleShot,
+				SessionType: string(orchestrator.SessionTypeTripleShot),
 			},
 			progress:   GroupProgress{Completed: 1, Total: 3},
 			collapsed:  false,
@@ -204,7 +204,7 @@ func TestRenderGroupHeaderWrapped(t *testing.T) {
 				ID:          "test-2",
 				Name:        "This is a very long group name that should wrap to multiple lines in the sidebar",
 				Phase:       orchestrator.GroupPhaseExecuting,
-				SessionType: orchestrator.SessionTypeTripleShot,
+				SessionType: string(orchestrator.SessionTypeTripleShot),
 			},
 			progress:   GroupProgress{Completed: 2, Total: 5},
 			collapsed:  false,
@@ -218,7 +218,7 @@ func TestRenderGroupHeaderWrapped(t *testing.T) {
 				ID:          "test-3",
 				Name:        "Selected Group",
 				Phase:       orchestrator.GroupPhaseCompleted,
-				SessionType: orchestrator.SessionTypePlan,
+				SessionType: string(orchestrator.SessionTypePlan),
 			},
 			progress:   GroupProgress{Completed: 3, Total: 3},
 			collapsed:  true,
@@ -247,7 +247,7 @@ func TestRenderGroupHeader_WrappedOutput(t *testing.T) {
 		ID:          "test-1",
 		Name:        "Test Group",
 		Phase:       orchestrator.GroupPhasePending,
-		SessionType: orchestrator.SessionTypeTripleShot,
+		SessionType: string(orchestrator.SessionTypeTripleShot),
 	}
 	progress := GroupProgress{Completed: 1, Total: 3}
 

--- a/internal/tui/view/sidebar_test.go
+++ b/internal/tui/view/sidebar_test.go
@@ -1462,7 +1462,7 @@ func TestSidebarView_GroupedModeShowsUngroupedInstances(t *testing.T) {
 				ID:          "tripleshot-group",
 				Name:        "Tripleshot",
 				Phase:       orchestrator.GroupPhaseExecuting,
-				SessionType: orchestrator.SessionTypeTripleShot,
+				SessionType: string(orchestrator.SessionTypeTripleShot),
 				Instances:   []string{"inst-1", "inst-2"},
 			},
 		},

--- a/internal/ultraplan/init_integration_test.go
+++ b/internal/ultraplan/init_integration_test.go
@@ -306,9 +306,9 @@ func TestInit_GroupSessionTypes(t *testing.T) {
 				t.Fatal("Group should be created")
 			}
 
-			if result.Group.SessionType != tt.wantSessionType {
+			if orchestrator.GetSessionType(result.Group) != tt.wantSessionType {
 				t.Errorf("Group.SessionType = %v, want %v",
-					result.Group.SessionType, tt.wantSessionType)
+					orchestrator.GetSessionType(result.Group), tt.wantSessionType)
 			}
 		})
 	}

--- a/internal/ultraplan/init_test.go
+++ b/internal/ultraplan/init_test.go
@@ -318,8 +318,8 @@ func TestCreateUltraPlanGroup(t *testing.T) {
 				t.Fatal("CreateUltraPlanGroup returned nil")
 			}
 
-			if group.SessionType != tt.wantSessionType {
-				t.Errorf("SessionType = %v, want %v", group.SessionType, tt.wantSessionType)
+			if orchestrator.GetSessionType(group) != tt.wantSessionType {
+				t.Errorf("SessionType = %v, want %v", orchestrator.GetSessionType(group), tt.wantSessionType)
 			}
 
 			if len(group.Name) > tt.wantNameMaxLen {
@@ -399,8 +399,8 @@ func TestCreateAndLinkUltraPlanGroup(t *testing.T) {
 			}
 
 			// Verify session type is correct
-			if group.SessionType != tt.wantSessionType {
-				t.Errorf("SessionType = %v, want %v", group.SessionType, tt.wantSessionType)
+			if orchestrator.GetSessionType(group) != tt.wantSessionType {
+				t.Errorf("SessionType = %v, want %v", orchestrator.GetSessionType(group), tt.wantSessionType)
 			}
 		})
 	}
@@ -757,8 +757,8 @@ func TestInit_GroupCreation(t *testing.T) {
 				if group == nil {
 					t.Fatal("expected group to be created")
 				}
-				if group.SessionType != tt.wantType {
-					t.Errorf("SessionType = %v, want %v", group.SessionType, tt.wantType)
+				if orchestrator.GetSessionType(group) != tt.wantType {
+					t.Errorf("SessionType = %v, want %v", orchestrator.GetSessionType(group), tt.wantType)
 				}
 				if ultraSession.GroupID != group.ID {
 					t.Errorf("GroupID = %q, want %q", ultraSession.GroupID, group.ID)


### PR DESCRIPTION
## Summary

- **Unified Group Types**: Creates a shared `grouptypes` package with canonical `InstanceGroup` and `GroupPhase` types, eliminating duplication across the `orchestrator`, `group`, and `session` packages. This removes ~80 lines of type conversion code and prevents data loss (SessionType and Objective fields were being silently dropped during conversions).

- **TimeoutType Consolidation**: Makes `state.TimeoutType` and `instance.TimeoutType` type aliases for `detect.TimeoutType`, eliminating duplicate type definitions and removing unnecessary type conversion code in the orchestrator.

## Changes

### New Package
- `internal/orchestrator/grouptypes/` - Shared type definitions with comprehensive tests (358 lines of test coverage)

### Modified Files
- `internal/orchestrator/instance_group.go` - Now uses type alias to grouptypes
- `internal/orchestrator/group/manager.go` - Uses grouptypes constructors
- `internal/orchestrator/session/types.go` - GroupData is now a type alias
- `internal/instance/manager.go` - TimeoutType is now a type alias
- `internal/instance/state/monitor.go` - TimeoutType is now a type alias
- `internal/orchestrator/orchestrator.go` - Removed type conversion code
- `internal/tui/inlineplan.go` - Removed ~80 lines of conversion functions

## Test plan

- [x] All existing tests pass
- [x] New tests for grouptypes package (100% coverage)
- [x] New test for `SetSessionType()` helper function
- [x] `go build ./...` succeeds
- [x] `go vet ./...` passes
- [x] `gofmt -d .` shows no formatting issues