### PR TITLE
Fix scroll-to-top key overload by changing g to 0

### DIFF
--- a/.claude-prompt
+++ b/.claude-prompt
@@ -1,1 +1,5 @@
-Implement a group shortcut that effectively does a `:D` on every member of the group. maybe `gq` if that's in keeping with vim norms?
+The 'g' key is overloaded:
+- 'g' triggers group commands like gc, gn, gp
+- 'g' used to trigger scroll-to-top (`G` scrolls to bottom). 
+
+We should change the scroll-to-top key and hint in the UI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Scroll-to-Top Key Binding** - Changed scroll-to-top from `g` to `0` (zero) to resolve overload conflict with group commands (`gc`, `gn`, `gp`, etc.). The `g` key now exclusively enters group command mode when in grouped sidebar view.
 - **Add Task Dialog Titles** - The "Add New Instance" dialog now displays context-aware titles based on the type of task being created: "Triple-Shot" for triple-shot mode, "Adversarial Review" for adversarial mode, "Chain Task" for dependent tasks, and "New Task" for standard tasks. Each mode also shows a descriptive subtitle explaining its purpose.
 
 ### Added

--- a/internal/tui/keyhandler.go
+++ b/internal/tui/keyhandler.go
@@ -523,8 +523,15 @@ func (m Model) handleNormalModeKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "ctrl+k":
 		return m.handleKillInstance()
 
-	case "g":
+	case "0":
 		return m.handleGoToTop()
+
+	case "g":
+		// Enter group command mode (for gc, gn, gp, etc.)
+		if m.sidebarMode == view.SidebarModeGrouped && m.session != nil && m.session.HasGroups() {
+			m.inputRouter.SetGroupCommandPending(true)
+		}
+		return m, nil
 
 	case "G":
 		return m.handleGoToBottom()
@@ -870,12 +877,6 @@ func (m Model) handleKillInstance() (tea.Model, tea.Cmd) {
 
 // handleGoToTop goes to the top of diff, help panel, or output.
 func (m Model) handleGoToTop() (tea.Model, tea.Cmd) {
-	// In grouped sidebar mode with groups, enter group command mode
-	if m.sidebarMode == view.SidebarModeGrouped && m.session != nil && m.session.HasGroups() {
-		m.inputRouter.SetGroupCommandPending(true)
-		return m, nil
-	}
-	// Otherwise, go to top of diff, help panel, or output
 	if m.showDiff {
 		m.diffScroll = 0
 		return m, nil

--- a/internal/tui/panel/diff.go
+++ b/internal/tui/panel/diff.go
@@ -88,7 +88,7 @@ func (p *DiffPanel) Render(state *RenderState) string {
 
 	// Show scroll indicator
 	scrollInfo := fmt.Sprintf("Lines %d-%d of %d", startLine+1, endLine, totalLines)
-	helpHint := "[j/k scroll, g/G top/bottom, d/Esc close]"
+	helpHint := "[j/k scroll, 0/G top/bottom, d/Esc close]"
 	if totalLines <= maxLines {
 		helpHint = "[d/Esc close]"
 	}

--- a/internal/tui/panel/help.go
+++ b/internal/tui/panel/help.go
@@ -134,7 +134,7 @@ func DefaultHelpSections() []HelpSection {
 				{Key: "Tab/l  Shift+Tab/h", Description: "Next / Previous instance"},
 				{Key: "j/↓  k/↑", Description: "Scroll down / up one line"},
 				{Key: "Ctrl+D/U  Ctrl+F/B", Description: "Scroll half / full page"},
-				{Key: "gg  G", Description: "Jump to top / bottom"},
+				{Key: "0  G", Description: "Jump to top / bottom"},
 			},
 		},
 		{

--- a/internal/tui/view/help_bar.go
+++ b/internal/tui/view/help_bar.go
@@ -149,7 +149,7 @@ func (v *HelpBarView) RenderHelp(state *HelpBarState) string {
 	if state.ShowDiff {
 		badge := styles.ModeBadgeDiff.Render("DIFF")
 		help := styles.HelpKey.Render("[j/k]") + " scroll  " +
-			styles.HelpKey.Render("[g/G]") + " top/bottom  " +
+			styles.HelpKey.Render("[0/G]") + " top/bottom  " +
 			styles.HelpKey.Render("[:d/Esc]") + " close"
 		return styles.HelpBar.Render(badge + "  " + help)
 	}


### PR DESCRIPTION
## Summary

- Changed scroll-to-top key from `g` to `0` (zero) to resolve conflict with group commands
- The `g` key now exclusively enters group command mode when in grouped sidebar view
- Updated all UI hints to reflect the new key binding

## Problem

The `g` key was overloaded:
- Single `g` triggered scroll-to-top
- `g` was also the prefix for group commands (`gc`, `gn`, `gp`, etc.)

This caused confusion because pressing `g` would either scroll to top OR enter group command mode depending on context.

## Solution

- `0` now scrolls to top (vim-like convention for "go to beginning")
- `g` exclusively enters group command mode when applicable
- `G` continues to scroll to bottom (unchanged)

## Test plan

- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [ ] Manual: Press `0` to scroll to top in output view
- [ ] Manual: Press `0` to scroll to top in diff view
- [ ] Manual: Press `g` in grouped sidebar mode enters group command mode
- [ ] Manual: Verify help text shows correct keys (`?` to open help)