### PR TITLE
Use subgroups for UltraPlan sidebar rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **UltraPlan Sidebar Subgroups** - Refactored UltraPlan sidebar rendering to use actual InstanceGroup subgroups instead of custom inline rendering. Planning, execution groups (Group 1, Group 2, etc.), Synthesis, Revision, and Consolidation phases now each have their own subgroup within the main UltraPlan group. This aligns with how tripleshot and adversarial modes render their content and enables standard group navigation and collapse/expand behavior. Added `SubgroupRouter` to automatically route instances to the correct subgroup based on session state.
+
 - **Dead Code Removal** - Removed unreachable code identified by static analysis to improve codebase maintainability:
   - Removed unused `Consolidator` type and all methods from `orchestrator/consolidation.go` (replaced by `group/consolidate/` package)
   - Deleted `orchestrator/consolidation_util.go` entirely (unused `BranchNameGenerator`, `Slugify`, `DeduplicateStrings`)

--- a/internal/orchestrator/ultraplan_subgroups.go
+++ b/internal/orchestrator/ultraplan_subgroups.go
@@ -1,0 +1,247 @@
+package orchestrator
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator/grouptypes"
+)
+
+// UltraPlan subgroup name constants.
+const (
+	SubgroupPlanning           = "Planning"
+	SubgroupPlanSelection      = "Plan Selection"
+	SubgroupSynthesis          = "Synthesis"
+	SubgroupRevision           = "Revision"
+	SubgroupConsolidation      = "Consolidation"
+	SubgroupExecutionPrefix    = "Group"        // e.g., "Group 1", "Group 2"
+	SubgroupConsolidatorSuffix = "Consolidator" // e.g., "Group 1 Consolidator"
+)
+
+// SubgroupType represents the type of ultraplan subgroup.
+type SubgroupType int
+
+const (
+	SubgroupTypeUnknown SubgroupType = iota
+	SubgroupTypePlanning
+	SubgroupTypePlanSelection
+	SubgroupTypeExecution    // For task instances
+	SubgroupTypeConsolidator // For group consolidators
+	SubgroupTypeSynthesis
+	SubgroupTypeRevision
+	SubgroupTypeFinalConsolidation
+)
+
+// determineSubgroupType determines which subgroup type an instance belongs to
+// based on the UltraPlanSession state.
+func determineSubgroupType(session *UltraPlanSession, instanceID string) SubgroupType {
+	if session == nil || instanceID == "" {
+		return SubgroupTypeUnknown
+	}
+
+	// Check planning coordinators
+	if session.CoordinatorID == instanceID {
+		return SubgroupTypePlanning
+	}
+	if slices.Contains(session.PlanCoordinatorIDs, instanceID) {
+		return SubgroupTypePlanning
+	}
+
+	// Check plan manager (plan selection)
+	if session.PlanManagerID == instanceID {
+		return SubgroupTypePlanSelection
+	}
+
+	// Check task instances
+	for _, instID := range session.TaskToInstance {
+		if instID == instanceID {
+			return SubgroupTypeExecution
+		}
+	}
+
+	// Check group consolidators
+	if slices.Contains(session.GroupConsolidatorIDs, instanceID) {
+		return SubgroupTypeConsolidator
+	}
+
+	// Check synthesis
+	if session.SynthesisID == instanceID {
+		return SubgroupTypeSynthesis
+	}
+
+	// Check revision
+	if session.RevisionID == instanceID {
+		return SubgroupTypeRevision
+	}
+
+	// Check final consolidation
+	if session.ConsolidationID == instanceID {
+		return SubgroupTypeFinalConsolidation
+	}
+
+	return SubgroupTypeUnknown
+}
+
+// getTaskGroupIndex returns the execution group index for a task instance.
+// Returns -1 if the instance is not a task instance or group cannot be determined.
+func getTaskGroupIndex(session *UltraPlanSession, instanceID string) int {
+	if session == nil || session.Plan == nil {
+		return -1
+	}
+
+	// Find the task ID for this instance
+	var taskID string
+	for tID, instID := range session.TaskToInstance {
+		if instID == instanceID {
+			taskID = tID
+			break
+		}
+	}
+	if taskID == "" {
+		return -1
+	}
+
+	// Find which execution group this task belongs to
+	for groupIdx, taskIDs := range session.Plan.ExecutionOrder {
+		if slices.Contains(taskIDs, taskID) {
+			return groupIdx
+		}
+	}
+
+	return -1
+}
+
+// getConsolidatorGroupIndex returns the execution group index for a group consolidator instance.
+// Returns -1 if the instance is not a consolidator or group cannot be determined.
+func getConsolidatorGroupIndex(session *UltraPlanSession, instanceID string) int {
+	if session == nil {
+		return -1
+	}
+	return slices.Index(session.GroupConsolidatorIDs, instanceID)
+}
+
+// executionGroupSubgroupName returns the subgroup name for an execution group.
+func executionGroupSubgroupName(groupIndex int) string {
+	return fmt.Sprintf("%s %d", SubgroupExecutionPrefix, groupIndex+1)
+}
+
+// getOrCreateSubgroup finds or creates a subgroup within the ultraplan group.
+// The subgroup is created with the appropriate name and added to the parent's SubGroups.
+func getOrCreateSubgroup(parentGroup *grouptypes.InstanceGroup, subgroupName string) *grouptypes.InstanceGroup {
+	if parentGroup == nil {
+		return nil
+	}
+
+	// First, try to find existing subgroup
+	for _, sg := range parentGroup.SubGroups {
+		if sg.Name == subgroupName {
+			return sg
+		}
+	}
+
+	// Create new subgroup
+	subgroupID := fmt.Sprintf("%s-%s", parentGroup.ID, sanitizeSubgroupID(subgroupName))
+	subgroup := grouptypes.NewInstanceGroup(subgroupID, subgroupName)
+	parentGroup.AddSubGroup(subgroup)
+
+	return subgroup
+}
+
+// sanitizeSubgroupID converts a subgroup name to a valid ID component.
+// Lowercase letters and digits are preserved, spaces become dashes, other characters are removed.
+func sanitizeSubgroupID(name string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			return r
+		case r >= 'A' && r <= 'Z':
+			return r + ('a' - 'A')
+		case r == ' ':
+			return '-'
+		default:
+			return -1 // Remove character
+		}
+	}, name)
+}
+
+// addInstanceToSubgroup determines the correct subgroup for an instance and adds it there.
+// Returns true if the instance was added to a subgroup, false otherwise.
+func addInstanceToSubgroup(parentGroup *grouptypes.InstanceGroup, session *UltraPlanSession, instanceID string) bool {
+	if parentGroup == nil || session == nil || instanceID == "" {
+		return false
+	}
+
+	subgroupType := determineSubgroupType(session, instanceID)
+	var subgroupName string
+
+	switch subgroupType {
+	case SubgroupTypePlanning:
+		subgroupName = SubgroupPlanning
+	case SubgroupTypePlanSelection:
+		subgroupName = SubgroupPlanSelection
+	case SubgroupTypeExecution:
+		groupIdx := getTaskGroupIndex(session, instanceID)
+		if groupIdx < 0 {
+			return false
+		}
+		subgroupName = executionGroupSubgroupName(groupIdx)
+	case SubgroupTypeConsolidator:
+		groupIdx := getConsolidatorGroupIndex(session, instanceID)
+		if groupIdx < 0 {
+			return false
+		}
+		// Add consolidator to the same subgroup as its execution group
+		subgroupName = executionGroupSubgroupName(groupIdx)
+	case SubgroupTypeSynthesis:
+		subgroupName = SubgroupSynthesis
+	case SubgroupTypeRevision:
+		subgroupName = SubgroupRevision
+	case SubgroupTypeFinalConsolidation:
+		subgroupName = SubgroupConsolidation
+	default:
+		// Unknown type - add to parent group directly
+		parentGroup.AddInstance(instanceID)
+		return true
+	}
+
+	// Get or create the subgroup and add the instance
+	subgroup := getOrCreateSubgroup(parentGroup, subgroupName)
+	if subgroup == nil {
+		return false
+	}
+
+	subgroup.AddInstance(instanceID)
+	return true
+}
+
+// SubgroupRouter is a wrapper that routes AddInstance calls to the appropriate subgroup.
+// This implements the interface expected by phase.addInstanceToGroup.
+type SubgroupRouter struct {
+	parentGroup *grouptypes.InstanceGroup
+	session     *UltraPlanSession
+}
+
+// NewSubgroupRouter creates a new SubgroupRouter for routing instances to ultraplan subgroups.
+func NewSubgroupRouter(parentGroup *grouptypes.InstanceGroup, session *UltraPlanSession) *SubgroupRouter {
+	return &SubgroupRouter{
+		parentGroup: parentGroup,
+		session:     session,
+	}
+}
+
+// AddInstance routes the instance to the appropriate subgroup based on session state.
+// This method is called by phase.addInstanceToGroup via interface.
+func (r *SubgroupRouter) AddInstance(instanceID string) {
+	if r.parentGroup == nil || instanceID == "" {
+		return
+	}
+
+	// Try to route to a subgroup
+	if r.session != nil && addInstanceToSubgroup(r.parentGroup, r.session, instanceID) {
+		return
+	}
+
+	// Fallback: add to main group
+	r.parentGroup.AddInstance(instanceID)
+}

