### PR TITLE
Respect terminal_support config for terminal keybindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Terminal Keybindings Respect Config** - Fixed backtick (`) and `T` keys toggling the terminal pane even when `experimental.terminal_support` is disabled in the config. The terminal keybindings now correctly check the config setting before activating.
+
 - **Adversarial Review Score Threshold Enforcement** - Fixed a bug where users who set a minimum passing score higher than the default (e.g., 9 or 10) would have the adversarial loop stop prematurely. The issue occurred because approval notifications were sent before score enforcement was applied, causing callbacks to receive the unenforced state. The enforcement check is now performed before any notifications, ensuring the loop correctly continues when the reviewer's score is below the configured threshold.
+
+## [0.10.0] - 2026-01-17
+
+This release introduces **Adversarial Review Mode** and **Ralph Wiggum Loop** - two powerful new workflows for iterative development and code review. It also graduates TripleShot from experimental to a permanent feature.
+
+### Fixed
 
 - **Terminal Pane Color Support** - Fixed the terminal pane not displaying colors properly by setting `TERM=xterm-256color` in the environment and configuring `default-terminal` per-session before tmux session creation. The approach now aligns with the instance package for consistency.
 
-### Changed
-
-- **Coordinator Thin Facade Refactoring** - The Coordinator has been refactored into a thin facade that delegates phase execution to specialized phase orchestrators (PlanningOrchestrator, ExecutionOrchestrator, SynthesisOrchestrator). This improves separation of concerns and testability by moving phase-specific logic into dedicated orchestrators, with the Coordinator now serving as the public API that coordinates between phases.
-
-- **Scroll-to-Top Key Binding** - Changed scroll-to-top from `g` to `0` (zero) to resolve overload conflict with group commands (`gc`, `gn`, `gp`, etc.). The `g` key now exclusively enters group command mode when in grouped sidebar view.
-
-- **Add Task Dialog Titles** - The "Add New Instance" dialog now displays context-aware titles based on the type of task being created: "Triple-Shot" for triple-shot mode, "Adversarial Review" for adversarial mode, "Chain Task" for dependent tasks, and "New Task" for standard tasks. Each mode also shows a descriptive subtitle explaining its purpose.
+- **Adversarial Mode Header Alignment** - Fixed the adversarial mode header displaying the status text outside the styled header border, causing visual misalignment.
 
 ### Added
 
@@ -44,9 +46,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Named after the Simpsons character Ralph Wiggum, referencing the "I'm helping!" meme for iterative self-improvement
 
 - **Task Chaining by Sidebar Number** - The `:chain`, `:dep`, and `:depends` commands now accept an optional sidebar number argument to specify which instance to chain from (e.g., `:chain 2` or `:chain #2`). This is more user-friendly than using instance IDs, which aren't prominently displayed.
-- **Adversarial Mode Header Alignment** - Fixed the adversarial mode header displaying the status text outside the styled header border, causing visual misalignment
 
 ### Changed
+
+- **Coordinator Thin Facade Refactoring** - The Coordinator has been refactored into a thin facade that delegates phase execution to specialized phase orchestrators (PlanningOrchestrator, ExecutionOrchestrator, SynthesisOrchestrator). This improves separation of concerns and testability by moving phase-specific logic into dedicated orchestrators, with the Coordinator now serving as the public API that coordinates between phases.
+
+- **Scroll-to-Top Key Binding** - Changed scroll-to-top from `g` to `0` (zero) to resolve overload conflict with group commands (`gc`, `gn`, `gp`, etc.). The `g` key now exclusively enters group command mode when in grouped sidebar view.
+
+- **Add Task Dialog Titles** - The "Add New Instance" dialog now displays context-aware titles based on the type of task being created: "Triple-Shot" for triple-shot mode, "Adversarial Review" for adversarial mode, "Chain Task" for dependent tasks, and "New Task" for standard tasks. Each mode also shows a descriptive subtitle explaining its purpose.
 
 - **Unified Group Types** - Refactored the `group`, `orchestrator`, and `session` packages to use a shared `grouptypes.InstanceGroup` type, eliminating type duplication and ~80 lines of conversion code. This also prevents data loss (SessionType and Objective fields) when using the group manager.
 

--- a/internal/tui/keyhandler.go
+++ b/internal/tui/keyhandler.go
@@ -10,6 +10,7 @@ import (
 	tuimsg "github.com/Iron-Ham/claudio/internal/tui/msg"
 	"github.com/Iron-Ham/claudio/internal/tui/view"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spf13/viper"
 )
 
 // -----------------------------------------------------------------------------
@@ -674,6 +675,10 @@ func (m Model) handleEnterInputMode() (tea.Model, tea.Cmd) {
 
 // handleToggleTerminal toggles terminal pane visibility.
 func (m Model) handleToggleTerminal() (tea.Model, tea.Cmd) {
+	// Check if terminal support is enabled
+	if !viper.GetBool("experimental.terminal_support") {
+		return m, nil
+	}
 	sessionID := ""
 	if m.orchestrator != nil {
 		sessionID = m.orchestrator.SessionID()
@@ -684,6 +689,10 @@ func (m Model) handleToggleTerminal() (tea.Model, tea.Cmd) {
 
 // handleSwitchTerminalDir switches terminal directory mode.
 func (m Model) handleSwitchTerminalDir() (tea.Model, tea.Cmd) {
+	// Check if terminal support is enabled
+	if !viper.GetBool("experimental.terminal_support") {
+		return m, nil
+	}
 	if m.terminalManager.IsVisible() {
 		m.switchTerminalDir()
 	}

--- a/internal/tui/terminal_test.go
+++ b/internal/tui/terminal_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/Iron-Ham/claudio/internal/tui/terminal"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spf13/viper"
 )
 
 func TestTerminalHeightConstants(t *testing.T) {
@@ -335,4 +337,101 @@ func TestGetTerminalDir(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTerminalKeybindingsDisabled(t *testing.T) {
+	// Save original value and restore after test
+	originalValue := viper.GetBool("experimental.terminal_support")
+	defer viper.Set("experimental.terminal_support", originalValue)
+
+	// Disable terminal support
+	viper.Set("experimental.terminal_support", false)
+
+	t.Run("backtick key does nothing when terminal disabled", func(t *testing.T) {
+		m := Model{
+			terminalManager: terminal.NewManager(),
+		}
+
+		// Verify terminal is not visible initially
+		if m.IsTerminalVisible() {
+			t.Fatal("terminal should not be visible initially")
+		}
+
+		// Call handleToggleTerminal (triggered by backtick key)
+		newModel, _ := m.handleToggleTerminal()
+		resultModel := newModel.(Model)
+
+		// Verify terminal is still not visible
+		if resultModel.IsTerminalVisible() {
+			t.Error("terminal should remain hidden when terminal support is disabled")
+		}
+	})
+
+	t.Run("T key does nothing when terminal disabled", func(t *testing.T) {
+		m := Model{
+			terminalManager: terminal.NewManager(),
+		}
+
+		// Verify terminal is not visible initially
+		if m.IsTerminalVisible() {
+			t.Fatal("terminal should not be visible initially")
+		}
+
+		// Call handleToggleTerminal (triggered by T key)
+		newModel, _ := m.handleToggleTerminal()
+		resultModel := newModel.(Model)
+
+		// Verify terminal is still not visible
+		if resultModel.IsTerminalVisible() {
+			t.Error("terminal should remain hidden when terminal support is disabled")
+		}
+	})
+
+	t.Run("ctrl+shift+t does nothing when terminal disabled", func(t *testing.T) {
+		m := Model{
+			terminalManager: terminal.NewManager(),
+		}
+		// Force terminal to be visible to test the switch dir function
+		m.terminalManager.SetLayout(terminal.LayoutVisible)
+
+		// Call handleSwitchTerminalDir (triggered by ctrl+shift+t)
+		newModel, _ := m.handleSwitchTerminalDir()
+		resultModel := newModel.(Model)
+
+		// Verify no error occurred and model is returned unchanged
+		if resultModel.errorMessage != "" {
+			t.Errorf("unexpected error message: %s", resultModel.errorMessage)
+		}
+	})
+}
+
+func TestHandleNormalModeKeyTerminalDisabled(t *testing.T) {
+	// Save original value and restore after test
+	originalValue := viper.GetBool("experimental.terminal_support")
+	defer viper.Set("experimental.terminal_support", originalValue)
+
+	// Disable terminal support
+	viper.Set("experimental.terminal_support", false)
+
+	t.Run("backtick key in normal mode does nothing when terminal disabled", func(t *testing.T) {
+		m := Model{
+			terminalManager: terminal.NewManager(),
+			inputMode:       false, // Normal mode
+		}
+
+		// Create backtick key message
+		keyMsg := tea.KeyMsg{
+			Type:  tea.KeyRunes,
+			Runes: []rune{'`'},
+		}
+
+		// Handle the key in normal mode
+		newModel, _ := m.handleNormalModeKey(keyMsg)
+		resultModel := newModel.(Model)
+
+		// Verify terminal is still not visible
+		if resultModel.IsTerminalVisible() {
+			t.Error("terminal should remain hidden when terminal support is disabled")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- When `experimental.terminal_support` is disabled, terminal keybindings (backtick, `T`, `ctrl+shift+t`) now correctly do nothing
- Previously, these keybindings would toggle/interact with the terminal pane regardless of the config setting
- This aligns keybinding behavior with the command-mode equivalents (`:term`, `:t`, `:termdir`) which already checked the config

## Test plan

- [x] Verify `go build ./...` succeeds
- [x] Verify `go vet ./...` passes
- [x] Verify `gofmt -d .` shows no formatting issues
- [x] Verify `go test ./internal/tui/...` passes
- [x] Manual testing: with `experimental.terminal_support: false` in config, pressing backtick should not open terminal pane
- [x] Manual testing: with `experimental.terminal_support: true` in config, pressing backtick should toggle terminal pane