### PR TITLE
Fix adversarial mode header alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Task Chaining by Sidebar Number** - The `:chain`, `:dep`, and `:depends` commands now accept an optional sidebar number argument to specify which instance to chain from (e.g., `:chain 2` or `:chain #2`). This is more user-friendly than using instance IDs, which aren't prominently displayed.
 
+### Fixed
+
+- **Adversarial Mode Header Alignment** - Fixed the adversarial mode header displaying the status text outside the styled header border, causing visual misalignment
+
 ### Changed
 
 - **Unified Group Types** - Refactored the `group`, `orchestrator`, and `session` packages to use a shared `grouptypes.InstanceGroup` type, eliminating type duplication and ~80 lines of conversion code. This also prevents data loss (SessionType and Objective fields) when using the group manager.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1471,11 +1471,37 @@ func (m Model) renderAdversarialHeader() string {
 	// Render the adversarial status part
 	advHeader := view.RenderAdversarialHeader(ctx)
 
-	// Combine title with adversarial header
-	if advHeader != "" {
-		return styles.Header.Render(title) + "  " + advHeader
+	// Calculate available width for layout
+	termWidth := m.terminalManager.Width()
+
+	// If no adversarial header, render simple header
+	if advHeader == "" {
+		return styles.Header.Width(termWidth).Render(title)
 	}
-	return styles.Header.Render(title)
+
+	// Calculate widths for left-right layout
+	advWidth := lipgloss.Width(advHeader)
+	titleWidth := termWidth - advWidth - 2 // 2 for spacing
+
+	// Style for title (left side)
+	titleStyled := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(styles.PrimaryColor).
+		Width(titleWidth).
+		Render(title)
+
+	// Join title and adversarial status
+	content := lipgloss.JoinHorizontal(lipgloss.Center, titleStyled, " ", advHeader)
+
+	// Apply the header border styling
+	return lipgloss.NewStyle().
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderBottom(true).
+		BorderForeground(styles.BorderColor).
+		MarginBottom(1).
+		PaddingBottom(1).
+		Width(termWidth).
+		Render(content)
 }
 
 // renderAdversarialHelp renders the help bar for adversarial mode.


### PR DESCRIPTION
## Summary

- Fixed the adversarial mode header displaying status text outside the styled header border
- Updated `renderAdversarialHeader()` to follow the same layout pattern as `renderHeader()`
- Properly composes title and adversarial status within a single styled container using `lipgloss.JoinHorizontal`

## Details

The original code was concatenating the styled title with the adversarial status:
```go
return styles.Header.Render(title) + "  " + advHeader
```

This caused the border to only wrap the title, leaving the adversarial status misaligned outside the styled box.

The fix uses proper lipgloss composition:
1. Calculate terminal width for layout
2. Style the title text (without border)  
3. Join title and status horizontally
4. Apply border styling to the entire composed content

## Test plan

- [x] Build passes (`go build ./...`)
- [x] Tests pass (`go test ./...`)
- [x] Linting passes (`go vet ./...`)
- [ ] Manually verify adversarial mode header renders correctly with status aligned inside the border