### PR TITLE
Add color support to terminal pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Terminal Pane Color Support** - Fixed the terminal pane not displaying colors properly by setting `TERM=xterm-256color` in the environment and configuring `default-terminal` per-session before tmux session creation. The approach now aligns with the instance package for consistency.
+
 ### Changed
 
 - **Add Task Dialog Titles** - The "Add New Instance" dialog now displays context-aware titles based on the type of task being created: "Triple-Shot" for triple-shot mode, "Adversarial Review" for adversarial mode, "Chain Task" for dependent tasks, and "New Task" for standard tasks. Each mode also shows a descriptive subtitle explaining its purpose.

--- a/internal/tui/terminal/process_test.go
+++ b/internal/tui/terminal/process_test.go
@@ -1,10 +1,56 @@
 package terminal
 
 import (
+	"os/exec"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/Iron-Ham/claudio/internal/tmux"
 )
+
+// mockCommandRunner records all tmux commands for verification in tests.
+type mockCommandRunner struct {
+	commands     []mockCommand // recorded commands
+	runErr       error         // error to return from Run
+	outputResult []byte        // result to return from Output
+	outputErr    error         // error to return from Output
+}
+
+// mockCommand represents a recorded tmux command.
+type mockCommand struct {
+	socketName string
+	args       []string
+	hasEnv     bool // whether this was from CommandWithEnv
+}
+
+func (m *mockCommandRunner) Run(socketName string, args ...string) error {
+	m.commands = append(m.commands, mockCommand{
+		socketName: socketName,
+		args:       args,
+	})
+	return m.runErr
+}
+
+func (m *mockCommandRunner) Output(socketName string, args ...string) ([]byte, error) {
+	m.commands = append(m.commands, mockCommand{
+		socketName: socketName,
+		args:       args,
+	})
+	return m.outputResult, m.outputErr
+}
+
+func (m *mockCommandRunner) CommandWithEnv(socketName string, args ...string) *exec.Cmd {
+	// Record the command but return a real exec.Cmd that we can inspect
+	// We use /bin/sh -c true which ignores Dir settings that might not exist
+	cmd := exec.Command("/bin/sh", "-c", "true")
+	m.commands = append(m.commands, mockCommand{
+		socketName: socketName,
+		args:       args,
+		hasEnv:     true,
+	})
+	return cmd
+}
 
 func TestNewProcess(t *testing.T) {
 	p := NewProcess("session123", "/tmp", 100, 50)
@@ -123,5 +169,209 @@ func TestProcess_CurrentDir(t *testing.T) {
 
 	if got := p.InvocationDir(); got != invocationDir {
 		t.Errorf("InvocationDir() = %q, want %q", got, invocationDir)
+	}
+}
+
+func TestProcess_Start_TmuxCommandSequence(t *testing.T) {
+	mock := &mockCommandRunner{}
+	// Use /tmp as it's guaranteed to exist on all Unix systems
+	p := NewProcessWithRunner("test-session", "test-socket", "/tmp", 100, 50, mock)
+
+	err := p.Start()
+	if err != nil {
+		t.Fatalf("Start() returned unexpected error: %v", err)
+	}
+
+	// Verify the correct sequence of tmux commands was executed
+	// Expected sequence:
+	// 1. kill-session (cleanup any existing session)
+	// 2. set-option -g history-limit 50000
+	// 3. new-session (via CommandWithEnv for environment variable support)
+	// 4. set-option -t <session> default-terminal xterm-256color
+
+	if len(mock.commands) != 4 {
+		t.Fatalf("Expected 4 tmux commands, got %d: %+v", len(mock.commands), mock.commands)
+	}
+
+	// Command 1: kill-session cleanup
+	cmd := mock.commands[0]
+	if cmd.socketName != "test-socket" {
+		t.Errorf("Command 1: socket = %q, want %q", cmd.socketName, "test-socket")
+	}
+	if len(cmd.args) < 1 || cmd.args[0] != "kill-session" {
+		t.Errorf("Command 1: expected kill-session, got %v", cmd.args)
+	}
+
+	// Command 2: set history-limit globally (before session creation)
+	cmd = mock.commands[1]
+	expectedArgs := []string{"set-option", "-g", "history-limit", "50000"}
+	if !slices.Equal(cmd.args, expectedArgs) {
+		t.Errorf("Command 2: args = %v, want %v", cmd.args, expectedArgs)
+	}
+
+	// Command 3: new-session with proper dimensions (via CommandWithEnv)
+	cmd = mock.commands[2]
+	if !cmd.hasEnv {
+		t.Errorf("Command 3: expected CommandWithEnv to be used for new-session")
+	}
+	if len(cmd.args) < 1 || cmd.args[0] != "new-session" {
+		t.Errorf("Command 3: expected new-session, got %v", cmd.args)
+	}
+	// Verify session name and dimensions are in args
+	argsStr := strings.Join(cmd.args, " ")
+	if !strings.Contains(argsStr, "claudio-term-test-session") {
+		t.Errorf("Command 3: session name not found in args: %v", cmd.args)
+	}
+	if !strings.Contains(argsStr, "-x 100") {
+		t.Errorf("Command 3: width not found in args: %v", cmd.args)
+	}
+	if !strings.Contains(argsStr, "-y 50") {
+		t.Errorf("Command 3: height not found in args: %v", cmd.args)
+	}
+
+	// Command 4: set default-terminal per-session (not global)
+	cmd = mock.commands[3]
+	if cmd.args[0] != "set-option" {
+		t.Errorf("Command 4: expected set-option, got %v", cmd.args)
+	}
+	// Should use -t (per-session) not -g (global)
+	if !slices.Contains(cmd.args, "-t") {
+		t.Errorf("Command 4: expected -t flag for per-session option, got %v", cmd.args)
+	}
+	if slices.Contains(cmd.args, "-g") {
+		t.Errorf("Command 4: should not use -g (global) for default-terminal, got %v", cmd.args)
+	}
+	if !slices.Contains(cmd.args, "default-terminal") || !slices.Contains(cmd.args, "xterm-256color") {
+		t.Errorf("Command 4: expected default-terminal xterm-256color, got %v", cmd.args)
+	}
+
+	// Verify running state
+	if !p.IsRunning() {
+		t.Error("Process should be running after Start()")
+	}
+}
+
+func TestProcess_Start_DefaultDimensions(t *testing.T) {
+	mock := &mockCommandRunner{}
+	// Use 0 for width and height to test default values
+	p := NewProcessWithRunner("test-session", "test-socket", "/tmp", 0, 0, mock)
+
+	err := p.Start()
+	if err != nil {
+		t.Fatalf("Start() returned unexpected error: %v", err)
+	}
+
+	// Find the new-session command
+	var newSessionCmd *mockCommand
+	for i := range mock.commands {
+		if len(mock.commands[i].args) > 0 && mock.commands[i].args[0] == "new-session" {
+			newSessionCmd = &mock.commands[i]
+			break
+		}
+	}
+
+	if newSessionCmd == nil {
+		t.Fatal("new-session command not found")
+	}
+
+	// Check for default dimensions (200x10)
+	argsStr := strings.Join(newSessionCmd.args, " ")
+	if !strings.Contains(argsStr, "-x 200") {
+		t.Errorf("Expected default width 200, got args: %v", newSessionCmd.args)
+	}
+	if !strings.Contains(argsStr, "-y 10") {
+		t.Errorf("Expected default height 10, got args: %v", newSessionCmd.args)
+	}
+}
+
+func TestProcess_Start_AlreadyRunning(t *testing.T) {
+	mock := &mockCommandRunner{}
+	p := NewProcessWithRunner("test", "socket", "/tmp", 100, 50, mock)
+
+	// Start the process
+	if err := p.Start(); err != nil {
+		t.Fatalf("First Start() failed: %v", err)
+	}
+
+	// Try to start again
+	err := p.Start()
+	if err != ErrAlreadyRunning {
+		t.Errorf("Second Start() = %v, want ErrAlreadyRunning", err)
+	}
+}
+
+func TestProcess_Stop_TmuxCommand(t *testing.T) {
+	mock := &mockCommandRunner{}
+	p := NewProcessWithRunner("test", "test-socket", "/tmp", 100, 50, mock)
+
+	// Start the process first
+	if err := p.Start(); err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	// Clear recorded commands
+	mock.commands = nil
+
+	// Stop the process
+	if err := p.Stop(); err != nil {
+		t.Fatalf("Stop() failed: %v", err)
+	}
+
+	// Verify kill-session command was sent
+	if len(mock.commands) != 1 {
+		t.Fatalf("Expected 1 command (kill-session), got %d", len(mock.commands))
+	}
+
+	cmd := mock.commands[0]
+	if cmd.args[0] != "kill-session" {
+		t.Errorf("Expected kill-session, got %v", cmd.args)
+	}
+	if !slices.Contains(cmd.args, "claudio-term-test") {
+		t.Errorf("Expected session name in kill-session args, got %v", cmd.args)
+	}
+
+	// Verify not running
+	if p.IsRunning() {
+		t.Error("Process should not be running after Stop()")
+	}
+}
+
+func TestProcess_NoMouseOrAggressiveResize(t *testing.T) {
+	// This test ensures we don't add mouse support or aggressive-resize
+	// as those were identified as scope creep in the review.
+	mock := &mockCommandRunner{}
+	p := NewProcessWithRunner("test", "socket", "/tmp", 100, 50, mock)
+
+	if err := p.Start(); err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	// Verify no mouse or aggressive-resize commands were sent
+	for _, cmd := range mock.commands {
+		argsStr := strings.Join(cmd.args, " ")
+		if strings.Contains(argsStr, "mouse") {
+			t.Errorf("Unexpected mouse command found: %v", cmd.args)
+		}
+		if strings.Contains(argsStr, "aggressive-resize") {
+			t.Errorf("Unexpected aggressive-resize command found: %v", cmd.args)
+		}
+	}
+}
+
+func TestNewProcessWithRunner(t *testing.T) {
+	mock := &mockCommandRunner{}
+	p := NewProcessWithRunner("session123", "custom-socket", "/home/user", 80, 24, mock)
+
+	if p == nil {
+		t.Fatal("NewProcessWithRunner returned nil")
+	}
+
+	if got := p.SocketName(); got != "custom-socket" {
+		t.Errorf("SocketName() = %q, want %q", got, "custom-socket")
+	}
+
+	expectedSession := "claudio-term-session123"
+	if got := p.SessionName(); got != expectedSession {
+		t.Errorf("SessionName() = %q, want %q", got, expectedSession)
 	}
 }


### PR DESCRIPTION
## Summary
- Fixed the terminal pane not displaying colors properly by setting `TERM=xterm-256color` in the environment when creating tmux sessions
- Configured `default-terminal` per-session (not globally) to avoid affecting other tmux sessions
- Added `CommandRunner` interface for dependency injection, enabling mock-based testing of tmux command sequences
- Aligned the approach with `internal/instance/process/tmux.go` for consistency across the codebase

## Test plan
- [x] Added `TestProcess_Start_TmuxCommandSequence` - verifies correct command sequence and per-session options
- [x] Added `TestProcess_Start_DefaultDimensions` - verifies default width/height fallbacks
- [x] Added `TestProcess_Start_AlreadyRunning` - verifies ErrAlreadyRunning error
- [x] Added `TestProcess_Stop_TmuxCommand` - verifies kill-session command
- [x] Added `TestProcess_NoMouseOrAggressiveResize` - guards against scope creep
- [x] Added `TestNewProcessWithRunner` - verifies constructor with custom runner
- [x] All tests pass: `go test ./internal/tui/terminal/...`