--- a/internal/orchestrator/ultraplan_subgroups_test.go
+++ b/internal/orchestrator/ultraplan_subgroups_test.go
@@ -1,0 +1,492 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator/grouptypes"
+)
+
+func TestDetermineSubgroupType(t *testing.T) {
+	tests := []struct {
+		name       string
+		session    *UltraPlanSession
+		instanceID string
+		want       SubgroupType
+	}{
+		{
+			name:       "nil session returns unknown",
+			session:    nil,
+			instanceID: "inst-1",
+			want:       SubgroupTypeUnknown,
+		},
+		{
+			name:       "empty instanceID returns unknown",
+			session:    &UltraPlanSession{},
+			instanceID: "",
+			want:       SubgroupTypeUnknown,
+		},
+		{
+			name: "coordinator ID returns planning",
+			session: &UltraPlanSession{
+				CoordinatorID: "coord-1",
+			},
+			instanceID: "coord-1",
+			want:       SubgroupTypePlanning,
+		},
+		{
+			name: "plan coordinator ID returns planning",
+			session: &UltraPlanSession{
+				PlanCoordinatorIDs: []string{"plan-1", "plan-2"},
+			},
+			instanceID: "plan-2",
+			want:       SubgroupTypePlanning,
+		},
+		{
+			name: "plan manager ID returns plan selection",
+			session: &UltraPlanSession{
+				PlanManagerID: "manager-1",
+			},
+			instanceID: "manager-1",
+			want:       SubgroupTypePlanSelection,
+		},
+		{
+			name: "task instance returns execution",
+			session: &UltraPlanSession{
+				TaskToInstance: map[string]string{
+					"task-1": "task-inst-1",
+					"task-2": "task-inst-2",
+				},
+			},
+			instanceID: "task-inst-2",
+			want:       SubgroupTypeExecution,
+		},
+		{
+			name: "group consolidator returns consolidator",
+			session: &UltraPlanSession{
+				GroupConsolidatorIDs: []string{"consol-0", "consol-1"},
+			},
+			instanceID: "consol-1",
+			want:       SubgroupTypeConsolidator,
+		},
+		{
+			name: "synthesis ID returns synthesis",
+			session: &UltraPlanSession{
+				SynthesisID: "synth-1",
+			},
+			instanceID: "synth-1",
+			want:       SubgroupTypeSynthesis,
+		},
+		{
+			name: "revision ID returns revision",
+			session: &UltraPlanSession{
+				RevisionID: "rev-1",
+			},
+			instanceID: "rev-1",
+			want:       SubgroupTypeRevision,
+		},
+		{
+			name: "consolidation ID returns final consolidation",
+			session: &UltraPlanSession{
+				ConsolidationID: "final-1",
+			},
+			instanceID: "final-1",
+			want:       SubgroupTypeFinalConsolidation,
+		},
+		{
+			name: "unknown instance returns unknown",
+			session: &UltraPlanSession{
+				CoordinatorID: "coord-1",
+				SynthesisID:   "synth-1",
+			},
+			instanceID: "unknown-inst",
+			want:       SubgroupTypeUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := determineSubgroupType(tt.session, tt.instanceID)
+			if got != tt.want {
+				t.Errorf("determineSubgroupType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetTaskGroupIndex(t *testing.T) {
+	tests := []struct {
+		name       string
+		session    *UltraPlanSession
+		instanceID string
+		want       int
+	}{
+		{
+			name:       "nil session returns -1",
+			session:    nil,
+			instanceID: "inst-1",
+			want:       -1,
+		},
+		{
+			name: "nil plan returns -1",
+			session: &UltraPlanSession{
+				Plan: nil,
+				TaskToInstance: map[string]string{
+					"task-1": "inst-1",
+				},
+			},
+			instanceID: "inst-1",
+			want:       -1,
+		},
+		{
+			name: "instance not in TaskToInstance returns -1",
+			session: &UltraPlanSession{
+				Plan: &PlanSpec{
+					ExecutionOrder: [][]string{{"task-1"}},
+				},
+				TaskToInstance: map[string]string{
+					"task-1": "inst-1",
+				},
+			},
+			instanceID: "unknown-inst",
+			want:       -1,
+		},
+		{
+			name: "task in first group returns 0",
+			session: &UltraPlanSession{
+				Plan: &PlanSpec{
+					ExecutionOrder: [][]string{
+						{"task-1", "task-2"},
+						{"task-3"},
+					},
+				},
+				TaskToInstance: map[string]string{
+					"task-1": "inst-1",
+					"task-2": "inst-2",
+					"task-3": "inst-3",
+				},
+			},
+			instanceID: "inst-1",
+			want:       0,
+		},
+		{
+			name: "task in second group returns 1",
+			session: &UltraPlanSession{
+				Plan: &PlanSpec{
+					ExecutionOrder: [][]string{
+						{"task-1", "task-2"},
+						{"task-3"},
+					},
+				},
+				TaskToInstance: map[string]string{
+					"task-1": "inst-1",
+					"task-2": "inst-2",
+					"task-3": "inst-3",
+				},
+			},
+			instanceID: "inst-3",
+			want:       1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getTaskGroupIndex(tt.session, tt.instanceID)
+			if got != tt.want {
+				t.Errorf("getTaskGroupIndex() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetConsolidatorGroupIndex(t *testing.T) {
+	tests := []struct {
+		name       string
+		session    *UltraPlanSession
+		instanceID string
+		want       int
+	}{
+		{
+			name:       "nil session returns -1",
+			session:    nil,
+			instanceID: "consol-0",
+			want:       -1,
+		},
+		{
+			name: "first consolidator returns 0",
+			session: &UltraPlanSession{
+				GroupConsolidatorIDs: []string{"consol-0", "consol-1"},
+			},
+			instanceID: "consol-0",
+			want:       0,
+		},
+		{
+			name: "second consolidator returns 1",
+			session: &UltraPlanSession{
+				GroupConsolidatorIDs: []string{"consol-0", "consol-1"},
+			},
+			instanceID: "consol-1",
+			want:       1,
+		},
+		{
+			name: "unknown consolidator returns -1",
+			session: &UltraPlanSession{
+				GroupConsolidatorIDs: []string{"consol-0"},
+			},
+			instanceID: "consol-unknown",
+			want:       -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getConsolidatorGroupIndex(tt.session, tt.instanceID)
+			if got != tt.want {
+				t.Errorf("getConsolidatorGroupIndex() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecutionGroupSubgroupName(t *testing.T) {
+	tests := []struct {
+		groupIndex int
+		want       string
+	}{
+		{0, "Group 1"},
+		{1, "Group 2"},
+		{9, "Group 10"},
+	}
+
+	for _, tt := range tests {
+		got := executionGroupSubgroupName(tt.groupIndex)
+		if got != tt.want {
+			t.Errorf("executionGroupSubgroupName(%d) = %q, want %q", tt.groupIndex, got, tt.want)
+		}
+	}
+}
+
+func TestSanitizeSubgroupID(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"Planning", "planning"},
+		{"Group 1", "group-1"},
+		{"Plan Selection", "plan-selection"},
+		{"Synthesis", "synthesis"},
+	}
+
+	for _, tt := range tests {
+		got := sanitizeSubgroupID(tt.name)
+		if got != tt.want {
+			t.Errorf("sanitizeSubgroupID(%q) = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestGetOrCreateSubgroup(t *testing.T) {
+	t.Run("nil parent returns nil", func(t *testing.T) {
+		got := getOrCreateSubgroup(nil, "Planning")
+		if got != nil {
+			t.Errorf("getOrCreateSubgroup(nil, ...) = %v, want nil", got)
+		}
+	})
+
+	t.Run("creates new subgroup", func(t *testing.T) {
+		parent := grouptypes.NewInstanceGroup("parent-1", "Parent")
+		subgroup := getOrCreateSubgroup(parent, "Planning")
+
+		if subgroup == nil {
+			t.Fatal("getOrCreateSubgroup() returned nil")
+		}
+		if subgroup.Name != "Planning" {
+			t.Errorf("subgroup.Name = %q, want %q", subgroup.Name, "Planning")
+		}
+		if subgroup.ID != "parent-1-planning" {
+			t.Errorf("subgroup.ID = %q, want %q", subgroup.ID, "parent-1-planning")
+		}
+		if len(parent.SubGroups) != 1 {
+			t.Errorf("len(parent.SubGroups) = %d, want 1", len(parent.SubGroups))
+		}
+	})
+
+	t.Run("returns existing subgroup", func(t *testing.T) {
+		parent := grouptypes.NewInstanceGroup("parent-1", "Parent")
+		first := getOrCreateSubgroup(parent, "Planning")
+		second := getOrCreateSubgroup(parent, "Planning")
+
+		if first != second {
+			t.Error("getOrCreateSubgroup() did not return existing subgroup")
+		}
+		if len(parent.SubGroups) != 1 {
+			t.Errorf("len(parent.SubGroups) = %d, want 1", len(parent.SubGroups))
+		}
+	})
+}
+
+func TestAddInstanceToSubgroup(t *testing.T) {
+	t.Run("nil parent returns false", func(t *testing.T) {
+		session := &UltraPlanSession{CoordinatorID: "coord-1"}
+		if addInstanceToSubgroup(nil, session, "coord-1") {
+			t.Error("addInstanceToSubgroup(nil, ...) = true, want false")
+		}
+	})
+
+	t.Run("nil session returns false", func(t *testing.T) {
+		parent := grouptypes.NewInstanceGroup("parent-1", "Parent")
+		if addInstanceToSubgroup(parent, nil, "inst-1") {
+			t.Error("addInstanceToSubgroup(..., nil, ...) = true, want false")
+		}
+	})
+
+	t.Run("empty instanceID returns false", func(t *testing.T) {
+		parent := grouptypes.NewInstanceGroup("parent-1", "Parent")
+		session := &UltraPlanSession{}
+		if addInstanceToSubgroup(parent, session, "") {
+			t.Error("addInstanceToSubgroup(..., \"\") = true, want false")
+		}
+	})
+
+	t.Run("planning instance added to Planning subgroup", func(t *testing.T) {
+		parent := grouptypes.NewInstanceGroup("parent-1", "Parent")
+		session := &UltraPlanSession{CoordinatorID: "coord-1"}
+
+		if !addInstanceToSubgroup(parent, session, "coord-1") {
+			t.Error("addInstanceToSubgroup() = false, want true")
+		}
+
+		// Verify subgroup was created and instance added
+		if len(parent.SubGroups) != 1 {
+			t.Fatalf("len(parent.SubGroups) = %d, want 1", len(parent.SubGroups))
+		}
+		subgroup := parent.SubGroups[0]
+		if subgroup.Name != "Planning" {
+			t.Errorf("subgroup.Name = %q, want %q", subgroup.Name, "Planning")
+		}
+		if !subgroup.HasInstance("coord-1") {
+			t.Error("subgroup does not contain coord-1")
+		}
+	})
+
+	t.Run("task instance added to correct execution group", func(t *testing.T) {
+		parent := grouptypes.NewInstanceGroup("parent-1", "Parent")
+		session := &UltraPlanSession{
+			Plan: &PlanSpec{
+				ExecutionOrder: [][]string{
+					{"task-1"},
+					{"task-2"},
+				},
+			},
+			TaskToInstance: map[string]string{
+				"task-1": "inst-1",
+				"task-2": "inst-2",
+			},
+		}
+
+		// Add instance from second group
+		if !addInstanceToSubgroup(parent, session, "inst-2") {
+			t.Error("addInstanceToSubgroup() = false, want true")
+		}
+
+		// Verify correct subgroup
+		var found bool
+		for _, sg := range parent.SubGroups {
+			if sg.Name == "Group 2" && sg.HasInstance("inst-2") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("inst-2 not found in Group 2 subgroup")
+		}
+	})
+
+	t.Run("synthesis instance added to Synthesis subgroup", func(t *testing.T) {
+		parent := grouptypes.NewInstanceGroup("parent-1", "Parent")
+		session := &UltraPlanSession{SynthesisID: "synth-1"}
+
+		if !addInstanceToSubgroup(parent, session, "synth-1") {
+			t.Error("addInstanceToSubgroup() = false, want true")
+		}
+
+		// Verify subgroup
+		var found bool
+		for _, sg := range parent.SubGroups {
+			if sg.Name == "Synthesis" && sg.HasInstance("synth-1") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("synth-1 not found in Synthesis subgroup")
+		}
+	})
+
+	t.Run("unknown instance added to parent group", func(t *testing.T) {
+		parent := grouptypes.NewInstanceGroup("parent-1", "Parent")
+		session := &UltraPlanSession{}
+
+		if !addInstanceToSubgroup(parent, session, "unknown-inst") {
+			t.Error("addInstanceToSubgroup() = false, want true")
+		}
+
+		if !parent.HasInstance("unknown-inst") {
+			t.Error("unknown-inst not added to parent group")
+		}
+	})
+}
+
+func TestSubgroupRouter(t *testing.T) {
+	t.Run("AddInstance routes to correct subgroup", func(t *testing.T) {
+		parent := grouptypes.NewInstanceGroup("parent-1", "Parent")
+		session := &UltraPlanSession{
+			CoordinatorID: "coord-1",
+			SynthesisID:   "synth-1",
+		}
+		router := NewSubgroupRouter(parent, session)
+
+		router.AddInstance("coord-1")
+		router.AddInstance("synth-1")
+
+		// Verify Planning subgroup has coord-1
+		planning := parent.GetSubGroup("parent-1-planning")
+		if planning == nil {
+			t.Fatal("Planning subgroup not created")
+		}
+		if !planning.HasInstance("coord-1") {
+			t.Error("coord-1 not in Planning subgroup")
+		}
+
+		// Verify Synthesis subgroup has synth-1
+		synthesis := parent.GetSubGroup("parent-1-synthesis")
+		if synthesis == nil {
+			t.Fatal("Synthesis subgroup not created")
+		}
+		if !synthesis.HasInstance("synth-1") {
+			t.Error("synth-1 not in Synthesis subgroup")
+		}
+	})
+
+	t.Run("AddInstance with nil parent does nothing", func(t *testing.T) {
+		router := NewSubgroupRouter(nil, &UltraPlanSession{})
+		router.AddInstance("inst-1") // Should not panic
+	})
+
+	t.Run("AddInstance with empty ID does nothing", func(t *testing.T) {
+		parent := grouptypes.NewInstanceGroup("parent-1", "Parent")
+		router := NewSubgroupRouter(parent, &UltraPlanSession{})
+		router.AddInstance("")
+		if len(parent.Instances) != 0 || len(parent.SubGroups) != 0 {
+			t.Error("Empty ID should not add anything")
+		}
+	})
+
+	t.Run("AddInstance falls back to parent when session nil", func(t *testing.T) {
+		parent := grouptypes.NewInstanceGroup("parent-1", "Parent")
+		router := NewSubgroupRouter(parent, nil)
+		router.AddInstance("inst-1")
+		if !parent.HasInstance("inst-1") {
+			t.Error("inst-1 not added to parent group when session nil")
+		}
+	})
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -847,14 +847,7 @@ func (m Model) getInstanceDisplayOrder() []string {
 
 	// In grouped mode, get the flattened display order
 	// Use the same logic as the sidebar rendering
-	var ultraPlanGroupID string
-	if m.ultraPlan != nil && m.ultraPlan.Coordinator != nil {
-		if upSession := m.ultraPlan.Coordinator.Session(); upSession != nil {
-			ultraPlanGroupID = upSession.GroupID
-		}
-	}
-
-	items := view.FlattenGroupsForDisplayWithUltraPlan(m.session, m.groupViewState, ultraPlanGroupID, m.ultraPlan)
+	items := view.FlattenGroupsForDisplay(m.session, m.groupViewState)
 	ids := make([]string, 0, len(m.session.Instances))
 	for _, item := range items {
 		if gi, ok := item.(view.GroupedInstance); ok {


### PR DESCRIPTION
## Summary

- Refactors UltraPlan sidebar rendering to use actual `InstanceGroup` subgroups instead of custom inline rendering
- Adds `SubgroupRouter` to automatically route instances to appropriate ultraplan subgroups (Planning, Group N, Synthesis, Revision, Consolidation)
- Removes backward compatibility shims that were no longer needed
- Aligns UltraPlan rendering with how tripleshot and adversarial modes render their content

## Changes

### New Files
- `internal/orchestrator/ultraplan_subgroups.go` - SubgroupRouter implementation and subgroup routing logic
- `internal/orchestrator/ultraplan_subgroups_test.go` - Comprehensive tests for subgroup routing

### Modified Files
- `internal/orchestrator/coordinator.go` - Use SubgroupRouter for planning phase
- `internal/orchestrator/coordinator_phase_adapter.go` - Add SubgroupRouter integration for ultraplan sessions
- `internal/tui/view/group.go` - Remove UltraPlanContentItem and duplicate flatten functions
- `internal/tui/view/sidebar.go` - Remove UltraPlanContentItem handling and renderUltraPlanContent
- `internal/tui/model.go` - Update to use standard FlattenGroupsForDisplay

### Removed Code
- `UltraPlanContentItem` type
- `FlattenGroupsForDisplayWithUltraPlan` function
- `flattenGroupRecursiveWithUltraPlan` function  
- `renderUltraPlanContent` method

## Test plan

- [x] All existing tests pass
- [x] New subgroup routing tests cover all subgroup types
- [x] Tests cover edge cases (nil session, empty instanceID, unknown instances)
- [x] Build and go vet pass