### PR TITLE
Add full adversarial review configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Reviewer critically examines the work and provides detailed feedback
   - Loop continues until Reviewer approves the implementation or max iterations reached
   - Configurable max iterations with `--max-iterations` flag (default: 10)
+  - Configurable minimum passing score with `--min-passing-score` flag (default: 8)
+  - Both settings can be configured in `config.yaml` under `adversarial:` section or via TUI config editor
   - Useful for complex implementations that benefit from rigorous code review
   - **NEW**: Now accessible from the TUI via `:adversarial` or `:adv` command
   - Supports multiple concurrent adversarial sessions, similar to TripleShot mode

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	Resources    ResourceConfig     `mapstructure:"resources"`
 	Ultraplan    UltraplanConfig    `mapstructure:"ultraplan"`
 	Plan         PlanConfig         `mapstructure:"plan"`
+	Adversarial  AdversarialConfig  `mapstructure:"adversarial"`
 	Logging      LoggingConfig      `mapstructure:"logging"`
 	Paths        PathsConfig        `mapstructure:"paths"`
 	Experimental ExperimentalConfig `mapstructure:"experimental"`
@@ -175,6 +176,18 @@ type PlanConfig struct {
 	Labels []string `mapstructure:"labels"`
 	// OutputFile is the default output file path for JSON output (default: ".claudio-plan.json")
 	OutputFile string `mapstructure:"output_file"`
+}
+
+// AdversarialConfig controls adversarial review mode behavior.
+// Note: This struct is for configuration file persistence and viper loading.
+// There is a corresponding orchestrator.AdversarialConfig struct used at runtime
+// which should be kept in sync with this one when adding new fields.
+type AdversarialConfig struct {
+	// MaxIterations limits the number of implement-review cycles (default: 10, 0 = unlimited)
+	MaxIterations int `mapstructure:"max_iterations"`
+	// MinPassingScore is the minimum score required for approval (1-10, default: 8)
+	// The reviewer must give a score >= this value for the implementation to be approved
+	MinPassingScore int `mapstructure:"min_passing_score"`
 }
 
 // LoggingConfig controls debug logging behavior
@@ -386,6 +399,10 @@ func Default() *Config {
 			Labels:       []string{},
 			OutputFile:   ".claudio-plan.json",
 		},
