### PR TITLE
Add unified multi-workflow header status display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed `CreateStackedPR` from `pr/pr.go`
   - Removed `DefaultConfig` from `plan/plan.go`
 
+### Fixed
+
+- **Unified Multi-Workflow Header** - The header now displays status indicators for all active workflow types (UltraPlan, TripleShot, Adversarial) simultaneously. Previously, the header used exclusive priority-based selection, which meant users lost visibility into other running workflows when multiple task types were active.
+
 ## [0.11.0] - 2026-01-18
 
 This release brings **Major Architecture Refactoring & Platform Guides** - a comprehensive refactoring of the Coordinator into a thin facade with specialized orchestrators, plus detailed platform-specific documentation for all major development environments.

--- a/internal/orchestrator/coordinator_testing.go
+++ b/internal/orchestrator/coordinator_testing.go
@@ -1,0 +1,29 @@
+package orchestrator
+
+import (
+	"context"
+	"sync"
+
+	"github.com/Iron-Ham/claudio/internal/logging"
+)
+
+// NewCoordinatorForTesting creates a minimal Coordinator for testing purposes.
+// This coordinator has a working Session() method but lacks the full orchestrator
+// infrastructure. It should only be used in tests where the only requirement is
+// to have a coordinator that returns a specific UltraPlanSession.
+//
+// Note: Most methods on this coordinator will panic or behave incorrectly.
+// Only Session() is guaranteed to work correctly.
+func NewCoordinatorForTesting(ultraSession *UltraPlanSession) *Coordinator {
+	logger := logging.NopLogger()
+	manager := NewUltraPlanManager(nil, nil, ultraSession, logger)
+
+	return &Coordinator{
+		manager:      manager,
+		logger:       logger,
+		runningTasks: make(map[string]string),
+		ctx:          context.Background(),
+		cancelFunc:   func() {},
+		mu:           sync.RWMutex{},
+	}
+}

--- a/internal/tui/ultraplan.go
+++ b/internal/tui/ultraplan.go
@@ -98,21 +98,6 @@ func (m *Model) createUltraplanView() *view.UltraplanView {
 	return view.NewUltraplanView(ctx)
 }
 
