### PR TITLE
Fix terminal pane shell prompt not visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Terminal Pane Shell Prompt Not Visible** - Fixed the terminal pane not displaying the shell prompt. The root cause was that `capture-pane` returns output ending with a newline, which caused `strings.Split` to create an extra empty element. When taking the "last N lines", the prompt (at position 0) was dropped while empty lines were kept. The fix trims trailing newlines before splitting and reorders the trimming/truncation logic to prioritize actual content.
+
 - **Terminal Keybindings Respect Config** - Fixed backtick (`) and `T` keys toggling the terminal pane even when `experimental.terminal_support` is disabled in the config. The terminal keybindings now correctly check the config setting before activating.
 
 - **Adversarial Review Score Threshold Enforcement** - Fixed a bug where users who set a minimum passing score higher than the default (e.g., 9 or 10) would have the adversarial loop stop prematurely. The issue occurred because approval notifications were sent before score enforcement was applied, causing callbacks to receive the unenforced state. The enforcement check is now performed before any notifications, ensuring the loop correctly continues when the reviewer's score is below the configured threshold.

--- a/internal/tui/view/terminal.go
+++ b/internal/tui/view/terminal.go
@@ -129,17 +129,24 @@ func (v *TerminalView) renderOutput(output string, height int) string {
 		return placeholder
 	}
 
-	// Split into lines
+	// Trim trailing whitespace before splitting to prevent capture-pane's trailing
+	// newline from creating an extra empty element. Without this, when we "take last
+	// N lines", we could drop content from the beginning (like the shell prompt) while
+	// keeping empty lines from the end.
+	output = strings.TrimRight(output, "\r\n")
+
 	lines := strings.Split(output, "\n")
 
-	// Take only the last 'height' lines (most recent output)
-	if len(lines) > height {
-		lines = lines[len(lines)-height:]
-	}
-
-	// Trim trailing empty lines (tmux capture often includes them)
+	// Trim trailing empty lines from the end of the content
+	// (e.g., empty lines before the cursor position in tmux)
 	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
 		lines = lines[:len(lines)-1]
+	}
+
+	// Take only the last 'height' lines (most recent output)
+	// This is done AFTER trimming empty lines so we prioritize showing actual content
+	if len(lines) > height {
+		lines = lines[len(lines)-height:]
 	}
 
 	// Join and return

--- a/internal/tui/view/terminal_test.go
+++ b/internal/tui/view/terminal_test.go
@@ -194,6 +194,30 @@ func TestTerminalViewRenderOutput(t *testing.T) {
 			height:       10,
 			wantContains: []string{"line1", "line2"},
 		},
+		{
+			name:         "preserves first line when capture ends with newline",
+			output:       "PROMPT\n\n\n\n\n\n\n\n\n\n\n\n",
+			height:       12,
+			wantContains: []string{"PROMPT"},
+		},
+		{
+			name:         "preserves prompt with ANSI codes when capture ends with newline",
+			output:       "\x1b[32mPrompt ❯\x1b[0m\n\n\n\n\n\n\n\n\n\n\n\n",
+			height:       12,
+			wantContains: []string{"Prompt"},
+		},
+		{
+			name:         "preserves prompt with content and trailing newlines",
+			output:       "PROMPT ❯ ls\nfile1.txt\nfile2.txt\n\n\n",
+			height:       10,
+			wantContains: []string{"PROMPT", "file1.txt", "file2.txt"},
+		},
+		{
+			name:         "preserves content when lines equal height after trim",
+			output:       "line1\nline2\nline3\n",
+			height:       3,
+			wantContains: []string{"line1", "line2", "line3"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Fix the terminal pane not displaying the shell prompt at all
- The prompt was being dropped during the "take last N lines" logic due to trailing newlines from capture-pane

## Problem

When opening the terminal pane, the shell prompt (especially fancy prompts like Starship) was completely invisible. Users could see command output and tab completion results, but never their prompt.

## Root Cause

In `internal/tui/view/terminal.go`, the `renderOutput()` function had a bug:

1. `capture-pane` returns output ending with a newline
2. `strings.Split(output, "\n")` creates an extra empty element at the end
3. For a 12-line tmux pane: `[prompt, "", "", "", "", "", "", "", "", "", "", "", ""]` (13 elements)
4. "Take last 12 lines" dropped `lines[0]` (the prompt!) and kept `lines[1-12]` (all empty)
5. Trimming trailing empty lines removed everything, leaving blank output

## Solution

1. Trim trailing newlines before splitting to prevent the extra element
2. Reorder operations: trim trailing empty lines first (prioritize actual content), then truncate to height

## Test plan

- [x] Added regression tests for the specific bug scenario
- [x] Added test with ANSI-coded prompts  
- [x] All existing tests pass
- [x] Verified fix with real tmux capture-pane output
- [x] `go build ./...` succeeds
- [x] `go vet ./...` passes