+		Adversarial: AdversarialConfig{
+			MaxIterations:   10, // Reasonable default to prevent infinite loops
+			MinPassingScore: 8,  // Score >= 8 required for approval
+		},
 		Logging: LoggingConfig{
 			Enabled:    true,
 			Level:      "info",
@@ -493,6 +510,10 @@ func SetDefaults() {
 	viper.SetDefault("plan.multi_pass", defaults.Plan.MultiPass)
 	viper.SetDefault("plan.labels", defaults.Plan.Labels)
 	viper.SetDefault("plan.output_file", defaults.Plan.OutputFile)
+
+	// Adversarial defaults
+	viper.SetDefault("adversarial.max_iterations", defaults.Adversarial.MaxIterations)
+	viper.SetDefault("adversarial.min_passing_score", defaults.Adversarial.MinPassingScore)
 
 	// Logging defaults
 	viper.SetDefault("logging.enabled", defaults.Logging.Enabled)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -264,6 +264,53 @@ func TestConfig_ResourceConfig_Values(t *testing.T) {
 	}
 }
 
+func TestConfig_AdversarialConfig_Defaults(t *testing.T) {
+	cfg := Default()
+
+	// MaxIterations should default to 10
+	if cfg.Adversarial.MaxIterations != 10 {
+		t.Errorf("Adversarial.MaxIterations = %d, want 10", cfg.Adversarial.MaxIterations)
+	}
+
+	// MinPassingScore should default to 8
+	if cfg.Adversarial.MinPassingScore != 8 {
+		t.Errorf("Adversarial.MinPassingScore = %d, want 8", cfg.Adversarial.MinPassingScore)
+	}
+}
+
+func TestConfig_AdversarialConfig_ViperLoading(t *testing.T) {
+	// Test that adversarial config is properly loaded via viper
+	viper.Reset()
+	SetDefaults()
+
+	// After SetDefaults, adversarial values should be the defaults
+	if viper.GetInt("adversarial.max_iterations") != 10 {
+		t.Errorf("viper.GetInt('adversarial.max_iterations') = %d, want 10", viper.GetInt("adversarial.max_iterations"))
+	}
+	if viper.GetInt("adversarial.min_passing_score") != 8 {
+		t.Errorf("viper.GetInt('adversarial.min_passing_score') = %d, want 8", viper.GetInt("adversarial.min_passing_score"))
+	}
+
+	// Test setting via viper (simulates config file or environment)
+	viper.Set("adversarial.max_iterations", 5)
+	viper.Set("adversarial.min_passing_score", 9)
+
+	cfg := Get()
+	if cfg.Adversarial.MaxIterations != 5 {
+		t.Errorf("Adversarial.MaxIterations = %d, want 5", cfg.Adversarial.MaxIterations)
+	}
+	if cfg.Adversarial.MinPassingScore != 9 {
+		t.Errorf("Adversarial.MinPassingScore = %d, want 9", cfg.Adversarial.MinPassingScore)
+	}
+
+	// Test unlimited iterations (0)
+	viper.Set("adversarial.max_iterations", 0)
+	cfg = Get()
+	if cfg.Adversarial.MaxIterations != 0 {
+		t.Errorf("Adversarial.MaxIterations = %d, want 0 (unlimited)", cfg.Adversarial.MaxIterations)
+	}
+}
+
 func TestConfig_UltraplanConfig_Values(t *testing.T) {
 	cfg := Default()
 

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -79,6 +79,9 @@ func (c *Config) Validate() []ValidationError {
 	// Validate Plan config
 	errors = append(errors, c.validatePlan()...)
 
+	// Validate Adversarial config
+	errors = append(errors, c.validateAdversarial()...)
+
 	// Validate Logging config
 	errors = append(errors, c.validateLogging()...)
 
@@ -401,6 +404,38 @@ func (c *Config) validatePlan() []ValidationError {
 			Field:   "plan.output_file",
 			Value:   c.Plan.OutputFile,
 			Message: "cannot be empty when output_format is 'json' or 'both'",
+		})
+	}
+
+	return errors
+}
+
+// validateAdversarial validates the AdversarialConfig
+func (c *Config) validateAdversarial() []ValidationError {
+	var errors []ValidationError
+
+	// MaxIterations must be non-negative (0 means unlimited)
+	if c.Adversarial.MaxIterations < 0 {
+		errors = append(errors, ValidationError{
+			Field:   "adversarial.max_iterations",
+			Value:   c.Adversarial.MaxIterations,
+			Message: "must be non-negative (0 = unlimited)",
+		})
+	}
+
+	// MinPassingScore must be between 1 and 10
+	if c.Adversarial.MinPassingScore < 1 {
+		errors = append(errors, ValidationError{
+			Field:   "adversarial.min_passing_score",
+			Value:   c.Adversarial.MinPassingScore,
+			Message: "must be at least 1",
+		})
+	}
+	if c.Adversarial.MinPassingScore > 10 {
+		errors = append(errors, ValidationError{
+			Field:   "adversarial.min_passing_score",
+			Value:   c.Adversarial.MinPassingScore,
+			Message: "cannot exceed 10",
 		})
 	}
 

--- a/internal/tui/config/config.go
+++ b/internal/tui/config/config.go
@@ -398,6 +398,25 @@ func New() Model {
 			},
 		},
 		{
+			Name: "Adversarial",
+			Items: []ConfigItem{
+				{
+					Key:         "adversarial.max_iterations",
+					Label:       "Max Iterations",
+					Description: "Maximum implement-review cycles (0 = unlimited)",
+					Type:        "int",
+					Category:    "adversarial",
+				},
+				{
+					Key:         "adversarial.min_passing_score",
+					Label:       "Min Passing Score",
+					Description: "Minimum reviewer score for approval (1-10)",
+					Type:        "int",
+					Category:    "adversarial",
+				},
+			},
+		},
+		{
 			Name: "Paths",
 			Items: []ConfigItem{
 				{
@@ -1056,6 +1075,12 @@ func (m *Model) validateAndSet(item ConfigItem, value string) error {
 		if intVal < 0 {
 			return fmt.Errorf("value must be non-negative")
 		}
+		// Item-specific validation for fields with special constraints
+		if item.Key == "adversarial.min_passing_score" {
+			if intVal < 1 || intVal > 10 {
+				return fmt.Errorf("value must be between 1 and 10")
+			}
+		}
 		viper.Set(item.Key, intVal)
 	case "float":
 		floatVal, err := strconv.ParseFloat(value, 64)
@@ -1164,6 +1189,9 @@ func (m *Model) resetCurrentToDefault() {
 		"plan.multi_pass":    defaults.Plan.MultiPass,
 		"plan.labels":        strings.Join(defaults.Plan.Labels, ","),
 		"plan.output_file":   defaults.Plan.OutputFile,
+		// Adversarial
+		"adversarial.max_iterations":    defaults.Adversarial.MaxIterations,
+		"adversarial.min_passing_score": defaults.Adversarial.MinPassingScore,
 		// Paths
 		"paths.worktree_dir":                   defaults.Paths.WorktreeDir,
 		"paths.sparse_checkout.enabled":        defaults.Paths.SparseCheckout.Enabled,


### PR DESCRIPTION
## Summary

- Add configurable `max_iterations` and `min_passing_score` for adversarial review mode
- Both settings can be configured via config.yaml, CLI flags, or TUI config editor
- Includes programmatic enforcement: reviews with score below threshold are automatically rejected

## Changes

### Configuration
- **AdversarialConfig struct** - Added to config package with:
  - `MaxIterations` (default: 10, 0 = unlimited)
  - `MinPassingScore` (default: 8, range 1-10)
- **Validation** - Both fields are validated at config load time
- **Viper defaults** - Properly registered in SetDefaults()

### CLI
- Added `--max-iterations` flag (defaults to config value)
- Added `--min-passing-score` flag (defaults to config value)
- Updated help text with configuration documentation

### TUI Config Editor
- Added "Adversarial" category with both settings
- Added item-specific validation for `min_passing_score` (immediate feedback for 1-10 range)
- Added reset-to-default support

### Runtime Enforcement
- Reviewer prompt now includes configurable score threshold
- **Programmatic enforcement**: If reviewer marks `approved: true` but `score < min_passing_score`, the review is automatically rejected with an explanatory message
- Runtime fallback to default (8) if config value is invalid

### Documentation
- Added cross-reference comments between `config.AdversarialConfig` and `orchestrator.AdversarialConfig` to prevent drift
- CHANGELOG entry included

## Test plan

- [ ] Run `go test ./internal/config/... -v -run Adversarial` - all tests pass
- [ ] Run `go test ./internal/tui/config/...` - all tests pass
- [ ] Build succeeds: `go build ./...`
- [ ] Verify CLI: `claudio adversarial --help` shows new flags
- [ ] Test TUI config editor: `claudio config` shows Adversarial category
- [ ] Test validation: setting min_passing_score to 0 or 11 in TUI shows error