-// renderUltraPlanHeader renders the ultra-plan header with phase and progress
-func (m Model) renderUltraPlanHeader() string {
-	if m.ultraPlan == nil || m.ultraPlan.Coordinator == nil {
-		return m.renderHeader()
-	}
-
-	session := m.ultraPlan.Coordinator.Session()
-	if session == nil {
-		return m.renderHeader()
-	}
-
-	v := m.createUltraplanView()
-	return v.RenderHeader()
-}
-
 // isInstanceSelected checks if the given instance ID is currently selected in the TUI
 func (m Model) isInstanceSelected(instanceID string) bool {
 	if instanceID == "" {

--- a/internal/tui/view/workflow_status.go
+++ b/internal/tui/view/workflow_status.go
@@ -1,0 +1,372 @@
+package view
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/orchestrator/workflows/adversarial"
+	"github.com/Iron-Ham/claudio/internal/orchestrator/workflows/tripleshot"
+	"github.com/Iron-Ham/claudio/internal/tui/styles"
+	"github.com/Iron-Ham/claudio/internal/tui/view/ultraplan"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// WorkflowStatusState aggregates status from all active workflow types.
+// This enables the header to show multiple concurrent workflows at once.
+type WorkflowStatusState struct {
+	UltraPlan   *UltraPlanState
+	TripleShot  *TripleShotState
+	Adversarial *AdversarialState
+}
+
+// WorkflowIndicator represents a single workflow's status indicator.
+type WorkflowIndicator struct {
+	Icon      string
+	Label     string
+	Style     lipgloss.Style
+	Count     int    // Number of active sessions (0 means single session mode)
+	Objective string // Objective/task description (used by ultraplan for single-workflow header display)
+}
+
+// HasActiveWorkflows returns true if any workflow type is active.
+func (s *WorkflowStatusState) HasActiveWorkflows() bool {
+	if s == nil {
+		return false
+	}
+	return s.hasUltraPlan() || s.hasTripleShot() || s.hasAdversarial()
+}
+
+// hasUltraPlan checks if ultraplan is active.
+func (s *WorkflowStatusState) hasUltraPlan() bool {
+	return s.UltraPlan != nil && s.UltraPlan.Coordinator != nil
+}
+
+// hasTripleShot checks if tripleshot is active.
+func (s *WorkflowStatusState) hasTripleShot() bool {
+	return s.TripleShot != nil && s.TripleShot.HasActiveCoordinators()
+}
+
+// hasAdversarial checks if adversarial is active.
+func (s *WorkflowStatusState) hasAdversarial() bool {
+	return s.Adversarial != nil && s.Adversarial.HasActiveCoordinators()
+}
+
+// GetUltraPlanObjective returns the ultraplan objective if ultraplan is active.
+// Returns empty string if ultraplan is not active or has no objective.
+func (s *WorkflowStatusState) GetUltraPlanObjective() string {
+	if !s.hasUltraPlan() {
+		return ""
+	}
+	session := s.UltraPlan.Coordinator.Session()
+	if session == nil {
+		return ""
+	}
+	return session.Objective
+}
+
+// GetIndicators returns a slice of workflow indicators for all active workflows.
+// The indicators are ordered by priority: UltraPlan, TripleShot, Adversarial.
+func (s *WorkflowStatusState) GetIndicators() []WorkflowIndicator {
+	if s == nil {
+		return nil
+	}
+
+	var indicators []WorkflowIndicator
+
+	if ind := s.getUltraPlanIndicator(); ind != nil {
+		indicators = append(indicators, *ind)
+	}
+	if ind := s.getTripleShotIndicator(); ind != nil {
+		indicators = append(indicators, *ind)
+	}
+	if ind := s.getAdversarialIndicator(); ind != nil {
+		indicators = append(indicators, *ind)
+	}
+
+	return indicators
+}
+
+// getUltraPlanIndicator returns the indicator for ultraplan mode.
+func (s *WorkflowStatusState) getUltraPlanIndicator() *WorkflowIndicator {
+	if !s.hasUltraPlan() {
+		return nil
+	}
+
+	session := s.UltraPlan.Coordinator.Session()
+	if session == nil {
+		return nil
+	}
+
+	phaseStr := ultraplan.PhaseToString(session.Phase)
+	pStyle := ultraplan.PhaseStyle(session.Phase)
+
+	// Build a compact progress indicator
+	var progress string
+	switch session.Phase {
+	case orchestrator.PhaseExecuting:
+		prog := session.Progress()
+		progress = fmt.Sprintf("%.0f%%", prog)
+	case orchestrator.PhaseConsolidating:
+		if session.Consolidation != nil && session.Consolidation.TotalGroups > 0 {
+			progress = fmt.Sprintf("%d/%d", session.Consolidation.CurrentGroup, session.Consolidation.TotalGroups)
+		}
+	case orchestrator.PhaseComplete:
+		progress = "done"
+	case orchestrator.PhaseFailed:
+		progress = "failed"
+	}
+
+	label := phaseStr
+	if progress != "" && progress != "done" && progress != "failed" {
+		label = fmt.Sprintf("%s:%s", phaseStr, progress)
+	}
+
+	return &WorkflowIndicator{
+		Icon:      styles.IconUltraPlan,
+		Label:     label,
+		Style:     pStyle,
+		Count:     0, // Ultraplan is always single-session
+		Objective: session.Objective,
+	}
+}
+
+// getTripleShotIndicator returns the indicator for tripleshot mode.
+func (s *WorkflowStatusState) getTripleShotIndicator() *WorkflowIndicator {
+	if !s.hasTripleShot() {
+		return nil
+	}
+
+	coordinators := s.TripleShot.GetAllCoordinators()
+	if len(coordinators) == 0 {
+		return nil
+	}
+
+	// Aggregate status across all tripleshot sessions
+	working := 0
+	evaluating := 0
+	complete := 0
+	failed := 0
+
+	for _, coord := range coordinators {
+		session := coord.Session()
+		if session == nil {
+			continue
+		}
+		switch session.Phase {
+		case tripleshot.PhaseWorking:
+			working++
+		case tripleshot.PhaseEvaluating:
+			evaluating++
+		case tripleshot.PhaseComplete:
+			complete++
+		case tripleshot.PhaseFailed:
+			failed++
+		}
+	}
+
+	// Determine overall status and label
+	var label string
+	var style lipgloss.Style
+
+	total := len(coordinators)
+	if total == 1 {
+		// Single session - show detailed phase
+		session := coordinators[0].Session()
+		if session == nil {
+			return nil
+		}
+		switch session.Phase {
+		case tripleshot.PhaseWorking:
+			label = "working"
+			style = tsHighlight
+		case tripleshot.PhaseEvaluating:
+			label = "evaluating"
+			style = tsWarning
+		case tripleshot.PhaseComplete:
+			label = "complete"
+			style = tsSuccess
+		case tripleshot.PhaseFailed:
+			label = "failed"
+			style = tsError
+		}
+	} else {
+		// Multiple sessions - show summary
+		if working > 0 || evaluating > 0 {
+			active := working + evaluating
+			label = fmt.Sprintf("%d active", active)
+			style = tsHighlight
+		} else if failed > 0 && complete == 0 {
+			label = "failed"
+			style = tsError
+		} else {
+			label = fmt.Sprintf("%d done", complete)
+			style = tsSuccess
+		}
+	}
+
+	count := 0
+	if total > 1 {
+		count = total
+	}
+
+	return &WorkflowIndicator{
+		Icon:  styles.IconTripleShot,
+		Label: label,
+		Style: style,
+		Count: count,
+	}
+}
+
+// getAdversarialIndicator returns the indicator for adversarial mode.
+func (s *WorkflowStatusState) getAdversarialIndicator() *WorkflowIndicator {
+	if !s.hasAdversarial() {
+		return nil
+	}
+
+	coordinators := s.Adversarial.GetAllCoordinators()
+	if len(coordinators) == 0 {
+		return nil
+	}
+
+	// Aggregate status across all adversarial sessions
+	implementing := 0
+	reviewing := 0
+	approved := 0
+	failed := 0
+
+	for _, coord := range coordinators {
+		session := coord.Session()
+		if session == nil {
+			continue
+		}
+		switch session.Phase {
+		case adversarial.PhaseImplementing:
+			implementing++
+		case adversarial.PhaseReviewing:
+			reviewing++
+		case adversarial.PhaseApproved, adversarial.PhaseComplete:
+			approved++
+		case adversarial.PhaseFailed:
+			failed++
+		}
+	}
+
+	var icon string
+	var label string
+	var style lipgloss.Style
+
+	total := len(coordinators)
+	if total == 1 {
+		// Single session - show detailed phase with round
+		session := coordinators[0].Session()
+		if session == nil {
+			return nil
+		}
+		roundStr := fmt.Sprintf("R%d", session.CurrentRound)
+		if session.Config.MaxIterations > 0 {
+			roundStr = fmt.Sprintf("R%d/%d", session.CurrentRound, session.Config.MaxIterations)
+		}
+
+		switch session.Phase {
+		case adversarial.PhaseImplementing:
+			icon = "🔨"
+			label = roundStr
+			style = advHighlight
+		case adversarial.PhaseReviewing:
+			icon = "🔍"
+			label = roundStr
+			style = advWarning
+		case adversarial.PhaseApproved, adversarial.PhaseComplete:
+			icon = "✓"
+			label = "approved"
+			style = advSuccess
+		case adversarial.PhaseFailed:
+			icon = "✗"
+			label = "failed"
+			style = advError
+		}
+	} else {
+		// Multiple sessions - show summary with most urgent status
+		if implementing > 0 {
+			icon = "🔨"
+			label = fmt.Sprintf("%d impl", implementing)
+			style = advHighlight
+		} else if reviewing > 0 {
+			icon = "🔍"
+			label = fmt.Sprintf("%d review", reviewing)
+			style = advWarning
+		} else if failed > 0 && approved == 0 {
+			icon = "✗"
+			label = "failed"
+			style = advError
+		} else {
+			icon = "✓"
+			label = fmt.Sprintf("%d done", approved)
+			style = advSuccess
+		}
+	}
+
+	count := 0
+	if total > 1 {
+		count = total
+	}
+
+	return &WorkflowIndicator{
+		Icon:  icon,
+		Label: label,
+		Style: style,
+		Count: count,
+	}
+}
+
+// RenderWorkflowStatus renders the unified workflow status for the header.
+// Returns an empty string if no workflows are active.
+func RenderWorkflowStatus(state *WorkflowStatusState) string {
+	if state == nil || !state.HasActiveWorkflows() {
+		return ""
+	}
+
+	indicators := state.GetIndicators()
+	if len(indicators) == 0 {
+		return ""
+	}
+
+	var parts []string
+	for _, ind := range indicators {
+		parts = append(parts, renderIndicator(ind))
+	}
+
+	return strings.Join(parts, " │ ")
+}
+
+// renderIndicator renders a single workflow indicator.
+func renderIndicator(ind WorkflowIndicator) string {
+	var b strings.Builder
+
+	b.WriteString(ind.Icon)
+	b.WriteString(" ")
+
+	if ind.Count > 0 {
+		// Show count in parentheses for multiple sessions
+		b.WriteString(fmt.Sprintf("(%d)", ind.Count))
+		b.WriteString(" ")
+	}
+
+	b.WriteString(ind.Style.Render(ind.Label))
+
+	return b.String()
+}
+
+// WorkflowStatusView provides methods for rendering workflow status components.
+type WorkflowStatusView struct{}
+
+// NewWorkflowStatusView creates a new workflow status view.
+func NewWorkflowStatusView() *WorkflowStatusView {
+	return &WorkflowStatusView{}
+}
+
+// Render renders the workflow status line.
+func (v *WorkflowStatusView) Render(state *WorkflowStatusState) string {
+	return RenderWorkflowStatus(state)
+}

--- a/internal/tui/view/workflow_status_test.go
+++ b/internal/tui/view/workflow_status_test.go
@@ -1,0 +1,830 @@
+package view
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/orchestrator/workflows/adversarial"
+	"github.com/Iron-Ham/claudio/internal/orchestrator/workflows/tripleshot"
+	"github.com/Iron-Ham/claudio/internal/tui/styles"
+)
+
+func TestWorkflowStatusState_HasActiveWorkflows(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    *WorkflowStatusState
+		expected bool
+	}{
+		{
+			name:     "nil state returns false",
+			state:    nil,
+			expected: false,
+		},
+		{
+			name:     "empty state returns false",
+			state:    &WorkflowStatusState{},
+			expected: false,
+		},
+		{
+			name: "ultraplan state without coordinator returns false",
+			state: &WorkflowStatusState{
+				UltraPlan: &UltraPlanState{},
+			},
+			expected: false,
+		},
+		{
+			name: "tripleshot active returns true",
+			state: &WorkflowStatusState{
+				TripleShot: &TripleShotState{
+					Coordinators: map[string]*tripleshot.Coordinator{
+						"group1": {},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "adversarial active returns true",
+			state: &WorkflowStatusState{
+				Adversarial: &AdversarialState{
+					Coordinators: map[string]*adversarial.Coordinator{
+						"group1": {},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "tripleshot and adversarial active returns true",
+			state: &WorkflowStatusState{
+				TripleShot: &TripleShotState{
+					Coordinators: map[string]*tripleshot.Coordinator{
+						"group1": {},
+					},
+				},
+				Adversarial: &AdversarialState{
+					Coordinators: map[string]*adversarial.Coordinator{
+						"group1": {},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.state.HasActiveWorkflows()
+			if got != tt.expected {
+				t.Errorf("HasActiveWorkflows() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestWorkflowStatusState_GetIndicators(t *testing.T) {
+	tests := []struct {
+		name          string
+		state         *WorkflowStatusState
+		expectedCount int
+	}{
+		{
+			name:          "nil state returns empty",
+			state:         nil,
+			expectedCount: 0,
+		},
+		{
+			name:          "empty state returns empty",
+			state:         &WorkflowStatusState{},
+			expectedCount: 0,
+		},
+		{
+			name: "single tripleshot returns one indicator",
+			state: &WorkflowStatusState{
+				TripleShot: createMockTripleShotState(1),
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "single adversarial returns one indicator",
+			state: &WorkflowStatusState{
+				Adversarial: createMockAdversarialState(1),
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "tripleshot and adversarial active returns two indicators",
+			state: &WorkflowStatusState{
+				TripleShot:  createMockTripleShotState(1),
+				Adversarial: createMockAdversarialState(1),
+			},
+			expectedCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			indicators := tt.state.GetIndicators()
+			if len(indicators) != tt.expectedCount {
+				t.Errorf("GetIndicators() returned %d indicators, want %d", len(indicators), tt.expectedCount)
+			}
+		})
+	}
+}
+
+func TestWorkflowStatusState_IndicatorOrder(t *testing.T) {
+	// Verify indicators are returned in priority order: UltraPlan, TripleShot, Adversarial
+	// This test verifies TripleShot and Adversarial order; see TestGetUltraPlanIndicator for UltraPlan tests
+	state := &WorkflowStatusState{
+		TripleShot:  createMockTripleShotState(1),
+		Adversarial: createMockAdversarialState(1),
+	}
+
+	indicators := state.GetIndicators()
+	if len(indicators) != 2 {
+		t.Fatalf("Expected 2 indicators, got %d", len(indicators))
+	}
+
+	// First should be TripleShot (△ icon)
+	if indicators[0].Icon != "△" {
+		t.Errorf("First indicator should be TripleShot (△), got %s", indicators[0].Icon)
+	}
+
+	// Second should be Adversarial (🔨, 🔍, ✓, or ✗ icon)
+	advIcons := []string{"🔨", "🔍", "✓", "✗"}
+	found := false
+	for _, icon := range advIcons {
+		if indicators[1].Icon == icon {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Second indicator should be Adversarial icon, got %s", indicators[1].Icon)
+	}
+}
+
+func TestRenderWorkflowStatus(t *testing.T) {
+	tests := []struct {
+		name            string
+		state           *WorkflowStatusState
+		expectEmpty     bool
+		expectContains  []string
+		expectSeparator bool
+	}{
+		{
+			name:        "nil state returns empty",
+			state:       nil,
+			expectEmpty: true,
+		},
+		{
+			name:        "empty state returns empty",
+			state:       &WorkflowStatusState{},
+			expectEmpty: true,
+		},
+		{
+			name: "single tripleshot shows no separator",
+			state: &WorkflowStatusState{
+				TripleShot: createMockTripleShotState(1),
+			},
+			expectEmpty:     false,
+			expectContains:  []string{"△"},
+			expectSeparator: false,
+		},
+		{
+			name: "multiple workflows shows separator",
+			state: &WorkflowStatusState{
+				TripleShot:  createMockTripleShotState(1),
+				Adversarial: createMockAdversarialState(1),
+			},
+			expectEmpty:     false,
+			expectContains:  []string{"△", "🔨", "│"},
+			expectSeparator: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RenderWorkflowStatus(tt.state)
+
+			if tt.expectEmpty {
+				if result != "" {
+					t.Errorf("Expected empty string, got %q", result)
+				}
+				return
+			}
+
+			if result == "" {
+				t.Error("Expected non-empty string, got empty")
+				return
+			}
+
+			for _, contains := range tt.expectContains {
+				if !strings.Contains(result, contains) {
+					t.Errorf("Expected result to contain %q, got %q", contains, result)
+				}
+			}
+
+			hasSeparator := strings.Contains(result, "│")
+			if tt.expectSeparator != hasSeparator {
+				t.Errorf("Separator expectation mismatch: expected %v, got %v in %q", tt.expectSeparator, hasSeparator, result)
+			}
+		})
+	}
+}
+
+func TestTripleShotIndicator_MultipleSessionsSummary(t *testing.T) {
+	// Test that multiple tripleshot sessions show a summary count
+	state := &WorkflowStatusState{
+		TripleShot: createMockTripleShotState(3),
+	}
+
+	indicators := state.GetIndicators()
+	if len(indicators) != 1 {
+		t.Fatalf("Expected 1 indicator, got %d", len(indicators))
+	}
+
+	ind := indicators[0]
+	if ind.Count != 3 {
+		t.Errorf("Expected count of 3, got %d", ind.Count)
+	}
+}
+
+func TestAdversarialIndicator_MultipleSessionsSummary(t *testing.T) {
+	// Test that multiple adversarial sessions show a summary count
+	state := &WorkflowStatusState{
+		Adversarial: createMockAdversarialState(2),
+	}
+
+	indicators := state.GetIndicators()
+	if len(indicators) != 1 {
+		t.Fatalf("Expected 1 indicator, got %d", len(indicators))
+	}
+
+	ind := indicators[0]
+	if ind.Count != 2 {
+		t.Errorf("Expected count of 2, got %d", ind.Count)
+	}
+}
+
+func TestWorkflowStatusView_Render(t *testing.T) {
+	v := NewWorkflowStatusView()
+
+	state := &WorkflowStatusState{
+		TripleShot: createMockTripleShotState(1),
+	}
+
+	result := v.Render(state)
+	if result == "" {
+		t.Error("Expected non-empty render result")
+	}
+
+	if !strings.Contains(result, "△") {
+		t.Error("Expected TripleShot indicator icon in render result")
+	}
+}
+
+// Helper functions to create mock states for testing
+
+func createMockTripleShotState(count int) *TripleShotState {
+	coordinators := make(map[string]*tripleshot.Coordinator)
+	for i := 0; i < count; i++ {
+		groupID := string(rune('a' + i))
+		coordinators[groupID] = createMockTripleShotCoordinator()
+	}
+	return &TripleShotState{
+		Coordinators: coordinators,
+	}
+}
+
+func createMockTripleShotCoordinator() *tripleshot.Coordinator {
+	session := &tripleshot.Session{
+		Phase: tripleshot.PhaseWorking,
+		Attempts: [3]tripleshot.Attempt{
+			{Status: tripleshot.AttemptStatusWorking},
+			{Status: tripleshot.AttemptStatusPending},
+			{Status: tripleshot.AttemptStatusPending},
+		},
+	}
+	cfg := tripleshot.CoordinatorConfig{
+		TripleSession: session,
+	}
+	return tripleshot.NewCoordinator(cfg)
+}
+
+func createMockAdversarialState(count int) *AdversarialState {
+	coordinators := make(map[string]*adversarial.Coordinator)
+	for i := 0; i < count; i++ {
+		groupID := string(rune('a' + i))
+		coordinators[groupID] = createMockAdversarialCoordinator()
+	}
+	return &AdversarialState{
+		Coordinators: coordinators,
+	}
+}
+
+func createMockAdversarialCoordinator() *adversarial.Coordinator {
+	session := &adversarial.Session{
+		Phase:        adversarial.PhaseImplementing,
+		CurrentRound: 1,
+		Config: adversarial.Config{
+			MaxIterations: 5,
+		},
+	}
+	cfg := adversarial.CoordinatorConfig{
+		AdvSession: session,
+	}
+	return adversarial.NewCoordinator(cfg)
+}
+
+// createMockUltraPlanState creates a mock UltraPlanState with a coordinator
+// that has a session with the given phase and objective.
+func createMockUltraPlanState(phase orchestrator.UltraPlanPhase, objective string) *UltraPlanState {
+	ultraSession := &orchestrator.UltraPlanSession{
+		ID:        "test-ultraplan-session",
+		Phase:     phase,
+		Objective: objective,
+	}
+	coordinator := orchestrator.NewCoordinatorForTesting(ultraSession)
+	return &UltraPlanState{
+		Coordinator: coordinator,
+	}
+}
+
+// createMockUltraPlanStateWithConsolidation creates a mock UltraPlanState
+// with consolidation progress information.
+func createMockUltraPlanStateWithConsolidation(currentGroup, totalGroups int, objective string) *UltraPlanState {
+	ultraSession := &orchestrator.UltraPlanSession{
+		ID:        "test-ultraplan-session",
+		Phase:     orchestrator.PhaseConsolidating,
+		Objective: objective,
+		Consolidation: &orchestrator.ConsolidatorState{
+			CurrentGroup: currentGroup,
+			TotalGroups:  totalGroups,
+		},
+	}
+	coordinator := orchestrator.NewCoordinatorForTesting(ultraSession)
+	return &UltraPlanState{
+		Coordinator: coordinator,
+	}
+}
+
+func TestGetUltraPlanIndicator(t *testing.T) {
+	tests := []struct {
+		name              string
+		state             *WorkflowStatusState
+		expectNil         bool
+		expectIcon        string
+		expectLabelPrefix string
+		expectObjective   string
+	}{
+		{
+			name:      "nil state returns nil",
+			state:     nil,
+			expectNil: true,
+		},
+		{
+			name:      "empty state returns nil",
+			state:     &WorkflowStatusState{},
+			expectNil: true,
+		},
+		{
+			name: "ultraplan without coordinator returns nil",
+			state: &WorkflowStatusState{
+				UltraPlan: &UltraPlanState{},
+			},
+			expectNil: true,
+		},
+		{
+			name: "planning phase shows correct indicator",
+			state: &WorkflowStatusState{
+				UltraPlan: createMockUltraPlanState(orchestrator.PhasePlanning, "Implement user auth"),
+			},
+			expectNil:         false,
+			expectIcon:        styles.IconUltraPlan,
+			expectLabelPrefix: "PLANNING",
+			expectObjective:   "Implement user auth",
+		},
+		{
+			name: "executing phase shows progress",
+			state: &WorkflowStatusState{
+				UltraPlan: createMockUltraPlanState(orchestrator.PhaseExecuting, "Add new feature"),
+			},
+			expectNil:         false,
+			expectIcon:        styles.IconUltraPlan,
+			expectLabelPrefix: "EXECUTING",
+			expectObjective:   "Add new feature",
+		},
+		{
+			name: "consolidating phase shows group progress",
+			state: &WorkflowStatusState{
+				UltraPlan: createMockUltraPlanStateWithConsolidation(2, 5, "Refactor API"),
+			},
+			expectNil:         false,
+			expectIcon:        styles.IconUltraPlan,
+			expectLabelPrefix: "CONSOLIDATING",
+			expectObjective:   "Refactor API",
+		},
+		{
+			name: "complete phase shows done",
+			state: &WorkflowStatusState{
+				UltraPlan: createMockUltraPlanState(orchestrator.PhaseComplete, "Fix bugs"),
+			},
+			expectNil:         false,
+			expectIcon:        styles.IconUltraPlan,
+			expectLabelPrefix: "COMPLETE",
+			expectObjective:   "Fix bugs",
+		},
+		{
+			name: "failed phase shows failed",
+			state: &WorkflowStatusState{
+				UltraPlan: createMockUltraPlanState(orchestrator.PhaseFailed, "Update tests"),
+			},
+			expectNil:         false,
+			expectIcon:        styles.IconUltraPlan,
+			expectLabelPrefix: "FAILED",
+			expectObjective:   "Update tests",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var indicator *WorkflowIndicator
+			if tt.state != nil {
+				indicator = tt.state.getUltraPlanIndicator()
+			}
+
+			if tt.expectNil {
+				if indicator != nil {
+					t.Errorf("expected nil indicator, got %+v", indicator)
+				}
+				return
+			}
+
+			if indicator == nil {
+				t.Fatal("expected non-nil indicator, got nil")
+			}
+
+			if indicator.Icon != tt.expectIcon {
+				t.Errorf("Icon = %q, want %q", indicator.Icon, tt.expectIcon)
+			}
+
+			if !strings.HasPrefix(indicator.Label, tt.expectLabelPrefix) {
+				t.Errorf("Label = %q, want prefix %q", indicator.Label, tt.expectLabelPrefix)
+			}
+
+			if indicator.Objective != tt.expectObjective {
+				t.Errorf("Objective = %q, want %q", indicator.Objective, tt.expectObjective)
+			}
+
+			// Ultraplan is always single-session, so Count should be 0
+			if indicator.Count != 0 {
+				t.Errorf("Count = %d, want 0 (ultraplan is single-session)", indicator.Count)
+			}
+		})
+	}
+}
+
+func TestGetUltraPlanObjective(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    *WorkflowStatusState
+		expected string
+	}{
+		{
+			name:     "nil state returns empty",
+			state:    nil,
+			expected: "",
+		},
+		{
+			name:     "empty state returns empty",
+			state:    &WorkflowStatusState{},
+			expected: "",
+		},
+		{
+			name: "ultraplan without coordinator returns empty",
+			state: &WorkflowStatusState{
+				UltraPlan: &UltraPlanState{},
+			},
+			expected: "",
+		},
+		{
+			name: "ultraplan with coordinator returns objective",
+			state: &WorkflowStatusState{
+				UltraPlan: createMockUltraPlanState(orchestrator.PhasePlanning, "Implement feature X"),
+			},
+			expected: "Implement feature X",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got string
+			if tt.state != nil {
+				got = tt.state.GetUltraPlanObjective()
+			}
+			if got != tt.expected {
+				t.Errorf("GetUltraPlanObjective() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestUltraPlanIndicatorInGetIndicators(t *testing.T) {
+	// Verify that ultraplan indicator appears first in GetIndicators when active
+	state := &WorkflowStatusState{
+		UltraPlan:   createMockUltraPlanState(orchestrator.PhaseExecuting, "Test objective"),
+		TripleShot:  createMockTripleShotState(1),
+		Adversarial: createMockAdversarialState(1),
+	}
+
+	indicators := state.GetIndicators()
+	if len(indicators) != 3 {
+		t.Fatalf("Expected 3 indicators, got %d", len(indicators))
+	}
+
+	// First should be UltraPlan (🎯 icon)
+	if indicators[0].Icon != styles.IconUltraPlan {
+		t.Errorf("First indicator should be UltraPlan (%s), got %s", styles.IconUltraPlan, indicators[0].Icon)
+	}
+
+	// Second should be TripleShot (△ icon)
+	if indicators[1].Icon != "△" {
+		t.Errorf("Second indicator should be TripleShot (△), got %s", indicators[1].Icon)
+	}
+
+	// Third should be Adversarial
+	advIcons := []string{"🔨", "🔍", "✓", "✗"}
+	found := false
+	for _, icon := range advIcons {
+		if indicators[2].Icon == icon {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Third indicator should be Adversarial icon, got %s", indicators[2].Icon)
+	}
+}
+
+// Phase-parameterized mock helpers for testing mixed-phase scenarios
+
+func createMockTripleShotCoordinatorWithPhase(phase tripleshot.Phase) *tripleshot.Coordinator {
+	session := &tripleshot.Session{
+		Phase: phase,
+		Attempts: [3]tripleshot.Attempt{
+			{Status: tripleshot.AttemptStatusWorking},
+			{Status: tripleshot.AttemptStatusPending},
+			{Status: tripleshot.AttemptStatusPending},
+		},
+	}
+	cfg := tripleshot.CoordinatorConfig{
+		TripleSession: session,
+	}
+	return tripleshot.NewCoordinator(cfg)
+}
+
+func createMockAdversarialCoordinatorWithPhase(phase adversarial.Phase) *adversarial.Coordinator {
+	session := &adversarial.Session{
+		Phase:        phase,
+		CurrentRound: 1,
+		Config: adversarial.Config{
+			MaxIterations: 5,
+		},
+	}
+	cfg := adversarial.CoordinatorConfig{
+		AdvSession: session,
+	}
+	return adversarial.NewCoordinator(cfg)
+}
+
+func TestTripleShotIndicator_MixedPhaseAggregation(t *testing.T) {
+	tests := []struct {
+		name        string
+		phases      []tripleshot.Phase
+		expectLabel string
+		expectStyle string // "highlight", "warning", "success", "error"
+	}{
+		{
+			name:        "working and evaluating shows active count",
+			phases:      []tripleshot.Phase{tripleshot.PhaseWorking, tripleshot.PhaseEvaluating},
+			expectLabel: "2 active",
+			expectStyle: "highlight",
+		},
+		{
+			name:        "all evaluating shows active count",
+			phases:      []tripleshot.Phase{tripleshot.PhaseEvaluating, tripleshot.PhaseEvaluating},
+			expectLabel: "2 active",
+			expectStyle: "highlight",
+		},
+		{
+			name:        "all complete shows done count",
+			phases:      []tripleshot.Phase{tripleshot.PhaseComplete, tripleshot.PhaseComplete, tripleshot.PhaseComplete},
+			expectLabel: "3 done",
+			expectStyle: "success",
+		},
+		{
+			name:        "all failed shows failed",
+			phases:      []tripleshot.Phase{tripleshot.PhaseFailed, tripleshot.PhaseFailed},
+			expectLabel: "failed",
+			expectStyle: "error",
+		},
+		{
+			name:        "mixed complete and failed shows done count",
+			phases:      []tripleshot.Phase{tripleshot.PhaseComplete, tripleshot.PhaseFailed},
+			expectLabel: "1 done",
+			expectStyle: "success",
+		},
+		{
+			name:        "working takes priority over complete",
+			phases:      []tripleshot.Phase{tripleshot.PhaseWorking, tripleshot.PhaseComplete, tripleshot.PhaseComplete},
+			expectLabel: "1 active",
+			expectStyle: "highlight",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			coordinators := make(map[string]*tripleshot.Coordinator)
+			for i, phase := range tt.phases {
+				groupID := string(rune('a' + i))
+				coordinators[groupID] = createMockTripleShotCoordinatorWithPhase(phase)
+			}
+			state := &WorkflowStatusState{
+				TripleShot: &TripleShotState{
+					Coordinators: coordinators,
+				},
+			}
+
+			indicators := state.GetIndicators()
+			if len(indicators) != 1 {
+				t.Fatalf("Expected 1 indicator, got %d", len(indicators))
+			}
+
+			ind := indicators[0]
+			if ind.Label != tt.expectLabel {
+				t.Errorf("Label = %q, want %q", ind.Label, tt.expectLabel)
+			}
+		})
+	}
+}
+
+func TestAdversarialIndicator_MixedPhaseAggregation(t *testing.T) {
+	tests := []struct {
+		name        string
+		phases      []adversarial.Phase
+		expectIcon  string
+		expectLabel string
+	}{
+		{
+			name:        "implementing takes priority over reviewing",
+			phases:      []adversarial.Phase{adversarial.PhaseImplementing, adversarial.PhaseReviewing, adversarial.PhaseReviewing},
+			expectIcon:  "🔨",
+			expectLabel: "1 impl",
+		},
+		{
+			name:        "reviewing shown when no implementing",
+			phases:      []adversarial.Phase{adversarial.PhaseReviewing, adversarial.PhaseReviewing},
+			expectIcon:  "🔍",
+			expectLabel: "2 review",
+		},
+		{
+			name:        "all approved shows done count",
+			phases:      []adversarial.Phase{adversarial.PhaseApproved, adversarial.PhaseApproved, adversarial.PhaseComplete},
+			expectIcon:  "✓",
+			expectLabel: "3 done",
+		},
+		{
+			name:        "all failed shows failed",
+			phases:      []adversarial.Phase{adversarial.PhaseFailed, adversarial.PhaseFailed},
+			expectIcon:  "✗",
+			expectLabel: "failed",
+		},
+		{
+			name:        "mixed approved and failed shows done count",
+			phases:      []adversarial.Phase{adversarial.PhaseApproved, adversarial.PhaseFailed},
+			expectIcon:  "✓",
+			expectLabel: "1 done",
+		},
+		{
+			name:        "implementing takes priority over approved",
+			phases:      []adversarial.Phase{adversarial.PhaseImplementing, adversarial.PhaseApproved, adversarial.PhaseApproved},
+			expectIcon:  "🔨",
+			expectLabel: "1 impl",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			coordinators := make(map[string]*adversarial.Coordinator)
+			for i, phase := range tt.phases {
+				groupID := string(rune('a' + i))
+				coordinators[groupID] = createMockAdversarialCoordinatorWithPhase(phase)
+			}
+			state := &WorkflowStatusState{
+				Adversarial: &AdversarialState{
+					Coordinators: coordinators,
+				},
+			}
+
+			indicators := state.GetIndicators()
+			if len(indicators) != 1 {
+				t.Fatalf("Expected 1 indicator, got %d", len(indicators))
+			}
+
+			ind := indicators[0]
+			if ind.Icon != tt.expectIcon {
+				t.Errorf("Icon = %q, want %q", ind.Icon, tt.expectIcon)
+			}
+			if ind.Label != tt.expectLabel {
+				t.Errorf("Label = %q, want %q", ind.Label, tt.expectLabel)
+			}
+		})
+	}
+}
+
+func TestRenderIndicator_WithCount(t *testing.T) {
+	tests := []struct {
+		name           string
+		indicator      WorkflowIndicator
+		expectContains []string
+	}{
+		{
+			name: "indicator without count shows no parentheses",
+			indicator: WorkflowIndicator{
+				Icon:  "🔨",
+				Label: "working",
+				Count: 0,
+			},
+			expectContains: []string{"🔨", "working"},
+		},
+		{
+			name: "indicator with count shows formatted count",
+			indicator: WorkflowIndicator{
+				Icon:  "🔨",
+				Label: "2 impl",
+				Count: 3,
+			},
+			expectContains: []string{"🔨", "(3)", "2 impl"},
+		},
+		{
+			name: "indicator with large count",
+			indicator: WorkflowIndicator{
+				Icon:  "△",
+				Label: "5 active",
+				Count: 10,
+			},
+			expectContains: []string{"△", "(10)", "5 active"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := renderIndicator(tt.indicator)
+
+			for _, expected := range tt.expectContains {
+				if !strings.Contains(result, expected) {
+					t.Errorf("renderIndicator() = %q, want to contain %q", result, expected)
+				}
+			}
+
+			// Verify count parentheses only appear when Count > 0
+			hasParens := strings.Contains(result, "(")
+			if tt.indicator.Count > 0 && !hasParens {
+				t.Errorf("Expected parentheses for Count=%d, got %q", tt.indicator.Count, result)
+			}
+			if tt.indicator.Count == 0 && hasParens {
+				t.Errorf("Unexpected parentheses for Count=0, got %q", result)
+			}
+		})
+	}
+}
+
+func TestRenderWorkflowStatus_AllThreeWorkflows(t *testing.T) {
+	// Test that all three workflows together renders correctly with two separators
+	state := &WorkflowStatusState{
+		UltraPlan:   createMockUltraPlanState(orchestrator.PhaseExecuting, "Test objective"),
+		TripleShot:  createMockTripleShotState(1),
+		Adversarial: createMockAdversarialState(1),
+	}
+
+	result := RenderWorkflowStatus(state)
+
+	// Should contain indicators for all three
+	if !strings.Contains(result, styles.IconUltraPlan) {
+		t.Error("Expected UltraPlan icon in result")
+	}
+	if !strings.Contains(result, "△") {
+		t.Error("Expected TripleShot icon in result")
+	}
+	if !strings.Contains(result, "🔨") {
+		t.Error("Expected Adversarial icon in result")
+	}
+
+	// Should have exactly 2 separators for 3 workflows
+	separatorCount := strings.Count(result, "│")
+	if separatorCount != 2 {
+		t.Errorf("Expected 2 separators for 3 workflows, got %d in %q", separatorCount, result)
+	}
+}


### PR DESCRIPTION
## Summary

- The header now displays status indicators for all active workflow types (UltraPlan, TripleShot, Adversarial) simultaneously
- Previously, the header used exclusive priority-based selection, which meant users lost visibility into other running workflows when multiple task types were active
- Added comprehensive test coverage for phase aggregation logic across all workflow types

## Changes

- **New file: `workflow_status.go`** - Contains `WorkflowStatusState` to aggregate status from all workflow types and `WorkflowIndicator` for unified rendering
- **New file: `workflow_status_test.go`** - Comprehensive tests including mixed-phase aggregation scenarios
- **New file: `coordinator_testing.go`** - Test helper `NewCoordinatorForTesting` for creating mock coordinators
- **Modified: `app.go`** - Refactored `renderUnifiedHeader()` to use the new unified workflow status
- **Modified: `ultraplan.go`** - Removed duplicate header rendering code

## Test plan

- [x] All existing tests pass
- [x] New tests cover nil/empty state handling
- [x] New tests cover mixed-phase TripleShot aggregation (working/evaluating/complete/failed combinations)
- [x] New tests cover mixed-phase Adversarial aggregation (implementing/reviewing/approved/failed combinations)
- [x] New tests cover `renderIndicator` with count display
- [x] New tests verify all three workflows render together with correct separators
- [x] Build passes
- [x] `go vet` passes
- [x] Formatting is correct