### PR TITLE
Coordinator refactoring phase 1 - establish delegation patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Coordinator Refactoring Phase 1** - Initial refactoring of `internal/orchestrator/coordinator.go` to establish delegation patterns:
+  - Extracted notification methods to `coordinator_callbacks.go` (~170 lines)
+  - Extracted adapter types to `coordinator_adapters.go` (~75 lines)
+  - Removed 6 deprecated functions: `runPlanningSinglePassDirect`, `runSynthesisDirect`, `monitorSynthesisInstance`, `checkForSynthesisCompletionFile`, `onSynthesisReady`, `buildSynthesisPrompt`
+  - Removed fallback paths - code now requires phase orchestrators to be initialized
+  - Fixed `restartTask()` to delegate to `ExecutionOrchestrator.StartSingleTask()`
+  - Added `StartSingleTask()` and `RestartLoop()` to `ExecutionOrchestrator`
+  - Created placeholder packages `phase/step/` and `group/consolidator.go` documenting future extraction targets
+
 - **Orchestrator Package Refactoring** - Major refactoring of `internal/orchestrator/` to improve modularity and testability:
   - Extracted workflow coordinators into dedicated subpackages: `workflows/tripleshot/`, `workflows/adversarial/`, `workflows/ralph/`
   - Created shared `types/` package for common type definitions (`TaskCompletionFile`, etc.)

--- a/internal/orchestrator/coordinator_adapters.go
+++ b/internal/orchestrator/coordinator_adapters.go
@@ -1,0 +1,77 @@
+package orchestrator
+
+import "fmt"
+
+// coordinatorRetryTracker adapts the Coordinator's RetryManager to the verify.RetryTracker interface.
+type coordinatorRetryTracker struct {
+	c *Coordinator
+}
+
+func (rt *coordinatorRetryTracker) GetRetryCount(taskID string) int {
+	state := rt.c.retryManager.GetState(taskID)
+	if state == nil {
+		return 0
+	}
+	return state.RetryCount
+}
+
+func (rt *coordinatorRetryTracker) IncrementRetry(taskID string) int {
+	session := rt.c.Session()
+	config := session.Config
+	maxRetries := config.MaxTaskRetries
+	if maxRetries == 0 {
+		maxRetries = 3
+	}
+	state := rt.c.retryManager.GetOrCreateState(taskID, maxRetries)
+	rt.c.retryManager.RecordAttempt(taskID, false) // false = failure
+	rt.c.retryManager.SetLastError(taskID, "task produced no commits")
+	return state.RetryCount + 1
+}
+
+func (rt *coordinatorRetryTracker) RecordCommitCount(taskID string, count int) {
+	session := rt.c.Session()
+	config := session.Config
+	maxRetries := config.MaxTaskRetries
+	if maxRetries == 0 {
+		maxRetries = 3
+	}
+	rt.c.retryManager.GetOrCreateState(taskID, maxRetries)
+	rt.c.retryManager.RecordCommitCount(taskID, count)
+}
+
+func (rt *coordinatorRetryTracker) GetMaxRetries(taskID string) int {
+	state := rt.c.retryManager.GetState(taskID)
+	if state == nil {
+		return 0
+	}
+	return state.MaxRetries
+}
+
+// coordinatorEventEmitter adapts the Coordinator's event emission to the verify.EventEmitter interface.
+type coordinatorEventEmitter struct {
+	c *Coordinator
+}
+
+func (e *coordinatorEventEmitter) EmitWarning(taskID, message string) {
+	e.c.manager.emitEvent(CoordinatorEvent{
+		Type:    EventConflict,
+		TaskID:  taskID,
+		Message: message,
+	})
+}
+
+func (e *coordinatorEventEmitter) EmitRetry(taskID string, attempt, maxRetries int, reason string) {
+	e.c.manager.emitEvent(CoordinatorEvent{
+		Type:    EventTaskStarted, // Reuse for retry notification
+		TaskID:  taskID,
+		Message: fmt.Sprintf("Task %s produced no commits, scheduling retry %d/%d", taskID, attempt, maxRetries),
+	})
+}
+
+func (e *coordinatorEventEmitter) EmitFailure(taskID, reason string) {
+	e.c.manager.emitEvent(CoordinatorEvent{
+		Type:    EventTaskFailed,
+		TaskID:  taskID,
+		Message: reason,
+	})
+}

