### PR TITLE
Update scroll hint from [g/G] to [0/G]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Monorepo Development** - Sparse checkout optimization, Turborepo/Nx integration, affected-only builds
   - **Data Science & ML** - Jupyter notebook management, experiment tracking, GPU resource coordination
 
+### Fixed
+
+- **Scroll Hint Accuracy** - Updated scroll indicator hint from `[g/G]` to `[0/G]` to match actual keybindings
+
 ### Changed
 
 - **Coordinator Refactoring Phase 1** - Initial refactoring of `internal/orchestrator/coordinator.go` to establish delegation patterns:

--- a/internal/tui/view/instance.go
+++ b/internal/tui/view/instance.go
@@ -611,7 +611,7 @@ func (v *InstanceView) buildScrollIndicator(
 		percent = scrollOffset * 100 / maxScroll
 	}
 	return styles.Muted.Render(fmt.Sprintf("Line %d-%d/%d (%d%%)", startLine+1, endLine, totalLines, percent)) +
-		"  " + styles.Muted.Render("[j/k] scroll  [g/G] top/bottom")
+		"  " + styles.Muted.Render("[j/k] scroll  [0/G] top/bottom")
 }
 
 // highlightSearchMatches highlights search matches in visible lines.


### PR DESCRIPTION
## Summary
- Updates the scroll indicator hint in the instance view from `[g/G]` to `[0/G]` to accurately reflect the actual keybindings for top/bottom navigation

## Test plan
- [ ] Launch Claudio and open an instance view with scrollable content
- [ ] Verify the scroll hint at the bottom shows `[0/G] top/bottom`
- [ ] Confirm `0` scrolls to top and `G` scrolls to bottom