### PR TITLE
Allow rejection of approved adversarial review results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Adversarial Review Rejection After Approval** - Users can now reject an "Approved" adversarial review result by having the reviewer write a new failing review file. When the reviewer writes a new completion file with a failing score, the implementer automatically restarts work on the next round.
+
 - **Comprehensive Platform-Specific Documentation** - Added detailed tutorials for using Claudio with all major development platforms:
   - **Web Development (Node.js/React/Vue)** - npm/yarn/pnpm caching, dev server coordination, framework-specific workflows
   - **Go Development** - Module caching, build optimization, workspace patterns, code generation

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -568,6 +568,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Handle async review file processing result
 		return m.handleAdversarialReviewProcessed(msg)
 
+	case tuimsg.AdversarialRejectionAfterApprovalMsg:
+		// Handle async rejection-after-approval processing result
+		return m.handleAdversarialRejectionAfterApprovalProcessed(msg)
+
 	// Ralph loop message handlers
 	case tuimsg.RalphIterationStartedMsg:
 		return m.handleRalphIterationStarted(msg)

--- a/internal/tui/msg/types.go
+++ b/internal/tui/msg/types.go
@@ -195,6 +195,15 @@ type AdversarialReviewProcessedMsg struct {
 	Err      error
 }
 
+// AdversarialRejectionAfterApprovalMsg contains the result of processing a rejection
+// that occurred after an initial approval. This allows users to reject an approved
+// result by having the reviewer write a new failing review file.
+type AdversarialRejectionAfterApprovalMsg struct {
+	GroupID string
+	Score   int
+	Err     error
+}
+
 // RalphIterationStartedMsg indicates a new ralph iteration has started.
 type RalphIterationStartedMsg struct {
 	GroupID   string


### PR DESCRIPTION
## Summary
- Users can now reject an "Approved" adversarial review result by having the reviewer write a new failing review file
- When a new completion file with a failing score is detected in the approved/complete phase, the implementer automatically restarts work on the next round
- This enables the scenario where: reviewer approves -> user tells reviewer it can't pass -> reviewer writes new failing review -> implementer starts again

## Changes
- Extended TUI polling to check review files during `PhaseApproved` and `PhaseComplete`
- Added `ProcessRejectionAfterApproval()` method in the adversarial coordinator
- Added `AdversarialRejectionAfterApprovalMsg` message type for async processing
- Added 3 comprehensive tests:
  - Rejection restarts workflow
  - Still-approved review files are ignored and cleaned up
  - Max iterations limit is respected

## Test plan
- [x] All existing tests pass
- [x] New tests added for `ProcessRejectionAfterApproval`:
  - `TestCoordinator_ProcessRejectionAfterApproval_RestartsWorkflow`
  - `TestCoordinator_ProcessRejectionAfterApproval_IgnoresApproval`
  - `TestCoordinator_ProcessRejectionAfterApproval_MaxIterationsReached`
- [x] golangci-lint passes
- [x] Manual verification: reviewer can write new failing review after approval and implementer restarts