--- a/internal/orchestrator/coordinator_callbacks.go
+++ b/internal/orchestrator/coordinator_callbacks.go
@@ -1,0 +1,197 @@
+package orchestrator
+
+// CoordinatorCallbacks holds callbacks for coordinator events
+type CoordinatorCallbacks struct {
+	// OnPhaseChange is called when the ultra-plan phase changes
+	OnPhaseChange func(phase UltraPlanPhase)
+
+	// OnTaskStart is called when a task begins execution
+	OnTaskStart func(taskID, instanceID string)
+
+	// OnTaskComplete is called when a task completes successfully
+	OnTaskComplete func(taskID string)
+
+	// OnTaskFailed is called when a task fails
+	OnTaskFailed func(taskID, reason string)
+
+	// OnGroupComplete is called when an execution group completes
+	OnGroupComplete func(groupIndex int)
+
+	// OnPlanReady is called when the plan is ready (after planning phase)
+	OnPlanReady func(plan *PlanSpec)
+
+	// OnProgress is called periodically with progress updates
+	OnProgress func(completed, total int, phase UltraPlanPhase)
+
+	// OnComplete is called when the entire ultra-plan completes
+	OnComplete func(success bool, summary string)
+}
+
+// notifyPhaseChange notifies callbacks of phase change
+func (c *Coordinator) notifyPhaseChange(phase UltraPlanPhase) {
+	// Get the previous phase for logging
+	session := c.Session()
+	fromPhase := PhasePlanning
+	if session != nil {
+		fromPhase = session.Phase
+	}
+
+	c.manager.SetPhase(phase)
+
+	// Log the phase transition
+	c.logger.Info("phase changed",
+		"from_phase", string(fromPhase),
+		"to_phase", string(phase),
+		"session_id", session.ID,
+	)
+
+	// Persist the phase change
+	_ = c.orch.SaveSession()
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnPhaseChange != nil {
+		cb.OnPhaseChange(phase)
+	}
+}
+
+// notifyTaskStart notifies callbacks of task start
+func (c *Coordinator) notifyTaskStart(taskID, instanceID string) {
+	c.manager.AssignTaskToInstance(taskID, instanceID)
+
+	// Get task title for logging
+	session := c.Session()
+	taskTitle := ""
+	if session != nil {
+		if task := session.GetTask(taskID); task != nil {
+			taskTitle = task.Title
+		}
+	}
+
+	// Log task started
+	c.logger.Info("task started",
+		"task_id", taskID,
+		"instance_id", instanceID,
+		"task_title", taskTitle,
+	)
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnTaskStart != nil {
+		cb.OnTaskStart(taskID, instanceID)
+	}
+}
+
+// notifyTaskComplete notifies callbacks of task completion
+func (c *Coordinator) notifyTaskComplete(taskID string) {
+	c.manager.MarkTaskComplete(taskID)
+
+	// Log task completed
+	// Note: duration tracking requires instance start time, which could be added in the future
+	c.logger.Info("task completed",
+		"task_id", taskID,
+	)
+
+	// Persist the task completion
+	_ = c.orch.SaveSession()
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnTaskComplete != nil {
+		cb.OnTaskComplete(taskID)
+	}
+}
+
+// notifyTaskFailed notifies callbacks of task failure
+func (c *Coordinator) notifyTaskFailed(taskID, reason string) {
+	c.manager.MarkTaskFailed(taskID, reason)
+
+	// Log task failed
+	c.logger.Info("task failed",
+		"task_id", taskID,
+		"reason", reason,
+	)
+
+	// Persist the task failure
+	_ = c.orch.SaveSession()
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnTaskFailed != nil {
+		cb.OnTaskFailed(taskID, reason)
+	}
+}
+
+// notifyPlanReady notifies callbacks that planning is complete
+func (c *Coordinator) notifyPlanReady(plan *PlanSpec) {
+	// Log plan ready
+	taskCount := 0
+	groupCount := 0
+	if plan != nil {
+		taskCount = len(plan.Tasks)
+		groupCount = len(plan.ExecutionOrder)
+	}
+	c.logger.Info("plan ready",
+		"task_count", taskCount,
+		"group_count", groupCount,
+	)
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnPlanReady != nil {
+		cb.OnPlanReady(plan)
+	}
+}
+
+// notifyProgress notifies callbacks of progress
+func (c *Coordinator) notifyProgress() {
+	session := c.Session()
+	if session == nil || session.Plan == nil {
+		return
+	}
+
+	completed := len(session.CompletedTasks)
+	total := len(session.Plan.Tasks)
+
+	// Log progress update at DEBUG level
+	c.logger.Debug("progress update",
+		"completed", completed,
+		"total", total,
+		"phase", string(session.Phase),
+	)
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnProgress != nil {
+		cb.OnProgress(completed, total, session.Phase)
+	}
+}
+
+// notifyComplete notifies callbacks of completion
+func (c *Coordinator) notifyComplete(success bool, summary string) {
+	// Log coordinator complete
+	c.logger.Info("coordinator complete",
+		"success", success,
+		"summary", summary,
+	)
+
+	c.mu.RLock()
+	cb := c.callbacks
+	c.mu.RUnlock()
+
+	if cb != nil && cb.OnComplete != nil {
+		cb.OnComplete(success, summary)
+	}
+}

--- a/internal/orchestrator/coordinator_phase_adapter.go
+++ b/internal/orchestrator/coordinator_phase_adapter.go
@@ -1242,12 +1242,19 @@ func (a *executionCoordinatorAdapter) EmitEvent(eventType, message string) {
 }
 
 // StartExecutionLoop restarts the execution loop (used by RetriggerGroup).
+// Delegates to the ExecutionOrchestrator's RestartLoop() method.
 func (a *executionCoordinatorAdapter) StartExecutionLoop() {
 	if a.c == nil {
 		return
 	}
-	a.c.wg.Add(1)
-	go a.c.executionLoop()
+
+	eo := a.c.ExecutionOrchestrator()
+	if eo == nil {
+		// ExecutionOrchestrator must be initialized - this is a programming error
+		a.c.logger.Error("StartExecutionLoop called but ExecutionOrchestrator is nil")
+		return
+	}
+	eo.RestartLoop()
 }
 
 // BuildExecutionContext creates an ExecutionContext for the ExecutionOrchestrator.

--- a/internal/orchestrator/group/consolidator.go
+++ b/internal/orchestrator/group/consolidator.go
@@ -1,0 +1,25 @@
+package group
+
+// This file is a placeholder for future group consolidation logic.
+//
+// The group consolidation logic is intended to contain:
+//   - consolidateGroupWithVerification - merge parallel task branches
+//   - getBaseBranchForGroup - determine base branch for a group
+//   - gatherTaskCompletionContextForGroup - collect context from completed tasks
+//   - getTaskBranchesForGroup - get branches for tasks in a group
+//   - buildGroupConsolidatorPrompt - build Claude prompt for consolidation
+//   - startGroupConsolidatorSession - start the consolidator instance
+//   - monitorGroupConsolidator - monitor consolidation progress
+//
+// Currently, the group consolidation logic remains in the Coordinator
+// (internal/orchestrator/coordinator.go) due to tight coupling with:
+//   - Session state (UltraPlanSession)
+//   - Orchestrator's worktree manager (wt)
+//   - Orchestrator's instance management
+//   - Base session for branch/instance operations
+//
+// Future refactoring could extract this logic here by defining interfaces
+// for the required dependencies, similar to how Tracker uses SessionData.
+//
+// The Tracker in this package already provides execution group tracking
+// that the consolidation logic could leverage.

--- a/internal/orchestrator/phase/step/doc.go
+++ b/internal/orchestrator/phase/step/doc.go
@@ -1,0 +1,19 @@
+// Package step provides step introspection and restart logic for ultra-plan workflows.
+//
+// This package is intended to contain:
+//   - StepInfo type and resolution logic (GetStepInfo)
+//   - RestartStep dispatch and phase-specific restarters
+//   - Step types (StepTypePlanning, StepTypeTask, etc.)
+//
+// Currently, the step management logic remains in the Coordinator
+// (internal/orchestrator/coordinator.go) due to tight coupling with:
+//   - Session state (UltraPlanSession)
+//   - All phase orchestrators (Planning, Execution, Synthesis, Consolidation)
+//   - Coordinator's internal state
+//
+// Future refactoring could extract this logic here by defining interfaces
+// for the required dependencies.
+//
+// The step types (StepType, StepInfo) are currently defined in
+// internal/orchestrator/ultraplan.go.
+package step


### PR DESCRIPTION
## Summary

This PR implements **Phase 1** of the coordinator refactoring plan from `CoordinatorRefactor.md`. It establishes the delegation patterns and removes deprecated code, preparing the codebase for the larger migration in Phases 2-5.

### Changes

- **Extract notification methods** to `coordinator_callbacks.go` (~170 lines)
- **Extract adapter types** to `coordinator_adapters.go` (~75 lines)
- **Remove 6 deprecated functions**: `runPlanningSinglePassDirect`, `runSynthesisDirect`, `monitorSynthesisInstance`, `checkForSynthesisCompletionFile`, `onSynthesisReady`, `buildSynthesisPrompt`
- **Remove fallback paths** - code now requires phase orchestrators to be initialized
- **Fix `restartTask()`** to delegate to `ExecutionOrchestrator.StartSingleTask()`
- **Add `StartSingleTask()` and `RestartLoop()`** to `ExecutionOrchestrator`
- **Create placeholder packages** (`phase/step/`, `group/consolidator.go`) documenting future extraction targets

### Metrics

| Metric | Before | After | Target |
|--------|--------|-------|--------|
| coordinator.go lines | ~3,900 | ~3,271 | 500-800 |
| Functions removed | 0 | 6 | - |
| Fallback paths | Multiple | None | None |

### Remaining Work (Phases 2-5)

This is **Phase 1 only**. The following phases remain:

- **Phase 2**: Migrate task execution logic to `ExecutionOrchestrator` (~600 lines)
- **Phase 3**: Migrate revision logic to `SynthesisOrchestrator` (~300 lines)
- **Phase 4**: Implement `phase/step/` package (~400 lines)
- **Phase 5**: Implement `group/consolidator.go` (~600 lines)

## Test plan

- [x] All orchestrator tests pass (`go test ./internal/orchestrator/...`)
- [x] `go vet ./...` reports no issues
- [x] `go build ./...` succeeds