### PR TITLE
Extract consolidation module into modular subpackages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Consolidation Module Extraction** - Refactored `internal/orchestrator/consolidation.go` into a modular package structure:
+  - Created `internal/orchestrator/consolidation/` package with shared types and interfaces
+  - Extracted `prbuilder/` subpackage for PR content generation (pure data transformation)
+  - Extracted `branch/` subpackage for git branch operations with `NamingStrategy`
+  - Extracted `conflict/` subpackage for merge conflict detection and handling
+  - Extracted `strategy/` subpackage with `Stacked` and `Single` consolidation strategies
+  - Added comprehensive tests with 100% coverage for prbuilder, high coverage elsewhere
+  - Follows Go best practices: interface segregation, dependency injection, adapter pattern
+
 - **UltraPlan Sidebar Subgroups** - Refactored UltraPlan sidebar rendering to use actual InstanceGroup subgroups instead of custom inline rendering. Planning, execution groups (Group 1, Group 2, etc.), Synthesis, Revision, and Consolidation phases now each have their own subgroup within the main UltraPlan group. This aligns with how tripleshot and adversarial modes render their content and enables standard group navigation and collapse/expand behavior. Added `SubgroupRouter` to automatically route instances to the correct subgroup based on session state.
 
 - **Dead Code Removal** - Removed unreachable code identified by static analysis to improve codebase maintainability:

--- a/internal/orchestrator/consolidation/branch/manager.go
+++ b/internal/orchestrator/consolidation/branch/manager.go
@@ -1,0 +1,147 @@
+// Package branch provides git branch operations for consolidation.
+// It wraps the worktree.Manager to provide consolidation-specific
+// branch management functionality.
+package branch
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator/consolidation"
+	"github.com/Iron-Ham/claudio/internal/worktree"
+)
+
+// Compile-time check that Manager implements consolidation.BranchManager.
+var _ consolidation.BranchManager = (*Manager)(nil)
+
+// Manager handles git branch operations for consolidation.
+type Manager struct {
+	wt     WorktreeManager
+	naming *NamingStrategy
+}
+
+// WorktreeManager defines the interface for git worktree operations.
+// This interface allows for easy testing with mocks.
+type WorktreeManager interface {
+	FindMainBranch() string
+	CreateBranchFrom(branchName, baseBranch string) error
+	CreateWorktreeFromBranch(path, branch string) error
+	CherryPickBranch(path, sourceBranch string) error
+	GetChangedFiles(path string) ([]string, error)
+	GetConflictingFiles(path string) ([]string, error)
+	CountCommitsBetween(path, baseBranch, headBranch string) (int, error)
+	Push(path string, force bool) error
+	Remove(path string) error
+	DeleteBranch(branch string) error
+	ContinueCherryPick(path string) error
+	AbortCherryPick(path string) error
+}
+
+// Option configures a Manager.
+type Option func(*Manager)
+
+// WithNamingStrategy sets a custom naming strategy.
+func WithNamingStrategy(ns *NamingStrategy) Option {
+	return func(m *Manager) {
+		m.naming = ns
+	}
+}
+
+// New creates a new branch Manager wrapping the given worktree manager.
+func New(wt WorktreeManager, opts ...Option) *Manager {
+	m := &Manager{
+		wt:     wt,
+		naming: NewNamingStrategy("", ""),
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// NewFromWorktreeManager creates a Manager from a worktree.Manager.
+// This is a convenience function for production use.
+func NewFromWorktreeManager(wt *worktree.Manager, opts ...Option) *Manager {
+	return New(wt, opts...)
+}
+
+// FindMainBranch returns the name of the main branch (main or master).
+func (m *Manager) FindMainBranch(_ context.Context) string {
+	return m.wt.FindMainBranch()
+}
+
+// CreateGroupBranch creates a branch for a consolidation group.
+func (m *Manager) CreateGroupBranch(_ context.Context, groupIdx int, baseBranch string) (string, error) {
+	branchName := m.naming.GroupBranchName(groupIdx)
+	if err := m.wt.CreateBranchFrom(branchName, baseBranch); err != nil {
+		return "", fmt.Errorf("failed to create group branch %s from %s: %w", branchName, baseBranch, err)
+	}
+	return branchName, nil
+}
+
+// CreateSingleBranch creates a branch for single PR mode consolidation.
+func (m *Manager) CreateSingleBranch(_ context.Context, baseBranch string) (string, error) {
+	branchName := m.naming.SingleBranchName()
+	if err := m.wt.CreateBranchFrom(branchName, baseBranch); err != nil {
+		return "", fmt.Errorf("failed to create consolidated branch %s from %s: %w", branchName, baseBranch, err)
+	}
+	return branchName, nil
+}
+
+// CreateWorktree creates a worktree for the given branch.
+func (m *Manager) CreateWorktree(_ context.Context, path, branch string) error {
+	if err := m.wt.CreateWorktreeFromBranch(path, branch); err != nil {
+		return fmt.Errorf("failed to create worktree at %s for branch %s: %w", path, branch, err)
+	}
+	return nil
+}
+
+// CherryPickBranch cherry-picks commits from source branch into the worktree.
+func (m *Manager) CherryPickBranch(_ context.Context, worktreePath, sourceBranch string) error {
+	return m.wt.CherryPickBranch(worktreePath, sourceBranch)
+}
+
+// GetChangedFiles returns files changed in the worktree compared to main.
+func (m *Manager) GetChangedFiles(_ context.Context, worktreePath string) ([]string, error) {
+	return m.wt.GetChangedFiles(worktreePath)
+}
+
+// GetConflictingFiles returns files with merge conflicts.
+func (m *Manager) GetConflictingFiles(_ context.Context, worktreePath string) ([]string, error) {
+	return m.wt.GetConflictingFiles(worktreePath)
+}
+
+// CountCommitsBetween returns the number of commits between base and head.
+func (m *Manager) CountCommitsBetween(_ context.Context, worktreePath, baseBranch, headBranch string) (int, error) {
+	return m.wt.CountCommitsBetween(worktreePath, baseBranch, headBranch)
+}
+
+// Push pushes the branch to the remote.
+func (m *Manager) Push(_ context.Context, worktreePath string, force bool) error {
+	return m.wt.Push(worktreePath, force)
+}
+
+// RemoveWorktree removes a worktree.
+func (m *Manager) RemoveWorktree(_ context.Context, path string) error {
+	return m.wt.Remove(path)
+}
+
+// DeleteBranch deletes a branch.
+func (m *Manager) DeleteBranch(_ context.Context, branch string) error {
+	return m.wt.DeleteBranch(branch)
+}
+
+// ContinueCherryPick continues a cherry-pick after conflict resolution.
+func (m *Manager) ContinueCherryPick(_ context.Context, worktreePath string) error {
+	return m.wt.ContinueCherryPick(worktreePath)
+}
+
+// AbortCherryPick aborts an in-progress cherry-pick.
+func (m *Manager) AbortCherryPick(_ context.Context, worktreePath string) error {
+	return m.wt.AbortCherryPick(worktreePath)
+}
+
+// NamingStrategy returns the naming strategy used by this manager.
+func (m *Manager) NamingStrategy() *NamingStrategy {
+	return m.naming
+}

--- a/internal/orchestrator/consolidation/branch/manager_test.go
+++ b/internal/orchestrator/consolidation/branch/manager_test.go
@@ -1,0 +1,386 @@
+package branch
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// mockWorktreeManager is a mock implementation of WorktreeManager for testing.
+type mockWorktreeManager struct {
+	mainBranch           string
+	createBranchFromErr  error
+	createWorktreeErr    error
+	cherryPickErr        error
+	changedFiles         []string
+	changedFilesErr      error
+	conflictingFiles     []string
+	conflictingFilesErr  error
+	commitCount          int
+	commitCountErr       error
+	pushErr              error
+	removeErr            error
+	deleteBranchErr      error
+	continueCherryErr    error
+	abortCherryErr       error
+	createBranchFromCall struct {
+		branchName string
+		baseBranch string
+	}
+	createWorktreeCall struct {
+		path   string
+		branch string
+	}
+	cherryPickCall struct {
+		path         string
+		sourceBranch string
+	}
+}
+
+func (m *mockWorktreeManager) FindMainBranch() string {
+	if m.mainBranch == "" {
+		return "main"
+	}
+	return m.mainBranch
+}
+
+func (m *mockWorktreeManager) CreateBranchFrom(branchName, baseBranch string) error {
+	m.createBranchFromCall.branchName = branchName
+	m.createBranchFromCall.baseBranch = baseBranch
+	return m.createBranchFromErr
+}
+
+func (m *mockWorktreeManager) CreateWorktreeFromBranch(path, branch string) error {
+	m.createWorktreeCall.path = path
+	m.createWorktreeCall.branch = branch
+	return m.createWorktreeErr
+}
+
+func (m *mockWorktreeManager) CherryPickBranch(path, sourceBranch string) error {
+	m.cherryPickCall.path = path
+	m.cherryPickCall.sourceBranch = sourceBranch
+	return m.cherryPickErr
+}
+
+func (m *mockWorktreeManager) GetChangedFiles(_ string) ([]string, error) {
+	return m.changedFiles, m.changedFilesErr
+}
+
+func (m *mockWorktreeManager) GetConflictingFiles(_ string) ([]string, error) {
+	return m.conflictingFiles, m.conflictingFilesErr
+}
+
+func (m *mockWorktreeManager) CountCommitsBetween(_, _, _ string) (int, error) {
+	return m.commitCount, m.commitCountErr
+}
+
+func (m *mockWorktreeManager) Push(_ string, _ bool) error {
+	return m.pushErr
+}
+
+func (m *mockWorktreeManager) Remove(_ string) error {
+	return m.removeErr
+}
+
+func (m *mockWorktreeManager) DeleteBranch(_ string) error {
+	return m.deleteBranchErr
+}
+
+func (m *mockWorktreeManager) ContinueCherryPick(_ string) error {
+	return m.continueCherryErr
+}
+
+func (m *mockWorktreeManager) AbortCherryPick(_ string) error {
+	return m.abortCherryErr
+}
+
+func TestManager_FindMainBranch(t *testing.T) {
+	mock := &mockWorktreeManager{mainBranch: "main"}
+	mgr := New(mock)
+
+	got := mgr.FindMainBranch(context.Background())
+	if got != "main" {
+		t.Errorf("FindMainBranch() = %q, want %q", got, "main")
+	}
+}
+
+func TestManager_CreateGroupBranch(t *testing.T) {
+	tests := []struct {
+		name       string
+		sessionID  string
+		groupIdx   int
+		baseBranch string
+		wantBranch string
+		mockErr    error
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name:       "success first group",
+			sessionID:  "abc12345",
+			groupIdx:   0,
+			baseBranch: "main",
+			wantBranch: "Iron-Ham/ultraplan-abc12345-group-1",
+		},
+		{
+			name:       "success second group",
+			sessionID:  "abc12345",
+			groupIdx:   1,
+			baseBranch: "Iron-Ham/ultraplan-abc12345-group-1",
+			wantBranch: "Iron-Ham/ultraplan-abc12345-group-2",
+		},
+		{
+			name:       "error creating branch",
+			sessionID:  "abc12345",
+			groupIdx:   0,
+			baseBranch: "main",
+			mockErr:    errors.New("branch already exists"),
+			wantErr:    true,
+			wantErrMsg: "failed to create group branch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockWorktreeManager{createBranchFromErr: tt.mockErr}
+			ns := NewNamingStrategy("Iron-Ham", tt.sessionID)
+			mgr := New(mock, WithNamingStrategy(ns))
+
+			got, err := mgr.CreateGroupBranch(context.Background(), tt.groupIdx, tt.baseBranch)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("CreateGroupBranch() expected error, got nil")
+				} else if tt.wantErrMsg != "" && !strings.Contains(err.Error(), tt.wantErrMsg) {
+					t.Errorf("CreateGroupBranch() error = %v, want containing %q", err, tt.wantErrMsg)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("CreateGroupBranch() unexpected error: %v", err)
+				return
+			}
+
+			if got != tt.wantBranch {
+				t.Errorf("CreateGroupBranch() = %q, want %q", got, tt.wantBranch)
+			}
+
+			if mock.createBranchFromCall.branchName != tt.wantBranch {
+				t.Errorf("CreateBranchFrom called with branchName = %q, want %q",
+					mock.createBranchFromCall.branchName, tt.wantBranch)
+			}
+
+			if mock.createBranchFromCall.baseBranch != tt.baseBranch {
+				t.Errorf("CreateBranchFrom called with baseBranch = %q, want %q",
+					mock.createBranchFromCall.baseBranch, tt.baseBranch)
+			}
+		})
+	}
+}
+
+func TestManager_CreateSingleBranch(t *testing.T) {
+	tests := []struct {
+		name       string
+		sessionID  string
+		baseBranch string
+		wantBranch string
+		mockErr    error
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			sessionID:  "xyz98765",
+			baseBranch: "main",
+			wantBranch: "Iron-Ham/ultraplan-xyz98765",
+		},
+		{
+			name:       "error",
+			sessionID:  "xyz98765",
+			baseBranch: "main",
+			mockErr:    errors.New("failed"),
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockWorktreeManager{createBranchFromErr: tt.mockErr}
+			ns := NewNamingStrategy("Iron-Ham", tt.sessionID)
+			mgr := New(mock, WithNamingStrategy(ns))
+
+			got, err := mgr.CreateSingleBranch(context.Background(), tt.baseBranch)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("CreateSingleBranch() expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("CreateSingleBranch() unexpected error: %v", err)
+				return
+			}
+
+			if got != tt.wantBranch {
+				t.Errorf("CreateSingleBranch() = %q, want %q", got, tt.wantBranch)
+			}
+		})
+	}
+}
+
+func TestManager_CreateWorktree(t *testing.T) {
+	mock := &mockWorktreeManager{}
+	mgr := New(mock)
+
+	err := mgr.CreateWorktree(context.Background(), "/path/to/worktree", "feature-branch")
+	if err != nil {
+		t.Errorf("CreateWorktree() unexpected error: %v", err)
+	}
+
+	if mock.createWorktreeCall.path != "/path/to/worktree" {
+		t.Errorf("CreateWorktreeFromBranch called with path = %q, want %q",
+			mock.createWorktreeCall.path, "/path/to/worktree")
+	}
+
+	if mock.createWorktreeCall.branch != "feature-branch" {
+		t.Errorf("CreateWorktreeFromBranch called with branch = %q, want %q",
+			mock.createWorktreeCall.branch, "feature-branch")
+	}
+}
+
+func TestManager_CreateWorktree_Error(t *testing.T) {
+	mock := &mockWorktreeManager{createWorktreeErr: errors.New("worktree exists")}
+	mgr := New(mock)
+
+	err := mgr.CreateWorktree(context.Background(), "/path", "branch")
+	if err == nil {
+		t.Error("CreateWorktree() expected error, got nil")
+	}
+}
+
+func TestManager_CherryPickBranch(t *testing.T) {
+	mock := &mockWorktreeManager{}
+	mgr := New(mock)
+
+	err := mgr.CherryPickBranch(context.Background(), "/worktree", "source-branch")
+	if err != nil {
+		t.Errorf("CherryPickBranch() unexpected error: %v", err)
+	}
+
+	if mock.cherryPickCall.path != "/worktree" {
+		t.Errorf("CherryPickBranch called with path = %q, want %q",
+			mock.cherryPickCall.path, "/worktree")
+	}
+
+	if mock.cherryPickCall.sourceBranch != "source-branch" {
+		t.Errorf("CherryPickBranch called with sourceBranch = %q, want %q",
+			mock.cherryPickCall.sourceBranch, "source-branch")
+	}
+}
+
+func TestManager_GetChangedFiles(t *testing.T) {
+	mock := &mockWorktreeManager{changedFiles: []string{"file1.go", "file2.go"}}
+	mgr := New(mock)
+
+	got, err := mgr.GetChangedFiles(context.Background(), "/worktree")
+	if err != nil {
+		t.Errorf("GetChangedFiles() unexpected error: %v", err)
+	}
+
+	if len(got) != 2 || got[0] != "file1.go" || got[1] != "file2.go" {
+		t.Errorf("GetChangedFiles() = %v, want [file1.go file2.go]", got)
+	}
+}
+
+func TestManager_GetConflictingFiles(t *testing.T) {
+	mock := &mockWorktreeManager{conflictingFiles: []string{"conflict.go"}}
+	mgr := New(mock)
+
+	got, err := mgr.GetConflictingFiles(context.Background(), "/worktree")
+	if err != nil {
+		t.Errorf("GetConflictingFiles() unexpected error: %v", err)
+	}
+
+	if len(got) != 1 || got[0] != "conflict.go" {
+		t.Errorf("GetConflictingFiles() = %v, want [conflict.go]", got)
+	}
+}
+
+func TestManager_CountCommitsBetween(t *testing.T) {
+	mock := &mockWorktreeManager{commitCount: 5}
+	mgr := New(mock)
+
+	got, err := mgr.CountCommitsBetween(context.Background(), "/worktree", "main", "feature")
+	if err != nil {
+		t.Errorf("CountCommitsBetween() unexpected error: %v", err)
+	}
+
+	if got != 5 {
+		t.Errorf("CountCommitsBetween() = %d, want 5", got)
+	}
+}
+
+func TestManager_Push(t *testing.T) {
+	mock := &mockWorktreeManager{}
+	mgr := New(mock)
+
+	err := mgr.Push(context.Background(), "/worktree", false)
+	if err != nil {
+		t.Errorf("Push() unexpected error: %v", err)
+	}
+}
+
+func TestManager_RemoveWorktree(t *testing.T) {
+	mock := &mockWorktreeManager{}
+	mgr := New(mock)
+
+	err := mgr.RemoveWorktree(context.Background(), "/worktree")
+	if err != nil {
+		t.Errorf("RemoveWorktree() unexpected error: %v", err)
+	}
+}
+
+func TestManager_DeleteBranch(t *testing.T) {
+	mock := &mockWorktreeManager{}
+	mgr := New(mock)
+
+	err := mgr.DeleteBranch(context.Background(), "feature-branch")
+	if err != nil {
+		t.Errorf("DeleteBranch() unexpected error: %v", err)
+	}
+}
+
+func TestManager_CherryPickOperations(t *testing.T) {
+	t.Run("ContinueCherryPick", func(t *testing.T) {
+		mock := &mockWorktreeManager{}
+		mgr := New(mock)
+
+		err := mgr.ContinueCherryPick(context.Background(), "/worktree")
+		if err != nil {
+			t.Errorf("ContinueCherryPick() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("AbortCherryPick", func(t *testing.T) {
+		mock := &mockWorktreeManager{}
+		mgr := New(mock)
+
+		err := mgr.AbortCherryPick(context.Background(), "/worktree")
+		if err != nil {
+			t.Errorf("AbortCherryPick() unexpected error: %v", err)
+		}
+	})
+}
+
+func TestManager_NamingStrategy(t *testing.T) {
+	ns := NewNamingStrategy("test", "session")
+	mgr := New(&mockWorktreeManager{}, WithNamingStrategy(ns))
+
+	got := mgr.NamingStrategy()
+	if got != ns {
+		t.Errorf("NamingStrategy() returned different instance")
+	}
+}

--- a/internal/orchestrator/consolidation/branch/naming.go
+++ b/internal/orchestrator/consolidation/branch/naming.go
@@ -1,0 +1,90 @@
+package branch
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// NamingStrategy generates branch names for consolidation workflows.
+type NamingStrategy struct {
+	prefix    string
+	sessionID string
+}
+
+// NewNamingStrategy creates a new naming strategy.
+// If prefix is empty, "Iron-Ham" is used as the default.
+func NewNamingStrategy(prefix, sessionID string) *NamingStrategy {
+	if prefix == "" {
+		prefix = "Iron-Ham"
+	}
+	return &NamingStrategy{
+		prefix:    prefix,
+		sessionID: sessionID,
+	}
+}
+
+// GroupBranchName generates a branch name for a consolidation group.
+// Example: "Iron-Ham/ultraplan-abc12345-group-1"
+func (n *NamingStrategy) GroupBranchName(groupIdx int) string {
+	planID := n.truncateID(n.sessionID)
+	return fmt.Sprintf("%s/ultraplan-%s-group-%d", n.prefix, planID, groupIdx+1)
+}
+
+// SingleBranchName generates a branch name for single PR mode consolidation.
+// Example: "Iron-Ham/ultraplan-abc12345"
+func (n *NamingStrategy) SingleBranchName() string {
+	planID := n.truncateID(n.sessionID)
+	return fmt.Sprintf("%s/ultraplan-%s", n.prefix, planID)
+}
+
+// TaskBranchName generates a branch name for a task.
+// Example: "Iron-Ham/ultraplan-abc12345-task-1-setup"
+func (n *NamingStrategy) TaskBranchName(taskID string) string {
+	planID := n.truncateID(n.sessionID)
+	taskSlug := Slugify(taskID)
+	return fmt.Sprintf("%s/ultraplan-%s-%s", n.prefix, planID, taskSlug)
+}
+
+// truncateID truncates a session ID to 8 characters for use in branch names.
+func (n *NamingStrategy) truncateID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}
+
+// Prefix returns the branch prefix.
+func (n *NamingStrategy) Prefix() string {
+	return n.prefix
+}
+
+// SessionID returns the session ID.
+func (n *NamingStrategy) SessionID() string {
+	return n.sessionID
+}
+
+// Slugify converts text to a slug suitable for branch names or identifiers.
+// It lowercases the text, replaces spaces with dashes, removes non-alphanumeric
+// characters (except dashes), and limits the length.
+func Slugify(text string) string {
+	slug := strings.ToLower(text)
+	slug = strings.ReplaceAll(slug, " ", "-")
+
+	// Remove non-alphanumeric characters except dashes
+	var result strings.Builder
+	for _, r := range slug {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' {
+			result.WriteRune(r)
+		}
+	}
+
+	// Limit length
+	s := result.String()
+	if len(s) > 30 {
+		s = s[:30]
+	}
+	// Trim trailing dashes
+	s = strings.TrimRight(s, "-")
+	return s
+}

--- a/internal/orchestrator/consolidation/branch/naming_test.go
+++ b/internal/orchestrator/consolidation/branch/naming_test.go
@@ -1,0 +1,186 @@
+package branch
+
+import (
+	"testing"
+)
+
+func TestNamingStrategy_GroupBranchName(t *testing.T) {
+	tests := []struct {
+		name      string
+		prefix    string
+		sessionID string
+		groupIdx  int
+		want      string
+	}{
+		{
+			name:      "default prefix first group",
+			prefix:    "",
+			sessionID: "abcd1234",
+			groupIdx:  0,
+			want:      "Iron-Ham/ultraplan-abcd1234-group-1",
+		},
+		{
+			name:      "default prefix second group",
+			prefix:    "",
+			sessionID: "abcd1234",
+			groupIdx:  1,
+			want:      "Iron-Ham/ultraplan-abcd1234-group-2",
+		},
+		{
+			name:      "custom prefix",
+			prefix:    "feature",
+			sessionID: "efgh5678",
+			groupIdx:  0,
+			want:      "feature/ultraplan-efgh5678-group-1",
+		},
+		{
+			name:      "long session ID truncated",
+			prefix:    "Iron-Ham",
+			sessionID: "abcdefghijklmnop",
+			groupIdx:  0,
+			want:      "Iron-Ham/ultraplan-abcdefgh-group-1",
+		},
+		{
+			name:      "short session ID",
+			prefix:    "Iron-Ham",
+			sessionID: "abc",
+			groupIdx:  2,
+			want:      "Iron-Ham/ultraplan-abc-group-3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns := NewNamingStrategy(tt.prefix, tt.sessionID)
+			got := ns.GroupBranchName(tt.groupIdx)
+			if got != tt.want {
+				t.Errorf("GroupBranchName(%d) = %q, want %q", tt.groupIdx, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNamingStrategy_SingleBranchName(t *testing.T) {
+	tests := []struct {
+		name      string
+		prefix    string
+		sessionID string
+		want      string
+	}{
+		{
+			name:      "default prefix",
+			prefix:    "",
+			sessionID: "abcd1234",
+			want:      "Iron-Ham/ultraplan-abcd1234",
+		},
+		{
+			name:      "custom prefix",
+			prefix:    "my-project",
+			sessionID: "xyz98765",
+			want:      "my-project/ultraplan-xyz98765",
+		},
+		{
+			name:      "long session ID truncated",
+			prefix:    "Iron-Ham",
+			sessionID: "verylongsessionidthatexceeds",
+			want:      "Iron-Ham/ultraplan-verylong",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns := NewNamingStrategy(tt.prefix, tt.sessionID)
+			got := ns.SingleBranchName()
+			if got != tt.want {
+				t.Errorf("SingleBranchName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNamingStrategy_TaskBranchName(t *testing.T) {
+	tests := []struct {
+		name      string
+		prefix    string
+		sessionID string
+		taskID    string
+		want      string
+	}{
+		{
+			name:      "simple task ID",
+			prefix:    "Iron-Ham",
+			sessionID: "abcd1234",
+			taskID:    "task-1",
+			want:      "Iron-Ham/ultraplan-abcd1234-task-1",
+		},
+		{
+			name:      "task ID with spaces",
+			prefix:    "Iron-Ham",
+			sessionID: "abcd1234",
+			taskID:    "task setup",
+			want:      "Iron-Ham/ultraplan-abcd1234-task-setup",
+		},
+		{
+			name:      "task ID with special chars",
+			prefix:    "Iron-Ham",
+			sessionID: "abcd1234",
+			taskID:    "task-1/setup@test",
+			want:      "Iron-Ham/ultraplan-abcd1234-task-1setuptest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns := NewNamingStrategy(tt.prefix, tt.sessionID)
+			got := ns.TaskBranchName(tt.taskID)
+			if got != tt.want {
+				t.Errorf("TaskBranchName(%q) = %q, want %q", tt.taskID, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "hello world", want: "hello-world"},
+		{input: "Hello World", want: "hello-world"},
+		{input: "task-1-setup", want: "task-1-setup"},
+		{input: "special@chars#removed!", want: "specialcharsremoved"},
+		{input: "numbers123okay", want: "numbers123okay"},
+		{input: "this is a very long string that should be truncated to fit the limit", want: "this-is-a-very-long-string-tha"},
+		{input: "", want: ""},
+		{input: "trailing-dash---", want: "trailing-dash"},
+		{input: "MiXeD CaSe", want: "mixed-case"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := Slugify(tt.input)
+			if got != tt.want {
+				t.Errorf("Slugify(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNamingStrategy_Accessors(t *testing.T) {
+	ns := NewNamingStrategy("my-prefix", "session123")
+
+	if got := ns.Prefix(); got != "my-prefix" {
+		t.Errorf("Prefix() = %q, want %q", got, "my-prefix")
+	}
+
+	if got := ns.SessionID(); got != "session123" {
+		t.Errorf("SessionID() = %q, want %q", got, "session123")
+	}
+}
+
+func TestNewNamingStrategy_DefaultPrefix(t *testing.T) {
+	ns := NewNamingStrategy("", "abc")
+	if ns.Prefix() != "Iron-Ham" {
+		t.Errorf("NewNamingStrategy with empty prefix should default to Iron-Ham, got %q", ns.Prefix())
+	}
+}

--- a/internal/orchestrator/consolidation/conflict/detector.go
+++ b/internal/orchestrator/consolidation/conflict/detector.go
@@ -1,0 +1,84 @@
+// Package conflict provides merge conflict detection and handling for consolidation.
+// It wraps git operations to provide a clean interface for detecting and reporting
+// conflicts during branch consolidation.
+package conflict
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator/consolidation"
+	"github.com/Iron-Ham/claudio/internal/worktree"
+)
+
+// Info is an alias to consolidation.ConflictInfo for convenience.
+type Info = consolidation.ConflictInfo
+
+// Compile-time check that Detector implements consolidation.ConflictManager.
+var _ consolidation.ConflictManager = (*Detector)(nil)
+
+// BranchOperator defines the operations needed for conflict detection.
+type BranchOperator interface {
+	GetConflictingFiles(ctx context.Context, worktreePath string) ([]string, error)
+	CherryPickBranch(ctx context.Context, worktreePath, sourceBranch string) error
+	AbortCherryPick(ctx context.Context, worktreePath string) error
+	ContinueCherryPick(ctx context.Context, worktreePath string) error
+}
+
+// Detector detects merge conflicts during consolidation.
+type Detector struct {
+	branch BranchOperator
+}
+
+// NewDetector creates a new conflict Detector.
+func NewDetector(branch BranchOperator) *Detector {
+	return &Detector{branch: branch}
+}
+
+// CheckCherryPick attempts a cherry-pick and reports any conflicts.
+// If the cherry-pick succeeds, it returns nil.
+// If there are conflicts, it returns an Info describing the conflict.
+// The caller is responsible for handling or aborting the cherry-pick.
+func (d *Detector) CheckCherryPick(ctx context.Context, worktreePath, sourceBranch, taskID, taskTitle string) (*Info, error) {
+	err := d.branch.CherryPickBranch(ctx, worktreePath, sourceBranch)
+	if err == nil {
+		return nil, nil // No conflict
+	}
+
+	// Check if it's a cherry-pick conflict error
+	var cpErr *worktree.CherryPickConflictError
+	if !errors.As(err, &cpErr) {
+		// Not a conflict error, something else went wrong
+		return nil, fmt.Errorf("cherry-pick failed: %w", err)
+	}
+
+	// Get the conflicting files
+	files, filesErr := d.branch.GetConflictingFiles(ctx, worktreePath)
+	if filesErr != nil {
+		files = []string{} // Use empty slice if we can't get the files
+	}
+
+	return &Info{
+		TaskID:       taskID,
+		TaskTitle:    taskTitle,
+		Branch:       sourceBranch,
+		Files:        files,
+		WorktreePath: worktreePath,
+	}, nil
+}
+
+// AbortCherryPick aborts an in-progress cherry-pick operation.
+func (d *Detector) AbortCherryPick(ctx context.Context, worktreePath string) error {
+	return d.branch.AbortCherryPick(ctx, worktreePath)
+}
+
+// ContinueCherryPick continues a cherry-pick after conflicts have been resolved.
+func (d *Detector) ContinueCherryPick(ctx context.Context, worktreePath string) error {
+	return d.branch.ContinueCherryPick(ctx, worktreePath)
+}
+
+// GetConflictingFiles returns the files with conflicts in the given worktree.
+func (d *Detector) GetConflictingFiles(ctx context.Context, worktreePath string) ([]string, error) {
+	return d.branch.GetConflictingFiles(ctx, worktreePath)
+}

--- a/internal/orchestrator/consolidation/conflict/detector_test.go
+++ b/internal/orchestrator/consolidation/conflict/detector_test.go
@@ -1,0 +1,215 @@
+package conflict
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/worktree"
+)
+
+// mockBranchOperator is a mock implementation of BranchOperator for testing.
+type mockBranchOperator struct {
+	conflictingFiles    []string
+	conflictingFilesErr error
+	cherryPickErr       error
+	abortErr            error
+	continueErr         error
+	cherryPickCall      struct {
+		worktreePath string
+		sourceBranch string
+	}
+	abortCall    string
+	continueCall string
+}
+
+func (m *mockBranchOperator) GetConflictingFiles(_ context.Context, worktreePath string) ([]string, error) {
+	return m.conflictingFiles, m.conflictingFilesErr
+}
+
+func (m *mockBranchOperator) CherryPickBranch(_ context.Context, worktreePath, sourceBranch string) error {
+	m.cherryPickCall.worktreePath = worktreePath
+	m.cherryPickCall.sourceBranch = sourceBranch
+	return m.cherryPickErr
+}
+
+func (m *mockBranchOperator) AbortCherryPick(_ context.Context, worktreePath string) error {
+	m.abortCall = worktreePath
+	return m.abortErr
+}
+
+func (m *mockBranchOperator) ContinueCherryPick(_ context.Context, worktreePath string) error {
+	m.continueCall = worktreePath
+	return m.continueErr
+}
+
+func TestDetector_CheckCherryPick_Success(t *testing.T) {
+	mock := &mockBranchOperator{}
+	detector := NewDetector(mock)
+
+	info, err := detector.CheckCherryPick(context.Background(), "/worktree", "feature", "task-1", "Task One")
+	if err != nil {
+		t.Errorf("CheckCherryPick() unexpected error: %v", err)
+	}
+	if info != nil {
+		t.Errorf("CheckCherryPick() expected nil info for successful cherry-pick, got %+v", info)
+	}
+
+	if mock.cherryPickCall.worktreePath != "/worktree" {
+		t.Errorf("CherryPickBranch called with worktreePath = %q, want %q",
+			mock.cherryPickCall.worktreePath, "/worktree")
+	}
+	if mock.cherryPickCall.sourceBranch != "feature" {
+		t.Errorf("CherryPickBranch called with sourceBranch = %q, want %q",
+			mock.cherryPickCall.sourceBranch, "feature")
+	}
+}
+
+func TestDetector_CheckCherryPick_Conflict(t *testing.T) {
+	conflictErr := &worktree.CherryPickConflictError{
+		Commit:       "abc123",
+		SourceBranch: "feature",
+		Output:       "CONFLICT (content): Merge conflict in file.go",
+	}
+	mock := &mockBranchOperator{
+		cherryPickErr:    conflictErr,
+		conflictingFiles: []string{"file.go", "other.go"},
+	}
+	detector := NewDetector(mock)
+
+	info, err := detector.CheckCherryPick(context.Background(), "/worktree", "feature", "task-1", "Task One")
+	if err != nil {
+		t.Errorf("CheckCherryPick() unexpected error: %v", err)
+	}
+	if info == nil {
+		t.Fatal("CheckCherryPick() expected conflict info, got nil")
+	}
+
+	if info.TaskID != "task-1" {
+		t.Errorf("info.TaskID = %q, want %q", info.TaskID, "task-1")
+	}
+	if info.TaskTitle != "Task One" {
+		t.Errorf("info.TaskTitle = %q, want %q", info.TaskTitle, "Task One")
+	}
+	if info.Branch != "feature" {
+		t.Errorf("info.Branch = %q, want %q", info.Branch, "feature")
+	}
+	if len(info.Files) != 2 || info.Files[0] != "file.go" || info.Files[1] != "other.go" {
+		t.Errorf("info.Files = %v, want [file.go other.go]", info.Files)
+	}
+	if info.WorktreePath != "/worktree" {
+		t.Errorf("info.WorktreePath = %q, want %q", info.WorktreePath, "/worktree")
+	}
+}
+
+func TestDetector_CheckCherryPick_ConflictFilesError(t *testing.T) {
+	conflictErr := &worktree.CherryPickConflictError{
+		Commit:       "abc123",
+		SourceBranch: "feature",
+	}
+	mock := &mockBranchOperator{
+		cherryPickErr:       conflictErr,
+		conflictingFilesErr: errors.New("failed to get files"),
+	}
+	detector := NewDetector(mock)
+
+	info, err := detector.CheckCherryPick(context.Background(), "/worktree", "feature", "task-1", "Task One")
+	if err != nil {
+		t.Errorf("CheckCherryPick() unexpected error: %v", err)
+	}
+	if info == nil {
+		t.Fatal("CheckCherryPick() expected conflict info, got nil")
+	}
+
+	// Files should be empty slice when we can't get them
+	if info.Files == nil || len(info.Files) != 0 {
+		t.Errorf("info.Files = %v, want empty slice", info.Files)
+	}
+}
+
+func TestDetector_CheckCherryPick_OtherError(t *testing.T) {
+	mock := &mockBranchOperator{
+		cherryPickErr: errors.New("some other error"),
+	}
+	detector := NewDetector(mock)
+
+	info, err := detector.CheckCherryPick(context.Background(), "/worktree", "feature", "task-1", "Task One")
+	if err == nil {
+		t.Error("CheckCherryPick() expected error, got nil")
+	}
+	if info != nil {
+		t.Errorf("CheckCherryPick() expected nil info on non-conflict error, got %+v", info)
+	}
+}
+
+func TestDetector_AbortCherryPick(t *testing.T) {
+	mock := &mockBranchOperator{}
+	detector := NewDetector(mock)
+
+	err := detector.AbortCherryPick(context.Background(), "/worktree")
+	if err != nil {
+		t.Errorf("AbortCherryPick() unexpected error: %v", err)
+	}
+
+	if mock.abortCall != "/worktree" {
+		t.Errorf("AbortCherryPick called with path = %q, want %q", mock.abortCall, "/worktree")
+	}
+}
+
+func TestDetector_AbortCherryPick_Error(t *testing.T) {
+	mock := &mockBranchOperator{abortErr: errors.New("abort failed")}
+	detector := NewDetector(mock)
+
+	err := detector.AbortCherryPick(context.Background(), "/worktree")
+	if err == nil {
+		t.Error("AbortCherryPick() expected error, got nil")
+	}
+}
+
+func TestDetector_ContinueCherryPick(t *testing.T) {
+	mock := &mockBranchOperator{}
+	detector := NewDetector(mock)
+
+	err := detector.ContinueCherryPick(context.Background(), "/worktree")
+	if err != nil {
+		t.Errorf("ContinueCherryPick() unexpected error: %v", err)
+	}
+
+	if mock.continueCall != "/worktree" {
+		t.Errorf("ContinueCherryPick called with path = %q, want %q", mock.continueCall, "/worktree")
+	}
+}
+
+func TestDetector_ContinueCherryPick_Error(t *testing.T) {
+	mock := &mockBranchOperator{continueErr: errors.New("continue failed")}
+	detector := NewDetector(mock)
+
+	err := detector.ContinueCherryPick(context.Background(), "/worktree")
+	if err == nil {
+		t.Error("ContinueCherryPick() expected error, got nil")
+	}
+}
+
+func TestDetector_GetConflictingFiles(t *testing.T) {
+	mock := &mockBranchOperator{conflictingFiles: []string{"a.go", "b.go"}}
+	detector := NewDetector(mock)
+
+	files, err := detector.GetConflictingFiles(context.Background(), "/worktree")
+	if err != nil {
+		t.Errorf("GetConflictingFiles() unexpected error: %v", err)
+	}
+
+	if len(files) != 2 || files[0] != "a.go" || files[1] != "b.go" {
+		t.Errorf("GetConflictingFiles() = %v, want [a.go b.go]", files)
+	}
+}
+
+func TestDetector_GetConflictingFiles_Error(t *testing.T) {
+	mock := &mockBranchOperator{conflictingFilesErr: errors.New("failed")}
+	detector := NewDetector(mock)
+
+	_, err := detector.GetConflictingFiles(context.Background(), "/worktree")
+	if err == nil {
+		t.Error("GetConflictingFiles() expected error, got nil")
+	}
+}

--- a/internal/orchestrator/consolidation/prbuilder/builder.go
+++ b/internal/orchestrator/consolidation/prbuilder/builder.go
@@ -1,0 +1,63 @@
+// Package prbuilder generates pull request content from completed tasks.
+// It handles title generation, body formatting, and metadata aggregation
+// without performing any git operations or I/O.
+package prbuilder
+
+import (
+	"github.com/Iron-Ham/claudio/internal/orchestrator/consolidation"
+)
+
+// Compile-time check that Builder implements consolidation.PRBuilder.
+var _ consolidation.PRBuilder = (*Builder)(nil)
+
+// Builder generates PR content from completed tasks.
+type Builder struct {
+	objectiveLimit int
+}
+
+// Option configures a Builder.
+type Option func(*Builder)
+
+// WithObjectiveLimit sets the maximum length for objective text in titles.
+func WithObjectiveLimit(limit int) Option {
+	return func(b *Builder) {
+		b.objectiveLimit = limit
+	}
+}
+
+// New creates a new Builder with the given options.
+func New(opts ...Option) *Builder {
+	b := &Builder{
+		objectiveLimit: 50,
+	}
+	for _, opt := range opts {
+		opt(b)
+	}
+	return b
+}
+
+// Build generates complete PR content from the given tasks and options.
+func (b *Builder) Build(tasks []consolidation.CompletedTask, opts consolidation.PRBuildOptions) (*consolidation.PRContent, error) {
+	return &consolidation.PRContent{
+		Title:      b.BuildTitle(tasks, opts),
+		Body:       b.BuildBody(tasks, opts),
+		Labels:     b.BuildLabels(tasks, opts),
+		BaseBranch: opts.BaseBranch,
+		HeadBranch: opts.HeadBranch,
+	}, nil
+}
+
+// BuildTitle generates a PR title from tasks and options.
+func (b *Builder) BuildTitle(tasks []consolidation.CompletedTask, opts consolidation.PRBuildOptions) string {
+	return buildTitle(opts.Objective, opts.Mode, opts.GroupIndex, b.objectiveLimit)
+}
+
+// BuildBody generates a PR body from tasks and options.
+func (b *Builder) BuildBody(tasks []consolidation.CompletedTask, opts consolidation.PRBuildOptions) string {
+	return buildBody(tasks, opts)
+}
+
+// BuildLabels determines appropriate labels for the PR.
+func (b *Builder) BuildLabels(tasks []consolidation.CompletedTask, opts consolidation.PRBuildOptions) []string {
+	return buildLabels(tasks)
+}

--- a/internal/orchestrator/consolidation/prbuilder/builder_test.go
+++ b/internal/orchestrator/consolidation/prbuilder/builder_test.go
@@ -1,0 +1,267 @@
+package prbuilder
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator/consolidation"
+	"github.com/Iron-Ham/claudio/internal/orchestrator/types"
+)
+
+func TestBuilder_Build(t *testing.T) {
+	tests := []struct {
+		name          string
+		tasks         []consolidation.CompletedTask
+		opts          consolidation.PRBuildOptions
+		wantTitle     string
+		wantBodyParts []string
+	}{
+		{
+			name: "single task in single mode",
+			tasks: []consolidation.CompletedTask{
+				{
+					ID:    "task-1",
+					Title: "Add feature X",
+				},
+			},
+			opts: consolidation.PRBuildOptions{
+				Mode:        consolidation.ModeSingle,
+				Objective:   "Implement authentication",
+				TotalGroups: 1,
+			},
+			wantTitle: "ultraplan: Implement authentication",
+			wantBodyParts: []string{
+				"## Ultraplan Consolidation",
+				"**Objective**: Implement authentication",
+				"## Tasks Included",
+				"- **task-1**: Add feature X",
+			},
+		},
+		{
+			name: "multiple tasks in stacked mode",
+			tasks: []consolidation.CompletedTask{
+				{
+					ID:    "task-1",
+					Title: "Add feature X",
+				},
+				{
+					ID:    "task-2",
+					Title: "Fix bug Y",
+				},
+			},
+			opts: consolidation.PRBuildOptions{
+				Mode:        consolidation.ModeStacked,
+				GroupIndex:  0,
+				TotalGroups: 3,
+				Objective:   "Major refactoring project",
+			},
+			wantTitle: "ultraplan: group 1 - Major refactoring project",
+			wantBodyParts: []string{
+				"## Ultraplan Consolidation",
+				"**Objective**: Major refactoring project",
+				"**Group**: 1 of 3",
+				"must be merged before Group 2",
+				"## Tasks Included",
+				"- **task-1**: Add feature X",
+				"- **task-2**: Fix bug Y",
+			},
+		},
+		{
+			name: "middle group in stacked mode",
+			tasks: []consolidation.CompletedTask{
+				{
+					ID:    "task-3",
+					Title: "Implement middleware",
+				},
+			},
+			opts: consolidation.PRBuildOptions{
+				Mode:        consolidation.ModeStacked,
+				GroupIndex:  1,
+				TotalGroups: 3,
+				Objective:   "API redesign",
+			},
+			wantTitle: "ultraplan: group 2 - API redesign",
+			wantBodyParts: []string{
+				"**Group**: 2 of 3",
+				"**Base**: Group 1",
+				"must be merged before Group 3",
+			},
+		},
+		{
+			name: "last group in stacked mode",
+			tasks: []consolidation.CompletedTask{
+				{
+					ID:    "task-5",
+					Title: "Final cleanup",
+				},
+			},
+			opts: consolidation.PRBuildOptions{
+				Mode:        consolidation.ModeStacked,
+				GroupIndex:  2,
+				TotalGroups: 3,
+				Objective:   "Cleanup",
+			},
+			wantTitle: "ultraplan: group 3 - Cleanup",
+			wantBodyParts: []string{
+				"**Group**: 3 of 3",
+				"**Base**: Group 2",
+			},
+		},
+		{
+			name: "tasks with completion summaries",
+			tasks: []consolidation.CompletedTask{
+				{
+					ID:    "task-1",
+					Title: "Add auth",
+					Completion: &types.TaskCompletionFile{
+						Summary: "Implemented JWT authentication with refresh tokens",
+					},
+				},
+			},
+			opts: consolidation.PRBuildOptions{
+				Mode:        consolidation.ModeSingle,
+				Objective:   "Auth system",
+				TotalGroups: 1,
+			},
+			wantTitle: "ultraplan: Auth system",
+			wantBodyParts: []string{
+				"- **task-1**: Add auth",
+				"Implemented JWT authentication with refresh tokens",
+			},
+		},
+		{
+			name: "with files changed",
+			tasks: []consolidation.CompletedTask{
+				{ID: "task-1", Title: "Update config"},
+			},
+			opts: consolidation.PRBuildOptions{
+				Mode:         consolidation.ModeSingle,
+				Objective:    "Config update",
+				TotalGroups:  1,
+				FilesChanged: []string{"config.go", "config_test.go"},
+			},
+			wantTitle: "ultraplan: Config update",
+			wantBodyParts: []string{
+				"## Files Changed",
+				"`config.go`",
+				"`config_test.go`",
+			},
+		},
+		{
+			name: "with synthesis notes",
+			tasks: []consolidation.CompletedTask{
+				{ID: "task-1", Title: "Add feature"},
+			},
+			opts: consolidation.PRBuildOptions{
+				Mode:            consolidation.ModeSingle,
+				Objective:       "Feature",
+				TotalGroups:     1,
+				SynthesisNotes:  "All tasks integrated cleanly",
+				Recommendations: []string{"Consider adding more tests", "Document the API"},
+			},
+			wantTitle: "ultraplan: Feature",
+			wantBodyParts: []string{
+				"## Synthesis Review Notes",
+				"**Integration Notes**: All tasks integrated cleanly",
+				"**Recommendations**:",
+				"- Consider adding more tests",
+				"- Document the API",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := New()
+			content, err := b.Build(tt.tasks, tt.opts)
+			if err != nil {
+				t.Fatalf("Build() error = %v", err)
+			}
+
+			if content.Title != tt.wantTitle {
+				t.Errorf("Build() title = %q, want %q", content.Title, tt.wantTitle)
+			}
+
+			for _, part := range tt.wantBodyParts {
+				if !strings.Contains(content.Body, part) {
+					t.Errorf("Build() body missing part %q\nGot body:\n%s", part, content.Body)
+				}
+			}
+		})
+	}
+}
+
+func TestBuilder_BuildTitle(t *testing.T) {
+	tests := []struct {
+		name       string
+		objective  string
+		mode       consolidation.Mode
+		groupIndex int
+		limit      int
+		want       string
+	}{
+		{
+			name:       "single mode short objective",
+			objective:  "Add auth",
+			mode:       consolidation.ModeSingle,
+			groupIndex: 0,
+			limit:      50,
+			want:       "ultraplan: Add auth",
+		},
+		{
+			name:       "single mode long objective truncated",
+			objective:  "This is a very long objective that exceeds the limit and needs to be truncated",
+			mode:       consolidation.ModeSingle,
+			groupIndex: 0,
+			limit:      50,
+			want:       "ultraplan: This is a very long objective that exceeds the ...",
+		},
+		{
+			name:       "stacked mode first group",
+			objective:  "Feature X",
+			mode:       consolidation.ModeStacked,
+			groupIndex: 0,
+			limit:      50,
+			want:       "ultraplan: group 1 - Feature X",
+		},
+		{
+			name:       "stacked mode fifth group",
+			objective:  "Feature Y",
+			mode:       consolidation.ModeStacked,
+			groupIndex: 4,
+			limit:      50,
+			want:       "ultraplan: group 5 - Feature Y",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := New(WithObjectiveLimit(tt.limit))
+			opts := consolidation.PRBuildOptions{
+				Mode:       tt.mode,
+				GroupIndex: tt.groupIndex,
+				Objective:  tt.objective,
+			}
+			got := b.BuildTitle(nil, opts)
+			if got != tt.want {
+				t.Errorf("BuildTitle() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuilder_WithOptions(t *testing.T) {
+	t.Run("default limits", func(t *testing.T) {
+		b := New()
+		if b.objectiveLimit != 50 {
+			t.Errorf("default objectiveLimit = %d, want 50", b.objectiveLimit)
+		}
+	})
+
+	t.Run("custom objective limit", func(t *testing.T) {
+		b := New(WithObjectiveLimit(100))
+		if b.objectiveLimit != 100 {
+			t.Errorf("objectiveLimit = %d, want 100", b.objectiveLimit)
+		}
+	})
+}

--- a/internal/orchestrator/consolidation/prbuilder/content.go
+++ b/internal/orchestrator/consolidation/prbuilder/content.go
@@ -1,0 +1,145 @@
+package prbuilder
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator/consolidation"
+)
+
+// buildBody generates the PR body content from tasks and options.
+func buildBody(tasks []consolidation.CompletedTask, opts consolidation.PRBuildOptions) string {
+	var body strings.Builder
+
+	// Header
+	body.WriteString("## Ultraplan Consolidation\n\n")
+	body.WriteString(fmt.Sprintf("**Objective**: %s\n\n", opts.Objective))
+
+	// Mode-specific information
+	if opts.Mode == consolidation.ModeStacked {
+		body.WriteString(fmt.Sprintf("**Group**: %d of %d\n\n", opts.GroupIndex+1, opts.TotalGroups))
+
+		if opts.GroupIndex > 0 {
+			body.WriteString(fmt.Sprintf("**Base**: Group %d\n\n", opts.GroupIndex))
+		}
+		if opts.GroupIndex < opts.TotalGroups-1 {
+			body.WriteString(fmt.Sprintf("> **Note**: This PR must be merged before Group %d.\n\n", opts.GroupIndex+2))
+		}
+	}
+
+	// Tasks included section
+	body.WriteString("## Tasks Included\n\n")
+	for _, task := range tasks {
+		taskLine := fmt.Sprintf("- **%s**: %s", task.ID, task.Title)
+		// Add summary from completion file if available
+		if task.Completion != nil && task.Completion.Summary != "" {
+			taskLine += fmt.Sprintf("\n  - %s", task.Completion.Summary)
+		}
+		body.WriteString(taskLine + "\n")
+	}
+
+	// Files changed section
+	if len(opts.FilesChanged) > 0 {
+		body.WriteString("\n## Files Changed\n\n")
+		for _, f := range opts.FilesChanged {
+			body.WriteString(fmt.Sprintf("- `%s`\n", f))
+		}
+	}
+
+	// Aggregated context from task completion files
+	aggregatedContent := buildAggregatedContext(tasks)
+	if aggregatedContent != "" {
+		body.WriteString(aggregatedContent)
+	}
+
+	// Synthesis review notes
+	if opts.SynthesisNotes != "" || len(opts.Recommendations) > 0 {
+		body.WriteString("\n## Synthesis Review Notes\n\n")
+		if opts.SynthesisNotes != "" {
+			body.WriteString(fmt.Sprintf("**Integration Notes**: %s\n\n", opts.SynthesisNotes))
+		}
+		if len(opts.Recommendations) > 0 {
+			body.WriteString("**Recommendations**:\n")
+			for _, rec := range opts.Recommendations {
+				body.WriteString(fmt.Sprintf("- %s\n", rec))
+			}
+		}
+	}
+
+	return body.String()
+}
+
+// buildAggregatedContext aggregates context from all task completion files.
+func buildAggregatedContext(tasks []consolidation.CompletedTask) string {
+	var notes []string
+	var issues []string
+	var suggestions []string
+	var dependencies []string
+	seenDeps := make(map[string]bool)
+
+	for _, task := range tasks {
+		if task.Completion == nil {
+			continue
+		}
+
+		// Collect notes
+		if notesStr := task.Completion.Notes.String(); notesStr != "" {
+			notes = append(notes, fmt.Sprintf("**%s**: %s", task.ID, notesStr))
+		}
+
+		// Collect issues (prefix with task ID for context)
+		for _, issue := range task.Completion.Issues {
+			if issue != "" {
+				issues = append(issues, fmt.Sprintf("[%s] %s", task.ID, issue))
+			}
+		}
+
+		// Collect suggestions
+		for _, suggestion := range task.Completion.Suggestions {
+			if suggestion != "" {
+				suggestions = append(suggestions, fmt.Sprintf("[%s] %s", task.ID, suggestion))
+			}
+		}
+
+		// Collect dependencies (deduplicated)
+		for _, dep := range task.Completion.Dependencies {
+			if dep != "" && !seenDeps[dep] {
+				seenDeps[dep] = true
+				dependencies = append(dependencies, dep)
+			}
+		}
+	}
+
+	// Build output
+	var sb strings.Builder
+
+	if len(notes) > 0 {
+		sb.WriteString("\n## Implementation Notes\n\n")
+		for _, note := range notes {
+			sb.WriteString(fmt.Sprintf("- %s\n", note))
+		}
+	}
+
+	if len(issues) > 0 {
+		sb.WriteString("\n## Issues/Concerns Flagged\n\n")
+		for _, issue := range issues {
+			sb.WriteString(fmt.Sprintf("- %s\n", issue))
+		}
+	}
+
+	if len(suggestions) > 0 {
+		sb.WriteString("\n## Integration Suggestions\n\n")
+		for _, suggestion := range suggestions {
+			sb.WriteString(fmt.Sprintf("- %s\n", suggestion))
+		}
+	}
+
+	if len(dependencies) > 0 {
+		sb.WriteString("\n## New Dependencies\n\n")
+		for _, dep := range dependencies {
+			sb.WriteString(fmt.Sprintf("- `%s`\n", dep))
+		}
+	}
+
+	return sb.String()
+}

--- a/internal/orchestrator/consolidation/prbuilder/content_test.go
+++ b/internal/orchestrator/consolidation/prbuilder/content_test.go
@@ -1,0 +1,252 @@
+package prbuilder
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator/consolidation"
+	"github.com/Iron-Ham/claudio/internal/orchestrator/types"
+)
+
+func TestBuildBody(t *testing.T) {
+	tests := []struct {
+		name          string
+		tasks         []consolidation.CompletedTask
+		opts          consolidation.PRBuildOptions
+		wantParts     []string
+		dontWantParts []string
+	}{
+		{
+			name:  "basic body structure",
+			tasks: []consolidation.CompletedTask{},
+			opts: consolidation.PRBuildOptions{
+				Mode:        consolidation.ModeSingle,
+				Objective:   "Test objective",
+				TotalGroups: 1,
+			},
+			wantParts: []string{
+				"## Ultraplan Consolidation",
+				"**Objective**: Test objective",
+				"## Tasks Included",
+			},
+		},
+		{
+			name: "stacked mode with base branch reference",
+			tasks: []consolidation.CompletedTask{
+				{ID: "task-1", Title: "Task one"},
+			},
+			opts: consolidation.PRBuildOptions{
+				Mode:        consolidation.ModeStacked,
+				GroupIndex:  2,
+				TotalGroups: 4,
+				Objective:   "Multi-group project",
+			},
+			wantParts: []string{
+				"**Group**: 3 of 4",
+				"**Base**: Group 2",
+				"must be merged before Group 4",
+			},
+		},
+		{
+			name: "first group no base reference",
+			tasks: []consolidation.CompletedTask{
+				{ID: "task-1", Title: "Task one"},
+			},
+			opts: consolidation.PRBuildOptions{
+				Mode:        consolidation.ModeStacked,
+				GroupIndex:  0,
+				TotalGroups: 3,
+				Objective:   "Test",
+			},
+			wantParts: []string{
+				"**Group**: 1 of 3",
+				"must be merged before Group 2",
+			},
+			dontWantParts: []string{
+				"**Base**:",
+			},
+		},
+		{
+			name: "last group no merge note",
+			tasks: []consolidation.CompletedTask{
+				{ID: "task-1", Title: "Task one"},
+			},
+			opts: consolidation.PRBuildOptions{
+				Mode:        consolidation.ModeStacked,
+				GroupIndex:  2,
+				TotalGroups: 3,
+				Objective:   "Test",
+			},
+			wantParts: []string{
+				"**Group**: 3 of 3",
+				"**Base**: Group 2",
+			},
+			dontWantParts: []string{
+				"must be merged before",
+			},
+		},
+		{
+			name: "tasks with completion data",
+			tasks: []consolidation.CompletedTask{
+				{
+					ID:    "task-1",
+					Title: "Add auth",
+					Completion: &types.TaskCompletionFile{
+						Summary: "Added JWT auth with refresh",
+						Notes:   "Uses RS256 algorithm",
+						Issues:  []string{"Rate limiting not implemented"},
+						Suggestions: []string{
+							"Consider adding OAuth support",
+							"Add session management",
+						},
+						Dependencies: []string{"go-jwt/v5", "crypto/rand"},
+					},
+				},
+				{
+					ID:    "task-2",
+					Title: "Add tests",
+					Completion: &types.TaskCompletionFile{
+						Summary:      "Added test coverage",
+						Dependencies: []string{"testify", "go-jwt/v5"}, // go-jwt/v5 should be deduplicated
+					},
+				},
+			},
+			opts: consolidation.PRBuildOptions{
+				Mode:        consolidation.ModeSingle,
+				Objective:   "Auth feature",
+				TotalGroups: 1,
+			},
+			wantParts: []string{
+				"Added JWT auth with refresh",
+				"## Implementation Notes",
+				"Uses RS256 algorithm",
+				"## Issues/Concerns Flagged",
+				"[task-1] Rate limiting not implemented",
+				"## Integration Suggestions",
+				"[task-1] Consider adding OAuth support",
+				"## New Dependencies",
+				"`go-jwt/v5`",
+				"`crypto/rand`",
+				"`testify`",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildBody(tt.tasks, tt.opts)
+
+			for _, part := range tt.wantParts {
+				if !strings.Contains(got, part) {
+					t.Errorf("buildBody() missing expected part %q\nGot:\n%s", part, got)
+				}
+			}
+
+			for _, part := range tt.dontWantParts {
+				if strings.Contains(got, part) {
+					t.Errorf("buildBody() unexpectedly contains %q\nGot:\n%s", part, got)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildAggregatedContext(t *testing.T) {
+	tests := []struct {
+		name      string
+		tasks     []consolidation.CompletedTask
+		wantParts []string
+		wantEmpty bool
+	}{
+		{
+			name:      "empty tasks",
+			tasks:     []consolidation.CompletedTask{},
+			wantEmpty: true,
+		},
+		{
+			name: "tasks without completion data",
+			tasks: []consolidation.CompletedTask{
+				{ID: "task-1", Title: "Task 1"},
+				{ID: "task-2", Title: "Task 2"},
+			},
+			wantEmpty: true,
+		},
+		{
+			name: "tasks with empty completion data",
+			tasks: []consolidation.CompletedTask{
+				{
+					ID:         "task-1",
+					Completion: &types.TaskCompletionFile{},
+				},
+			},
+			wantEmpty: true,
+		},
+		{
+			name: "deduplicates dependencies",
+			tasks: []consolidation.CompletedTask{
+				{
+					ID: "task-1",
+					Completion: &types.TaskCompletionFile{
+						Dependencies: []string{"pkg-a", "pkg-b"},
+					},
+				},
+				{
+					ID: "task-2",
+					Completion: &types.TaskCompletionFile{
+						Dependencies: []string{"pkg-b", "pkg-c"}, // pkg-b should be deduplicated
+					},
+				},
+			},
+			wantParts: []string{
+				"`pkg-a`",
+				"`pkg-b`",
+				"`pkg-c`",
+			},
+		},
+		{
+			name: "filters empty strings",
+			tasks: []consolidation.CompletedTask{
+				{
+					ID: "task-1",
+					Completion: &types.TaskCompletionFile{
+						Issues:       []string{"real issue", ""},
+						Suggestions:  []string{"", "real suggestion"},
+						Dependencies: []string{"", "real-dep", ""},
+					},
+				},
+			},
+			wantParts: []string{
+				"real issue",
+				"real suggestion",
+				"`real-dep`",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildAggregatedContext(tt.tasks)
+
+			if tt.wantEmpty {
+				if got != "" {
+					t.Errorf("buildAggregatedContext() = %q, want empty string", got)
+				}
+				return
+			}
+
+			for _, part := range tt.wantParts {
+				if !strings.Contains(got, part) {
+					t.Errorf("buildAggregatedContext() missing %q\nGot:\n%s", part, got)
+				}
+			}
+
+			// Check that pkg-b only appears once (deduplication)
+			if tt.name == "deduplicates dependencies" {
+				count := strings.Count(got, "`pkg-b`")
+				if count != 1 {
+					t.Errorf("buildAggregatedContext() has pkg-b %d times, want 1", count)
+				}
+			}
+		})
+	}
+}

--- a/internal/orchestrator/consolidation/prbuilder/metadata.go
+++ b/internal/orchestrator/consolidation/prbuilder/metadata.go
@@ -1,0 +1,42 @@
+package prbuilder
+
+import (
+	"fmt"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator/consolidation"
+)
+
+// buildTitle generates a PR title based on mode and objective.
+func buildTitle(objective string, mode consolidation.Mode, groupIndex int, objectiveLimit int) string {
+	truncatedObjective := truncateString(objective, objectiveLimit)
+
+	if mode == consolidation.ModeSingle {
+		return fmt.Sprintf("ultraplan: %s", truncatedObjective)
+	}
+
+	// Stacked mode: include group number
+	// Use a shorter objective limit for stacked mode to accommodate group info
+	stackedLimit := max(objectiveLimit-10, 20) // Leave room for "group N - "
+	truncatedObjective = truncateString(objective, stackedLimit)
+	return fmt.Sprintf("ultraplan: group %d - %s", groupIndex+1, truncatedObjective)
+}
+
+// buildLabels determines appropriate labels for the PR based on task content.
+// The tasks parameter is reserved for future smart labeling based on task analysis.
+func buildLabels(_ []consolidation.CompletedTask) []string {
+	// Currently returns empty - labels are typically configured externally
+	// via Config.PRLabels. This function exists for future smart labeling
+	// based on task content analysis.
+	return nil
+}
+
+// truncateString truncates a string to the given length, adding "..." if truncated.
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/internal/orchestrator/consolidation/prbuilder/metadata_test.go
+++ b/internal/orchestrator/consolidation/prbuilder/metadata_test.go
@@ -1,0 +1,161 @@
+package prbuilder
+
+import (
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator/consolidation"
+)
+
+func TestBuildTitle(t *testing.T) {
+	tests := []struct {
+		name       string
+		objective  string
+		mode       consolidation.Mode
+		groupIndex int
+		limit      int
+		want       string
+	}{
+		{
+			name:       "single mode",
+			objective:  "Add authentication",
+			mode:       consolidation.ModeSingle,
+			groupIndex: 0,
+			limit:      50,
+			want:       "ultraplan: Add authentication",
+		},
+		{
+			name:       "single mode truncates long objective",
+			objective:  "This is a very long objective that should be truncated to fit",
+			mode:       consolidation.ModeSingle,
+			groupIndex: 0,
+			limit:      50,
+			want:       "ultraplan: This is a very long objective that should be tr...",
+		},
+		{
+			name:       "stacked mode first group",
+			objective:  "Feature X",
+			mode:       consolidation.ModeStacked,
+			groupIndex: 0,
+			limit:      50,
+			want:       "ultraplan: group 1 - Feature X",
+		},
+		{
+			name:       "stacked mode second group",
+			objective:  "Feature Y",
+			mode:       consolidation.ModeStacked,
+			groupIndex: 1,
+			limit:      50,
+			want:       "ultraplan: group 2 - Feature Y",
+		},
+		{
+			name:       "stacked mode tenth group",
+			objective:  "Feature Z",
+			mode:       consolidation.ModeStacked,
+			groupIndex: 9,
+			limit:      50,
+			want:       "ultraplan: group 10 - Feature Z",
+		},
+		{
+			name:       "stacked mode truncates with room for group",
+			objective:  "This is a very long objective for stacked mode",
+			mode:       consolidation.ModeStacked,
+			groupIndex: 0,
+			limit:      50,
+			want:       "ultraplan: group 1 - This is a very long objective for sta...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildTitle(tt.objective, tt.mode, tt.groupIndex, tt.limit)
+			if got != tt.want {
+				t.Errorf("buildTitle() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildLabels(t *testing.T) {
+	tests := []struct {
+		name  string
+		tasks []consolidation.CompletedTask
+		want  []string
+	}{
+		{
+			name:  "empty tasks returns nil",
+			tasks: []consolidation.CompletedTask{},
+			want:  nil,
+		},
+		{
+			name: "tasks return nil (future feature)",
+			tasks: []consolidation.CompletedTask{
+				{ID: "task-1", Title: "Task 1"},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildLabels(tt.tasks)
+			if len(got) != len(tt.want) {
+				t.Errorf("buildLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTruncateString(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		maxLen int
+		want   string
+	}{
+		{
+			name:   "short string unchanged",
+			input:  "hello",
+			maxLen: 10,
+			want:   "hello",
+		},
+		{
+			name:   "exact length unchanged",
+			input:  "hello",
+			maxLen: 5,
+			want:   "hello",
+		},
+		{
+			name:   "long string truncated with ellipsis",
+			input:  "hello world",
+			maxLen: 8,
+			want:   "hello...",
+		},
+		{
+			name:   "empty string",
+			input:  "",
+			maxLen: 10,
+			want:   "",
+		},
+		{
+			name:   "very short max length",
+			input:  "hello",
+			maxLen: 3,
+			want:   "hel",
+		},
+		{
+			name:   "max length of 4 adds ellipsis",
+			input:  "hello world",
+			maxLen: 4,
+			want:   "h...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateString(tt.input, tt.maxLen)
+			if got != tt.want {
+				t.Errorf("truncateString(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/consolidation/strategy/single.go
+++ b/internal/orchestrator/consolidation/strategy/single.go
@@ -1,0 +1,232 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator/consolidation"
+)
+
+// Compile-time check that Single implements consolidation.Strategy.
+var _ consolidation.Strategy = (*Single)(nil)
+
+// Single implements the single PR consolidation strategy.
+// It consolidates all tasks from all groups into a single PR.
+type Single struct {
+	*Base
+}
+
+// NewSingle creates a new Single strategy.
+func NewSingle(deps Dependencies, config Config) *Single {
+	return &Single{
+		Base: NewBase(deps, config),
+	}
+}
+
+// Name returns the strategy name.
+func (s *Single) Name() string {
+	return "single"
+}
+
+// SupportsParallel returns whether this strategy supports parallel task processing.
+func (s *Single) SupportsParallel() bool {
+	return true // Single strategy can process tasks in parallel within a group
+}
+
+// Execute runs the single PR consolidation strategy.
+func (s *Single) Execute(ctx context.Context, groups []TaskGroup) (*Result, error) {
+	startTime := time.Now()
+	result := &Result{
+		PRs:          make([]consolidation.PRInfo, 0, 1),
+		GroupResults: make([]GroupResult, 0, len(groups)),
+	}
+
+	// Flatten all tasks from all groups
+	var allTasks []consolidation.CompletedTask
+	for _, group := range groups {
+		allTasks = append(allTasks, group.Tasks...)
+	}
+
+	s.emit(consolidation.Event{
+		Type:    consolidation.EventStarted,
+		Message: fmt.Sprintf("Starting single PR consolidation for %d tasks", len(allTasks)),
+	})
+
+	mainBranch := s.deps.Branch.FindMainBranch(ctx)
+
+	// Create consolidated branch
+	branchName, err := s.deps.Branch.CreateSingleBranch(ctx, mainBranch)
+	if err != nil {
+		result.Error = err
+		return result, fmt.Errorf("failed to create consolidated branch: %w", err)
+	}
+
+	// Create temporary worktree for consolidation
+	worktreePath := filepath.Join(s.config.WorktreeDir, "consolidate-single")
+	if err := s.deps.Branch.CreateWorktree(ctx, worktreePath, branchName); err != nil {
+		result.Error = err
+		return result, fmt.Errorf("failed to create worktree: %w", err)
+	}
+	defer func() {
+		if err := s.deps.Branch.RemoveWorktree(ctx, worktreePath); err != nil {
+			s.log().Warn("failed to remove worktree during cleanup",
+				"worktree_path", worktreePath,
+				"error", err,
+			)
+		}
+	}()
+
+	// Process each group in order (to maintain dependency order)
+	for _, group := range groups {
+		s.emit(consolidation.Event{
+			Type:     consolidation.EventGroupStarted,
+			GroupIdx: group.Index,
+			Message:  fmt.Sprintf("Processing group %d with %d tasks", group.Index+1, len(group.Tasks)),
+		})
+
+		groupResult := GroupResult{
+			GroupIndex: group.Index,
+			BranchName: branchName,
+			TaskIDs:    make([]string, 0, len(group.Tasks)),
+			Success:    true,
+		}
+
+		for _, task := range group.Tasks {
+			s.emit(consolidation.Event{
+				Type:     consolidation.EventTaskMerging,
+				GroupIdx: group.Index,
+				TaskID:   task.ID,
+				Message:  fmt.Sprintf("Merging task %s", task.ID),
+			})
+
+			conflictInfo, err := s.deps.Conflict.CheckCherryPick(ctx, worktreePath, task.Branch, task.ID, task.Title)
+			if err != nil {
+				groupResult.Success = false
+				groupResult.Error = err.Error()
+				result.GroupResults = append(result.GroupResults, groupResult)
+				result.Error = fmt.Errorf("cherry-pick check failed for task %s: %w", task.ID, err)
+				return result, result.Error
+			}
+
+			if conflictInfo != nil {
+				s.emit(consolidation.Event{
+					Type:     consolidation.EventConflict,
+					GroupIdx: group.Index,
+					TaskID:   task.ID,
+					Message:  fmt.Sprintf("Conflict in task %s: %v", task.ID, conflictInfo.Files),
+				})
+
+				if abortErr := s.deps.Conflict.AbortCherryPick(ctx, worktreePath); abortErr != nil {
+					s.log().Warn("failed to abort cherry-pick after conflict detection",
+						"worktree_path", worktreePath,
+						"task_id", task.ID,
+						"abort_error", abortErr,
+					)
+				}
+				groupResult.Success = false
+				groupResult.Error = fmt.Sprintf("merge conflict: files %v", conflictInfo.Files)
+				result.GroupResults = append(result.GroupResults, groupResult)
+				result.Error = fmt.Errorf("merge conflict in task %s", task.ID)
+				return result, result.Error
+			}
+
+			groupResult.TaskIDs = append(groupResult.TaskIDs, task.ID)
+
+			s.emit(consolidation.Event{
+				Type:     consolidation.EventTaskMerged,
+				GroupIdx: group.Index,
+				TaskID:   task.ID,
+				Message:  fmt.Sprintf("Task %s merged successfully", task.ID),
+			})
+		}
+
+		result.GroupResults = append(result.GroupResults, groupResult)
+
+		s.emit(consolidation.Event{
+			Type:     consolidation.EventGroupComplete,
+			GroupIdx: group.Index,
+			Message:  fmt.Sprintf("Group %d processing complete", group.Index+1),
+		})
+	}
+
+	// Get commit count and changed files
+	commitCount, err := s.deps.Branch.CountCommitsBetween(ctx, worktreePath, mainBranch, "HEAD")
+	if err != nil {
+		s.log().Warn("failed to count commits",
+			"worktree_path", worktreePath,
+			"base_branch", mainBranch,
+			"error", err,
+		)
+	} else {
+		result.TotalCommits = commitCount
+	}
+
+	changedFiles, err := s.deps.Branch.GetChangedFiles(ctx, worktreePath)
+	if err != nil {
+		s.log().Warn("failed to get changed files",
+			"worktree_path", worktreePath,
+			"error", err,
+		)
+	} else {
+		result.FilesChanged = changedFiles
+	}
+
+	// Push branch
+	if err := s.deps.Branch.Push(ctx, worktreePath, false); err != nil {
+		result.Error = err
+		return result, fmt.Errorf("failed to push branch: %w", err)
+	}
+
+	s.emit(consolidation.Event{
+		Type:    consolidation.EventPRCreating,
+		Message: "Creating consolidated PR",
+	})
+
+	// Build PR content
+	prOpts := consolidation.PRBuildOptions{
+		Mode:            consolidation.ModeSingle,
+		GroupIndex:      0,
+		TotalGroups:     1,
+		Objective:       s.config.Objective,
+		SynthesisNotes:  s.config.SynthesisNotes,
+		Recommendations: s.config.Recommendations,
+		FilesChanged:    result.FilesChanged,
+		BaseBranch:      mainBranch,
+		HeadBranch:      branchName,
+	}
+
+	prContent, err := s.deps.PRBuilder.Build(allTasks, prOpts)
+	if err != nil {
+		result.Error = err
+		return result, fmt.Errorf("failed to build PR content: %w", err)
+	}
+
+	// Create PR
+	prURL, err := s.deps.PRCreator.Create(ctx, prContent, s.config.CreateDraftPRs, s.config.PRLabels)
+	if err != nil {
+		result.Error = err
+		return result, fmt.Errorf("failed to create PR: %w", err)
+	}
+
+	result.PRs = append(result.PRs, consolidation.PRInfo{
+		URL:        prURL,
+		Title:      "Consolidated PR",
+		GroupIndex: 0,
+	})
+
+	s.emit(consolidation.Event{
+		Type:    consolidation.EventPRCreated,
+		Message: fmt.Sprintf("PR created: %s", prURL),
+	})
+
+	result.Duration = time.Since(startTime)
+
+	s.emit(consolidation.Event{
+		Type:    consolidation.EventComplete,
+		Message: "Single PR consolidation complete",
+	})
+
+	return result, nil
+}

--- a/internal/orchestrator/consolidation/strategy/stacked.go
+++ b/internal/orchestrator/consolidation/strategy/stacked.go
@@ -1,0 +1,254 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator/consolidation"
+)
+
+// Compile-time check that Stacked implements consolidation.Strategy.
+var _ consolidation.Strategy = (*Stacked)(nil)
+
+// Stacked implements the stacked PRs consolidation strategy.
+// It creates one PR per execution group, where each group's PR
+// is based on the previous group's branch.
+type Stacked struct {
+	*Base
+}
+
+// NewStacked creates a new Stacked strategy.
+func NewStacked(deps Dependencies, config Config) *Stacked {
+	return &Stacked{
+		Base: NewBase(deps, config),
+	}
+}
+
+// Name returns the strategy name.
+func (s *Stacked) Name() string {
+	return "stacked"
+}
+
+// SupportsParallel returns whether this strategy supports parallel task processing.
+func (s *Stacked) SupportsParallel() bool {
+	return false // Stacked strategy processes groups sequentially
+}
+
+// Execute runs the stacked consolidation strategy.
+func (s *Stacked) Execute(ctx context.Context, groups []TaskGroup) (*Result, error) {
+	startTime := time.Now()
+	result := &Result{
+		PRs:          make([]consolidation.PRInfo, 0, len(groups)),
+		GroupResults: make([]GroupResult, 0, len(groups)),
+	}
+
+	s.emit(consolidation.Event{
+		Type:    consolidation.EventStarted,
+		Message: fmt.Sprintf("Starting stacked consolidation for %d groups", len(groups)),
+	})
+
+	mainBranch := s.deps.Branch.FindMainBranch(ctx)
+	baseBranch := mainBranch
+	allFiles := make(map[string]bool)
+
+	for _, group := range groups {
+		s.emit(consolidation.Event{
+			Type:     consolidation.EventGroupStarted,
+			GroupIdx: group.Index,
+			Message:  fmt.Sprintf("Consolidating group %d with %d tasks", group.Index+1, len(group.Tasks)),
+		})
+
+		groupResult, err := s.consolidateGroup(ctx, group, baseBranch, mainBranch, len(groups))
+		if err != nil {
+			s.log().Error("failed to consolidate group",
+				"group_index", group.Index,
+				"error", err,
+			)
+			groupResult.Error = err.Error()
+			groupResult.Success = false
+		}
+
+		result.GroupResults = append(result.GroupResults, *groupResult)
+		result.TotalCommits += groupResult.CommitCount
+
+		for _, f := range groupResult.FilesChanged {
+			allFiles[f] = true
+		}
+
+		if groupResult.PRUrl != "" {
+			result.PRs = append(result.PRs, consolidation.PRInfo{
+				URL:        groupResult.PRUrl,
+				Title:      fmt.Sprintf("Group %d", group.Index+1),
+				GroupIndex: group.Index,
+			})
+		}
+
+		// Next group will be based on this group's branch
+		if groupResult.Success && groupResult.BranchName != "" {
+			baseBranch = groupResult.BranchName
+		}
+
+		s.emit(consolidation.Event{
+			Type:     consolidation.EventGroupComplete,
+			GroupIdx: group.Index,
+			Message:  fmt.Sprintf("Group %d consolidation complete", group.Index+1),
+		})
+	}
+
+	// Collect all changed files
+	for f := range allFiles {
+		result.FilesChanged = append(result.FilesChanged, f)
+	}
+
+	result.Duration = time.Since(startTime)
+
+	s.emit(consolidation.Event{
+		Type:    consolidation.EventComplete,
+		Message: fmt.Sprintf("Stacked consolidation complete: %d PRs created", len(result.PRs)),
+	})
+
+	return result, nil
+}
+
+// consolidateGroup consolidates a single execution group.
+// The mainBranch parameter is reserved for future use when computing diffs.
+func (s *Stacked) consolidateGroup(ctx context.Context, group TaskGroup, baseBranch, _ string, totalGroups int) (*GroupResult, error) {
+	result := &GroupResult{
+		GroupIndex: group.Index,
+		TaskIDs:    make([]string, 0, len(group.Tasks)),
+		Success:    true,
+	}
+
+	// Create branch for this group
+	branchName, err := s.deps.Branch.CreateGroupBranch(ctx, group.Index, baseBranch)
+	if err != nil {
+		return result, fmt.Errorf("failed to create group branch: %w", err)
+	}
+	result.BranchName = branchName
+
+	// Create temporary worktree for consolidation
+	worktreePath := filepath.Join(s.config.WorktreeDir, fmt.Sprintf("consolidate-group-%d", group.Index))
+	if err := s.deps.Branch.CreateWorktree(ctx, worktreePath, branchName); err != nil {
+		return result, fmt.Errorf("failed to create worktree: %w", err)
+	}
+	defer func() {
+		if err := s.deps.Branch.RemoveWorktree(ctx, worktreePath); err != nil {
+			s.log().Warn("failed to remove worktree during cleanup",
+				"worktree_path", worktreePath,
+				"error", err,
+			)
+		}
+	}()
+
+	// Cherry-pick commits from each task
+	for _, task := range group.Tasks {
+		s.emit(consolidation.Event{
+			Type:     consolidation.EventTaskMerging,
+			GroupIdx: group.Index,
+			TaskID:   task.ID,
+			Message:  fmt.Sprintf("Merging task %s", task.ID),
+		})
+
+		conflictInfo, err := s.deps.Conflict.CheckCherryPick(ctx, worktreePath, task.Branch, task.ID, task.Title)
+		if err != nil {
+			return result, fmt.Errorf("cherry-pick check failed for task %s: %w", task.ID, err)
+		}
+
+		if conflictInfo != nil {
+			// Conflict detected
+			s.emit(consolidation.Event{
+				Type:     consolidation.EventConflict,
+				GroupIdx: group.Index,
+				TaskID:   task.ID,
+				Message:  fmt.Sprintf("Conflict in task %s: %v", task.ID, conflictInfo.Files),
+			})
+
+			if abortErr := s.deps.Conflict.AbortCherryPick(ctx, worktreePath); abortErr != nil {
+				s.log().Warn("failed to abort cherry-pick after conflict detection",
+					"worktree_path", worktreePath,
+					"task_id", task.ID,
+					"abort_error", abortErr,
+				)
+			}
+			return result, fmt.Errorf("merge conflict in task %s: files %v", task.ID, conflictInfo.Files)
+		}
+
+		result.TaskIDs = append(result.TaskIDs, task.ID)
+
+		s.emit(consolidation.Event{
+			Type:     consolidation.EventTaskMerged,
+			GroupIdx: group.Index,
+			TaskID:   task.ID,
+			Message:  fmt.Sprintf("Task %s merged successfully", task.ID),
+		})
+	}
+
+	// Get commit count and changed files
+	commitCount, err := s.deps.Branch.CountCommitsBetween(ctx, worktreePath, baseBranch, "HEAD")
+	if err != nil {
+		s.log().Warn("failed to count commits",
+			"worktree_path", worktreePath,
+			"base_branch", baseBranch,
+			"error", err,
+		)
+	} else {
+		result.CommitCount = commitCount
+	}
+
+	changedFiles, err := s.deps.Branch.GetChangedFiles(ctx, worktreePath)
+	if err != nil {
+		s.log().Warn("failed to get changed files",
+			"worktree_path", worktreePath,
+			"error", err,
+		)
+	} else {
+		result.FilesChanged = changedFiles
+	}
+
+	// Push branch
+	if err := s.deps.Branch.Push(ctx, worktreePath, false); err != nil {
+		return result, fmt.Errorf("failed to push branch: %w", err)
+	}
+
+	s.emit(consolidation.Event{
+		Type:     consolidation.EventPRCreating,
+		GroupIdx: group.Index,
+		Message:  fmt.Sprintf("Creating PR for group %d", group.Index+1),
+	})
+
+	// Build PR content
+	prOpts := consolidation.PRBuildOptions{
+		Mode:            consolidation.ModeStacked,
+		GroupIndex:      group.Index,
+		TotalGroups:     totalGroups,
+		Objective:       s.config.Objective,
+		SynthesisNotes:  s.config.SynthesisNotes,
+		Recommendations: s.config.Recommendations,
+		FilesChanged:    result.FilesChanged,
+		BaseBranch:      baseBranch,
+		HeadBranch:      branchName,
+	}
+
+	prContent, err := s.deps.PRBuilder.Build(group.Tasks, prOpts)
+	if err != nil {
+		return result, fmt.Errorf("failed to build PR content: %w", err)
+	}
+
+	// Create PR
+	prURL, err := s.deps.PRCreator.Create(ctx, prContent, s.config.CreateDraftPRs, s.config.PRLabels)
+	if err != nil {
+		return result, fmt.Errorf("failed to create PR: %w", err)
+	}
+
+	result.PRUrl = prURL
+
+	s.emit(consolidation.Event{
+		Type:     consolidation.EventPRCreated,
+		GroupIdx: group.Index,
+		Message:  fmt.Sprintf("PR created: %s", prURL),
+	})
+
+	return result, nil
+}

--- a/internal/orchestrator/consolidation/strategy/strategy.go
+++ b/internal/orchestrator/consolidation/strategy/strategy.go
@@ -1,0 +1,113 @@
+// Package strategy provides consolidation strategies for combining task branches.
+// It implements the Strategy pattern to support different consolidation modes
+// such as stacked PRs and single PR.
+package strategy
+
+import (
+	"context"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator/consolidation"
+)
+
+// Dependencies holds the dependencies needed by consolidation strategies.
+type Dependencies struct {
+	Branch    BranchOps
+	Conflict  ConflictOps
+	PRBuilder PRBuilderOps
+	PRCreator PRCreatorOps
+	Events    consolidation.EventEmitter
+	Logger    consolidation.Logger
+}
+
+// BranchOps defines branch operations needed by strategies.
+type BranchOps interface {
+	FindMainBranch(ctx context.Context) string
+	CreateGroupBranch(ctx context.Context, groupIdx int, baseBranch string) (string, error)
+	CreateSingleBranch(ctx context.Context, baseBranch string) (string, error)
+	CreateWorktree(ctx context.Context, path, branch string) error
+	CherryPickBranch(ctx context.Context, worktreePath, sourceBranch string) error
+	GetChangedFiles(ctx context.Context, worktreePath string) ([]string, error)
+	CountCommitsBetween(ctx context.Context, worktreePath, baseBranch, headBranch string) (int, error)
+	Push(ctx context.Context, worktreePath string, force bool) error
+	RemoveWorktree(ctx context.Context, path string) error
+}
+
+// ConflictOps defines conflict detection operations.
+type ConflictOps interface {
+	CheckCherryPick(ctx context.Context, worktreePath, sourceBranch, taskID, taskTitle string) (*ConflictInfo, error)
+	AbortCherryPick(ctx context.Context, worktreePath string) error
+	GetConflictingFiles(ctx context.Context, worktreePath string) ([]string, error)
+}
+
+// ConflictInfo is an alias to consolidation.ConflictInfo for convenience.
+type ConflictInfo = consolidation.ConflictInfo
+
+// PRBuilderOps defines PR content generation operations.
+type PRBuilderOps interface {
+	Build(tasks []consolidation.CompletedTask, opts consolidation.PRBuildOptions) (*consolidation.PRContent, error)
+}
+
+// PRCreatorOps defines PR creation operations.
+type PRCreatorOps interface {
+	Create(ctx context.Context, content *consolidation.PRContent, draft bool, labels []string) (string, error)
+}
+
+// Config holds configuration for consolidation strategies.
+type Config struct {
+	Mode            consolidation.Mode
+	BranchPrefix    string
+	CreateDraftPRs  bool
+	PRLabels        []string
+	WorktreeDir     string // Base directory for creating worktrees
+	Objective       string // The ultraplan objective
+	SynthesisNotes  string
+	Recommendations []string
+}
+
+// Result is an alias to consolidation.StrategyResult for convenience.
+type Result = consolidation.StrategyResult
+
+// GroupResult is an alias to consolidation.GroupResult for convenience.
+type GroupResult = consolidation.GroupResult
+
+// TaskGroup is an alias to consolidation.TaskGroup for convenience.
+type TaskGroup = consolidation.TaskGroup
+
+// Base provides common functionality for consolidation strategies.
+type Base struct {
+	deps   Dependencies
+	config Config
+}
+
+// NewBase creates a new Base with the given dependencies and config.
+func NewBase(deps Dependencies, config Config) *Base {
+	return &Base{
+		deps:   deps,
+		config: config,
+	}
+}
+
+// emit sends a consolidation event.
+func (b *Base) emit(event consolidation.Event) {
+	event.Timestamp = time.Now()
+	if b.deps.Events != nil {
+		b.deps.Events.Emit(event)
+	}
+}
+
+// log provides convenient access to the logger.
+func (b *Base) log() consolidation.Logger {
+	if b.deps.Logger != nil {
+		return b.deps.Logger
+	}
+	return &nopLogger{}
+}
+
+// nopLogger is a no-op logger implementation.
+type nopLogger struct{}
+
+func (n *nopLogger) Debug(_ string, _ ...any) {}
+func (n *nopLogger) Info(_ string, _ ...any)  {}
+func (n *nopLogger) Warn(_ string, _ ...any)  {}
+func (n *nopLogger) Error(_ string, _ ...any) {}

--- a/internal/orchestrator/consolidation/strategy/strategy_test.go
+++ b/internal/orchestrator/consolidation/strategy/strategy_test.go
@@ -1,0 +1,738 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator/consolidation"
+)
+
+// mockBranchOps is a mock implementation of BranchOps.
+type mockBranchOps struct {
+	mainBranch          string
+	groupBranchName     string
+	groupBranchNames    []string // For multi-group tests
+	singleBranchName    string
+	createGroupErr      error
+	createSingleErr     error
+	createWorktreeErr   error
+	cherryPickErr       error
+	changedFiles        []string
+	changedFilesErr     error
+	commitCount         int
+	commitCountErr      error
+	pushErr             error
+	removeWorktreeErr   error
+	createWorktreeCall  struct{ path, branch string }
+	cherryPickCalls     []struct{ path, branch string }
+	removeWorktreeCalls []string
+	createGroupCalls    []struct {
+		groupIdx   int
+		baseBranch string
+	}
+}
+
+func (m *mockBranchOps) FindMainBranch(_ context.Context) string {
+	if m.mainBranch == "" {
+		return "main"
+	}
+	return m.mainBranch
+}
+
+func (m *mockBranchOps) CreateGroupBranch(_ context.Context, groupIdx int, baseBranch string) (string, error) {
+	m.createGroupCalls = append(m.createGroupCalls, struct {
+		groupIdx   int
+		baseBranch string
+	}{groupIdx, baseBranch})
+	if m.createGroupErr != nil {
+		return "", m.createGroupErr
+	}
+	if len(m.groupBranchNames) > groupIdx {
+		return m.groupBranchNames[groupIdx], nil
+	}
+	if m.groupBranchName != "" {
+		return m.groupBranchName, nil
+	}
+	return fmt.Sprintf("Iron-Ham/ultraplan-abc-group-%d", groupIdx+1), nil
+}
+
+func (m *mockBranchOps) CreateSingleBranch(_ context.Context, _ string) (string, error) {
+	if m.createSingleErr != nil {
+		return "", m.createSingleErr
+	}
+	if m.singleBranchName != "" {
+		return m.singleBranchName, nil
+	}
+	return "Iron-Ham/ultraplan-abc", nil
+}
+
+func (m *mockBranchOps) CreateWorktree(_ context.Context, path, branch string) error {
+	m.createWorktreeCall = struct{ path, branch string }{path, branch}
+	return m.createWorktreeErr
+}
+
+func (m *mockBranchOps) CherryPickBranch(_ context.Context, worktreePath, sourceBranch string) error {
+	m.cherryPickCalls = append(m.cherryPickCalls, struct{ path, branch string }{worktreePath, sourceBranch})
+	return m.cherryPickErr
+}
+
+func (m *mockBranchOps) GetChangedFiles(_ context.Context, _ string) ([]string, error) {
+	return m.changedFiles, m.changedFilesErr
+}
+
+func (m *mockBranchOps) CountCommitsBetween(_ context.Context, _, _, _ string) (int, error) {
+	return m.commitCount, m.commitCountErr
+}
+
+func (m *mockBranchOps) Push(_ context.Context, _ string, _ bool) error {
+	return m.pushErr
+}
+
+func (m *mockBranchOps) RemoveWorktree(_ context.Context, path string) error {
+	m.removeWorktreeCalls = append(m.removeWorktreeCalls, path)
+	return m.removeWorktreeErr
+}
+
+// mockConflictOps is a mock implementation of ConflictOps.
+type mockConflictOps struct {
+	conflictInfo *ConflictInfo
+	checkErr     error
+	abortErr     error
+	files        []string
+	filesErr     error
+}
+
+func (m *mockConflictOps) CheckCherryPick(_ context.Context, _, _, _, _ string) (*ConflictInfo, error) {
+	return m.conflictInfo, m.checkErr
+}
+
+func (m *mockConflictOps) AbortCherryPick(_ context.Context, _ string) error {
+	return m.abortErr
+}
+
+func (m *mockConflictOps) GetConflictingFiles(_ context.Context, _ string) ([]string, error) {
+	return m.files, m.filesErr
+}
+
+// mockPRBuilder is a mock implementation of PRBuilderOps.
+type mockPRBuilder struct {
+	content  *consolidation.PRContent
+	buildErr error
+}
+
+func (m *mockPRBuilder) Build(_ []consolidation.CompletedTask, _ consolidation.PRBuildOptions) (*consolidation.PRContent, error) {
+	if m.buildErr != nil {
+		return nil, m.buildErr
+	}
+	if m.content != nil {
+		return m.content, nil
+	}
+	return &consolidation.PRContent{
+		Title:      "Test PR",
+		Body:       "Test body",
+		BaseBranch: "main",
+		HeadBranch: "feature",
+	}, nil
+}
+
+// mockPRCreator is a mock implementation of PRCreatorOps.
+type mockPRCreator struct {
+	prURL     string
+	createErr error
+}
+
+func (m *mockPRCreator) Create(_ context.Context, _ *consolidation.PRContent, _ bool, _ []string) (string, error) {
+	if m.createErr != nil {
+		return "", m.createErr
+	}
+	if m.prURL != "" {
+		return m.prURL, nil
+	}
+	return "https://github.com/org/repo/pull/1", nil
+}
+
+// mockEventEmitter is a mock implementation of EventEmitter.
+type mockEventEmitter struct {
+	events []consolidation.Event
+}
+
+func (m *mockEventEmitter) Emit(event consolidation.Event) {
+	m.events = append(m.events, event)
+}
+
+func TestStacked_Name(t *testing.T) {
+	s := NewStacked(Dependencies{}, Config{})
+	if got := s.Name(); got != "stacked" {
+		t.Errorf("Name() = %q, want %q", got, "stacked")
+	}
+}
+
+func TestStacked_SupportsParallel(t *testing.T) {
+	s := NewStacked(Dependencies{}, Config{})
+	if got := s.SupportsParallel(); got != false {
+		t.Errorf("SupportsParallel() = %v, want false", got)
+	}
+}
+
+func TestSingle_Name(t *testing.T) {
+	s := NewSingle(Dependencies{}, Config{})
+	if got := s.Name(); got != "single" {
+		t.Errorf("Name() = %q, want %q", got, "single")
+	}
+}
+
+func TestSingle_SupportsParallel(t *testing.T) {
+	s := NewSingle(Dependencies{}, Config{})
+	if got := s.SupportsParallel(); got != true {
+		t.Errorf("SupportsParallel() = %v, want true", got)
+	}
+}
+
+func TestStacked_Execute_Success(t *testing.T) {
+	events := &mockEventEmitter{}
+	deps := Dependencies{
+		Branch:    &mockBranchOps{commitCount: 3, changedFiles: []string{"a.go", "b.go"}},
+		Conflict:  &mockConflictOps{},
+		PRBuilder: &mockPRBuilder{},
+		PRCreator: &mockPRCreator{prURL: "https://github.com/org/repo/pull/1"},
+		Events:    events,
+	}
+	config := Config{
+		WorktreeDir: "/tmp",
+		Objective:   "Test objective",
+	}
+
+	s := NewStacked(deps, config)
+
+	groups := []TaskGroup{
+		{
+			Index: 0,
+			Tasks: []consolidation.CompletedTask{
+				{ID: "task-1", Title: "Task 1", Branch: "feature-1"},
+				{ID: "task-2", Title: "Task 2", Branch: "feature-2"},
+			},
+		},
+	}
+
+	result, err := s.Execute(context.Background(), groups)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if len(result.PRs) != 1 {
+		t.Errorf("Execute() created %d PRs, want 1", len(result.PRs))
+	}
+
+	if result.PRs[0].URL != "https://github.com/org/repo/pull/1" {
+		t.Errorf("Execute() PR URL = %q, want %q", result.PRs[0].URL, "https://github.com/org/repo/pull/1")
+	}
+
+	if result.TotalCommits != 3 {
+		t.Errorf("Execute() TotalCommits = %d, want 3", result.TotalCommits)
+	}
+
+	// Check events were emitted
+	if len(events.events) == 0 {
+		t.Error("Execute() should emit events")
+	}
+}
+
+func TestStacked_Execute_Conflict(t *testing.T) {
+	deps := Dependencies{
+		Branch: &mockBranchOps{},
+		Conflict: &mockConflictOps{
+			conflictInfo: &ConflictInfo{
+				TaskID: "task-1",
+				Files:  []string{"conflict.go"},
+			},
+		},
+		PRBuilder: &mockPRBuilder{},
+		PRCreator: &mockPRCreator{},
+	}
+	config := Config{
+		WorktreeDir: "/tmp",
+	}
+
+	s := NewStacked(deps, config)
+
+	groups := []TaskGroup{
+		{
+			Index: 0,
+			Tasks: []consolidation.CompletedTask{
+				{ID: "task-1", Title: "Task 1", Branch: "feature-1"},
+			},
+		},
+	}
+
+	result, _ := s.Execute(context.Background(), groups)
+
+	// Should have one group result with failure
+	if len(result.GroupResults) != 1 {
+		t.Fatalf("Execute() returned %d group results, want 1", len(result.GroupResults))
+	}
+
+	if result.GroupResults[0].Success {
+		t.Error("Execute() group should have failed due to conflict")
+	}
+}
+
+func TestSingle_Execute_Success(t *testing.T) {
+	events := &mockEventEmitter{}
+	deps := Dependencies{
+		Branch:    &mockBranchOps{commitCount: 5, changedFiles: []string{"x.go", "y.go"}},
+		Conflict:  &mockConflictOps{},
+		PRBuilder: &mockPRBuilder{},
+		PRCreator: &mockPRCreator{prURL: "https://github.com/org/repo/pull/42"},
+		Events:    events,
+	}
+	config := Config{
+		WorktreeDir: "/tmp",
+		Objective:   "Single PR test",
+	}
+
+	s := NewSingle(deps, config)
+
+	groups := []TaskGroup{
+		{
+			Index: 0,
+			Tasks: []consolidation.CompletedTask{
+				{ID: "task-1", Title: "Task 1", Branch: "feature-1"},
+			},
+		},
+		{
+			Index: 1,
+			Tasks: []consolidation.CompletedTask{
+				{ID: "task-2", Title: "Task 2", Branch: "feature-2"},
+			},
+		},
+	}
+
+	result, err := s.Execute(context.Background(), groups)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if len(result.PRs) != 1 {
+		t.Errorf("Execute() created %d PRs, want 1", len(result.PRs))
+	}
+
+	if result.PRs[0].URL != "https://github.com/org/repo/pull/42" {
+		t.Errorf("Execute() PR URL = %q", result.PRs[0].URL)
+	}
+
+	if result.TotalCommits != 5 {
+		t.Errorf("Execute() TotalCommits = %d, want 5", result.TotalCommits)
+	}
+
+	// Should have processed both groups
+	if len(result.GroupResults) != 2 {
+		t.Errorf("Execute() returned %d group results, want 2", len(result.GroupResults))
+	}
+}
+
+func TestSingle_Execute_CreateBranchError(t *testing.T) {
+	deps := Dependencies{
+		Branch: &mockBranchOps{
+			createSingleErr: errors.New("branch already exists"),
+		},
+		Conflict:  &mockConflictOps{},
+		PRBuilder: &mockPRBuilder{},
+		PRCreator: &mockPRCreator{},
+	}
+	config := Config{
+		WorktreeDir: "/tmp",
+	}
+
+	s := NewSingle(deps, config)
+
+	groups := []TaskGroup{
+		{
+			Index: 0,
+			Tasks: []consolidation.CompletedTask{
+				{ID: "task-1", Title: "Task 1", Branch: "feature-1"},
+			},
+		},
+	}
+
+	_, err := s.Execute(context.Background(), groups)
+	if err == nil {
+		t.Error("Execute() expected error for branch creation failure")
+	}
+}
+
+func TestSingle_Execute_Conflict(t *testing.T) {
+	deps := Dependencies{
+		Branch: &mockBranchOps{},
+		Conflict: &mockConflictOps{
+			conflictInfo: &ConflictInfo{
+				TaskID: "task-1",
+				Files:  []string{"conflict.go"},
+			},
+		},
+		PRBuilder: &mockPRBuilder{},
+		PRCreator: &mockPRCreator{},
+	}
+	config := Config{
+		WorktreeDir: "/tmp",
+	}
+
+	s := NewSingle(deps, config)
+
+	groups := []TaskGroup{
+		{
+			Index: 0,
+			Tasks: []consolidation.CompletedTask{
+				{ID: "task-1", Title: "Task 1", Branch: "feature-1"},
+			},
+		},
+	}
+
+	result, err := s.Execute(context.Background(), groups)
+	if err == nil {
+		t.Error("Execute() expected error for conflict")
+	}
+
+	if result.Error == nil {
+		t.Error("Execute() result.Error should be set on conflict")
+	}
+}
+
+func TestBase_NilLogger(t *testing.T) {
+	// Test that Base handles nil logger gracefully
+	deps := Dependencies{
+		Logger: nil,
+	}
+	base := NewBase(deps, Config{})
+
+	// Should return nopLogger
+	logger := base.log()
+	if logger == nil {
+		t.Error("log() should return nopLogger when Logger is nil")
+	}
+
+	// nopLogger methods should not panic
+	logger.Debug("test")
+	logger.Info("test")
+	logger.Warn("test")
+	logger.Error("test")
+}
+
+func TestBase_NilEventEmitter(t *testing.T) {
+	// Test that Base handles nil event emitter gracefully
+	deps := Dependencies{
+		Events: nil,
+	}
+	base := NewBase(deps, Config{})
+
+	// Should not panic
+	base.emit(consolidation.Event{
+		Type:    consolidation.EventStarted,
+		Message: "test",
+	})
+}
+
+func TestStacked_Execute_MultipleGroups(t *testing.T) {
+	// Test that stacked strategy correctly chains baseBranch through multiple groups
+	branchOps := &mockBranchOps{
+		commitCount:      2,
+		changedFiles:     []string{"file.go"},
+		groupBranchNames: []string{"group-1-branch", "group-2-branch", "group-3-branch"},
+	}
+	deps := Dependencies{
+		Branch:    branchOps,
+		Conflict:  &mockConflictOps{},
+		PRBuilder: &mockPRBuilder{},
+		PRCreator: &mockPRCreator{},
+	}
+	config := Config{
+		WorktreeDir: "/tmp",
+		Objective:   "Multi-group test",
+	}
+
+	s := NewStacked(deps, config)
+
+	groups := []TaskGroup{
+		{Index: 0, Tasks: []consolidation.CompletedTask{{ID: "task-1", Branch: "feature-1"}}},
+		{Index: 1, Tasks: []consolidation.CompletedTask{{ID: "task-2", Branch: "feature-2"}}},
+		{Index: 2, Tasks: []consolidation.CompletedTask{{ID: "task-3", Branch: "feature-3"}}},
+	}
+
+	result, err := s.Execute(context.Background(), groups)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	// Should have 3 PRs
+	if len(result.PRs) != 3 {
+		t.Errorf("Execute() created %d PRs, want 3", len(result.PRs))
+	}
+
+	// Verify baseBranch chaining: each group should use previous group's branch as base
+	if len(branchOps.createGroupCalls) != 3 {
+		t.Fatalf("Expected 3 CreateGroupBranch calls, got %d", len(branchOps.createGroupCalls))
+	}
+
+	// First group should use "main" as base
+	if branchOps.createGroupCalls[0].baseBranch != "main" {
+		t.Errorf("Group 0 baseBranch = %q, want %q", branchOps.createGroupCalls[0].baseBranch, "main")
+	}
+
+	// Second group should use first group's branch as base
+	if branchOps.createGroupCalls[1].baseBranch != "group-1-branch" {
+		t.Errorf("Group 1 baseBranch = %q, want %q", branchOps.createGroupCalls[1].baseBranch, "group-1-branch")
+	}
+
+	// Third group should use second group's branch as base
+	if branchOps.createGroupCalls[2].baseBranch != "group-2-branch" {
+		t.Errorf("Group 2 baseBranch = %q, want %q", branchOps.createGroupCalls[2].baseBranch, "group-2-branch")
+	}
+}
+
+func TestStacked_Execute_WorktreeError(t *testing.T) {
+	deps := Dependencies{
+		Branch: &mockBranchOps{
+			createWorktreeErr: errors.New("failed to create worktree"),
+		},
+		Conflict:  &mockConflictOps{},
+		PRBuilder: &mockPRBuilder{},
+		PRCreator: &mockPRCreator{},
+	}
+	config := Config{WorktreeDir: "/tmp"}
+
+	s := NewStacked(deps, config)
+
+	groups := []TaskGroup{
+		{Index: 0, Tasks: []consolidation.CompletedTask{{ID: "task-1", Branch: "feature-1"}}},
+	}
+
+	result, _ := s.Execute(context.Background(), groups)
+
+	if len(result.GroupResults) != 1 {
+		t.Fatalf("Expected 1 group result, got %d", len(result.GroupResults))
+	}
+
+	if result.GroupResults[0].Success {
+		t.Error("Group should have failed due to worktree error")
+	}
+}
+
+func TestStacked_Execute_PushError(t *testing.T) {
+	deps := Dependencies{
+		Branch: &mockBranchOps{
+			pushErr: errors.New("failed to push"),
+		},
+		Conflict:  &mockConflictOps{},
+		PRBuilder: &mockPRBuilder{},
+		PRCreator: &mockPRCreator{},
+	}
+	config := Config{WorktreeDir: "/tmp"}
+
+	s := NewStacked(deps, config)
+
+	groups := []TaskGroup{
+		{Index: 0, Tasks: []consolidation.CompletedTask{{ID: "task-1", Branch: "feature-1"}}},
+	}
+
+	result, _ := s.Execute(context.Background(), groups)
+
+	if len(result.GroupResults) != 1 {
+		t.Fatalf("Expected 1 group result, got %d", len(result.GroupResults))
+	}
+
+	if result.GroupResults[0].Success {
+		t.Error("Group should have failed due to push error")
+	}
+}
+
+func TestStacked_Execute_PRBuildError(t *testing.T) {
+	deps := Dependencies{
+		Branch:    &mockBranchOps{},
+		Conflict:  &mockConflictOps{},
+		PRBuilder: &mockPRBuilder{buildErr: errors.New("failed to build PR content")},
+		PRCreator: &mockPRCreator{},
+	}
+	config := Config{WorktreeDir: "/tmp"}
+
+	s := NewStacked(deps, config)
+
+	groups := []TaskGroup{
+		{Index: 0, Tasks: []consolidation.CompletedTask{{ID: "task-1", Branch: "feature-1"}}},
+	}
+
+	result, _ := s.Execute(context.Background(), groups)
+
+	if len(result.GroupResults) != 1 {
+		t.Fatalf("Expected 1 group result, got %d", len(result.GroupResults))
+	}
+
+	if result.GroupResults[0].Success {
+		t.Error("Group should have failed due to PR build error")
+	}
+}
+
+func TestStacked_Execute_PRCreateError(t *testing.T) {
+	deps := Dependencies{
+		Branch:    &mockBranchOps{},
+		Conflict:  &mockConflictOps{},
+		PRBuilder: &mockPRBuilder{},
+		PRCreator: &mockPRCreator{createErr: errors.New("failed to create PR")},
+	}
+	config := Config{WorktreeDir: "/tmp"}
+
+	s := NewStacked(deps, config)
+
+	groups := []TaskGroup{
+		{Index: 0, Tasks: []consolidation.CompletedTask{{ID: "task-1", Branch: "feature-1"}}},
+	}
+
+	result, _ := s.Execute(context.Background(), groups)
+
+	if len(result.GroupResults) != 1 {
+		t.Fatalf("Expected 1 group result, got %d", len(result.GroupResults))
+	}
+
+	if result.GroupResults[0].Success {
+		t.Error("Group should have failed due to PR creation error")
+	}
+}
+
+func TestSingle_Execute_WorktreeError(t *testing.T) {
+	deps := Dependencies{
+		Branch: &mockBranchOps{
+			createWorktreeErr: errors.New("failed to create worktree"),
+		},
+		Conflict:  &mockConflictOps{},
+		PRBuilder: &mockPRBuilder{},
+		PRCreator: &mockPRCreator{},
+	}
+	config := Config{WorktreeDir: "/tmp"}
+
+	s := NewSingle(deps, config)
+
+	groups := []TaskGroup{
+		{Index: 0, Tasks: []consolidation.CompletedTask{{ID: "task-1", Branch: "feature-1"}}},
+	}
+
+	_, err := s.Execute(context.Background(), groups)
+	if err == nil {
+		t.Error("Execute() expected error for worktree creation failure")
+	}
+}
+
+func TestSingle_Execute_PushError(t *testing.T) {
+	deps := Dependencies{
+		Branch: &mockBranchOps{
+			pushErr: errors.New("failed to push"),
+		},
+		Conflict:  &mockConflictOps{},
+		PRBuilder: &mockPRBuilder{},
+		PRCreator: &mockPRCreator{},
+	}
+	config := Config{WorktreeDir: "/tmp"}
+
+	s := NewSingle(deps, config)
+
+	groups := []TaskGroup{
+		{Index: 0, Tasks: []consolidation.CompletedTask{{ID: "task-1", Branch: "feature-1"}}},
+	}
+
+	_, err := s.Execute(context.Background(), groups)
+	if err == nil {
+		t.Error("Execute() expected error for push failure")
+	}
+}
+
+func TestSingle_Execute_PRBuildError(t *testing.T) {
+	deps := Dependencies{
+		Branch:    &mockBranchOps{},
+		Conflict:  &mockConflictOps{},
+		PRBuilder: &mockPRBuilder{buildErr: errors.New("failed to build PR content")},
+		PRCreator: &mockPRCreator{},
+	}
+	config := Config{WorktreeDir: "/tmp"}
+
+	s := NewSingle(deps, config)
+
+	groups := []TaskGroup{
+		{Index: 0, Tasks: []consolidation.CompletedTask{{ID: "task-1", Branch: "feature-1"}}},
+	}
+
+	_, err := s.Execute(context.Background(), groups)
+	if err == nil {
+		t.Error("Execute() expected error for PR build failure")
+	}
+}
+
+func TestSingle_Execute_PRCreateError(t *testing.T) {
+	deps := Dependencies{
+		Branch:    &mockBranchOps{},
+		Conflict:  &mockConflictOps{},
+		PRBuilder: &mockPRBuilder{},
+		PRCreator: &mockPRCreator{createErr: errors.New("failed to create PR")},
+	}
+	config := Config{WorktreeDir: "/tmp"}
+
+	s := NewSingle(deps, config)
+
+	groups := []TaskGroup{
+		{Index: 0, Tasks: []consolidation.CompletedTask{{ID: "task-1", Branch: "feature-1"}}},
+	}
+
+	_, err := s.Execute(context.Background(), groups)
+	if err == nil {
+		t.Error("Execute() expected error for PR creation failure")
+	}
+}
+
+func TestStacked_Execute_CreateGroupBranchError(t *testing.T) {
+	deps := Dependencies{
+		Branch: &mockBranchOps{
+			createGroupErr: errors.New("branch already exists"),
+		},
+		Conflict:  &mockConflictOps{},
+		PRBuilder: &mockPRBuilder{},
+		PRCreator: &mockPRCreator{},
+	}
+	config := Config{WorktreeDir: "/tmp"}
+
+	s := NewStacked(deps, config)
+
+	groups := []TaskGroup{
+		{Index: 0, Tasks: []consolidation.CompletedTask{{ID: "task-1", Branch: "feature-1"}}},
+	}
+
+	result, _ := s.Execute(context.Background(), groups)
+
+	if len(result.GroupResults) != 1 {
+		t.Fatalf("Expected 1 group result, got %d", len(result.GroupResults))
+	}
+
+	if result.GroupResults[0].Success {
+		t.Error("Group should have failed due to branch creation error")
+	}
+}
+
+func TestSingle_Execute_CherryPickCheckError(t *testing.T) {
+	deps := Dependencies{
+		Branch: &mockBranchOps{},
+		Conflict: &mockConflictOps{
+			checkErr: errors.New("git error during cherry-pick check"),
+		},
+		PRBuilder: &mockPRBuilder{},
+		PRCreator: &mockPRCreator{},
+	}
+	config := Config{WorktreeDir: "/tmp"}
+
+	s := NewSingle(deps, config)
+
+	groups := []TaskGroup{
+		{Index: 0, Tasks: []consolidation.CompletedTask{{ID: "task-1", Branch: "feature-1"}}},
+	}
+
+	_, err := s.Execute(context.Background(), groups)
+	if err == nil {
+		t.Error("Execute() expected error for cherry-pick check failure")
+	}
+}

--- a/internal/orchestrator/consolidation/types.go
+++ b/internal/orchestrator/consolidation/types.go
@@ -1,0 +1,286 @@
+// Package consolidation provides the consolidation orchestration for combining
+// completed task branches into pull requests. It coordinates branch operations,
+// PR content generation, and conflict handling through a modular architecture.
+package consolidation
+
+import (
+	"context"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator/types"
+)
+
+// Mode defines how work is consolidated after ultraplan execution.
+type Mode string
+
+const (
+	// ModeStacked creates one PR per execution group, stacked on each other.
+	ModeStacked Mode = "stacked"
+	// ModeSingle consolidates all work into a single PR.
+	ModeSingle Mode = "single"
+)
+
+// Phase represents sub-phases within consolidation.
+type Phase string
+
+const (
+	PhaseIdle             Phase = "idle"
+	PhaseDetecting        Phase = "detecting_conflicts"
+	PhaseCreatingBranches Phase = "creating_branches"
+	PhaseMergingTasks     Phase = "merging_tasks"
+	PhasePushing          Phase = "pushing"
+	PhaseCreatingPRs      Phase = "creating_prs"
+	PhasePaused           Phase = "paused"
+	PhaseComplete         Phase = "complete"
+	PhaseFailed           Phase = "failed"
+)
+
+// State tracks the progress of consolidation.
+type State struct {
+	Phase            Phase      `json:"phase"`
+	CurrentGroup     int        `json:"current_group"`
+	TotalGroups      int        `json:"total_groups"`
+	CurrentTask      string     `json:"current_task,omitempty"`
+	GroupBranches    []string   `json:"group_branches"`
+	PRUrls           []string   `json:"pr_urls"`
+	ConflictFiles    []string   `json:"conflict_files,omitempty"`
+	ConflictTaskID   string     `json:"conflict_task_id,omitempty"`
+	ConflictWorktree string     `json:"conflict_worktree,omitempty"`
+	Error            string     `json:"error,omitempty"`
+	StartedAt        *time.Time `json:"started_at,omitempty"`
+	CompletedAt      *time.Time `json:"completed_at,omitempty"`
+}
+
+// HasConflict returns true if consolidation is paused due to a conflict.
+func (s *State) HasConflict() bool {
+	return s.Phase == PhasePaused && len(s.ConflictFiles) > 0
+}
+
+// GroupResult holds the result of consolidating one group.
+type GroupResult struct {
+	GroupIndex   int      `json:"group_index"`
+	TaskIDs      []string `json:"task_ids"`
+	BranchName   string   `json:"branch_name"`
+	CommitCount  int      `json:"commit_count"`
+	FilesChanged []string `json:"files_changed"`
+	PRUrl        string   `json:"pr_url,omitempty"`
+	Success      bool     `json:"success"`
+	Error        string   `json:"error,omitempty"`
+}
+
+// Config holds configuration for branch consolidation.
+type Config struct {
+	Mode           Mode
+	BranchPrefix   string
+	CreateDraftPRs bool
+	PRLabels       []string
+}
+
+// EventType represents events during consolidation.
+type EventType string
+
+const (
+	EventStarted       EventType = "consolidation_started"
+	EventGroupStarted  EventType = "consolidation_group_started"
+	EventTaskMerging   EventType = "consolidation_task_merging"
+	EventTaskMerged    EventType = "consolidation_task_merged"
+	EventGroupComplete EventType = "consolidation_group_complete"
+	EventPRCreating    EventType = "consolidation_pr_creating"
+	EventPRCreated     EventType = "consolidation_pr_created"
+	EventConflict      EventType = "consolidation_conflict"
+	EventComplete      EventType = "consolidation_complete"
+	EventFailed        EventType = "consolidation_failed"
+)
+
+// Event represents an event during consolidation.
+type Event struct {
+	Type      EventType `json:"type"`
+	GroupIdx  int       `json:"group_idx,omitempty"`
+	TaskID    string    `json:"task_id,omitempty"`
+	Message   string    `json:"message,omitempty"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// PRContent holds PR title and body.
+type PRContent struct {
+	Title      string
+	Body       string
+	Labels     []string
+	Assignees  []string
+	BaseBranch string
+	HeadBranch string
+}
+
+// CompletedTask represents a task that has been completed and is ready for consolidation.
+type CompletedTask struct {
+	ID           string
+	Title        string
+	Branch       string
+	WorktreePath string
+	Files        []string
+	Description  string
+	Completion   *types.TaskCompletionFile
+}
+
+// ConflictInfo holds information about a merge conflict.
+type ConflictInfo struct {
+	TaskID       string   `json:"task_id"`
+	TaskTitle    string   `json:"task_title,omitempty"`
+	Branch       string   `json:"branch"`
+	Files        []string `json:"files"`
+	WorktreePath string   `json:"worktree_path"`
+}
+
+// Result holds the overall result of a consolidation run.
+type Result struct {
+	PRs            []PRInfo
+	MergedBranches []string
+	Conflicts      []ConflictInfo
+	Duration       time.Duration
+}
+
+// PRInfo holds information about a created PR.
+type PRInfo struct {
+	URL        string `json:"url"`
+	Title      string `json:"title"`
+	GroupIndex int    `json:"group_index"`
+}
+
+// TaskGroup represents a group of tasks to be consolidated together.
+// Tasks within a group are executed together and may be combined into
+// a single PR (single mode) or stacked PRs (stacked mode).
+type TaskGroup struct {
+	Index int
+	Tasks []CompletedTask
+}
+
+// StrategyResult holds the result of a consolidation strategy execution.
+type StrategyResult struct {
+	PRs          []PRInfo
+	GroupResults []GroupResult
+	TotalCommits int
+	FilesChanged []string
+	Duration     time.Duration
+	Error        error
+}
+
+// Strategy defines how tasks are consolidated into PRs.
+type Strategy interface {
+	// Execute runs the consolidation strategy on the given task groups.
+	Execute(ctx context.Context, groups []TaskGroup) (*StrategyResult, error)
+
+	// Name returns the strategy name for logging.
+	Name() string
+
+	// SupportsParallel indicates if tasks can be processed in parallel.
+	SupportsParallel() bool
+}
+
+// PRBuilder generates PR content from completed tasks.
+type PRBuilder interface {
+	// Build generates PR content from the given tasks.
+	Build(tasks []CompletedTask, opts PRBuildOptions) (*PRContent, error)
+
+	// BuildTitle generates a PR title from tasks.
+	BuildTitle(tasks []CompletedTask, opts PRBuildOptions) string
+
+	// BuildBody generates a PR body from tasks.
+	BuildBody(tasks []CompletedTask, opts PRBuildOptions) string
+
+	// BuildLabels determines appropriate labels for the PR.
+	BuildLabels(tasks []CompletedTask, opts PRBuildOptions) []string
+}
+
+// PRBuildOptions provides options for building PR content.
+type PRBuildOptions struct {
+	Mode            Mode
+	GroupIndex      int
+	TotalGroups     int
+	Objective       string
+	SynthesisNotes  string
+	Recommendations []string
+	FilesChanged    []string
+	BaseBranch      string
+	HeadBranch      string
+}
+
+// BranchManager handles git branch operations for consolidation.
+type BranchManager interface {
+	// FindMainBranch returns the name of the main branch (main or master).
+	FindMainBranch(ctx context.Context) string
+
+	// CreateGroupBranch creates a branch for a consolidation group.
+	CreateGroupBranch(ctx context.Context, groupIdx int, baseBranch string) (string, error)
+
+	// CreateSingleBranch creates a branch for single PR mode consolidation.
+	CreateSingleBranch(ctx context.Context, baseBranch string) (string, error)
+
+	// CreateWorktree creates a worktree for the given branch.
+	CreateWorktree(ctx context.Context, path, branch string) error
+
+	// CherryPickBranch cherry-picks commits from source branch into the worktree.
+	CherryPickBranch(ctx context.Context, worktreePath, sourceBranch string) error
+
+	// GetChangedFiles returns files changed in the worktree compared to main.
+	GetChangedFiles(ctx context.Context, worktreePath string) ([]string, error)
+
+	// GetConflictingFiles returns files with merge conflicts.
+	GetConflictingFiles(ctx context.Context, worktreePath string) ([]string, error)
+
+	// CountCommitsBetween returns the number of commits between base and head.
+	CountCommitsBetween(ctx context.Context, worktreePath, baseBranch, headBranch string) (int, error)
+
+	// Push pushes the branch to the remote.
+	Push(ctx context.Context, worktreePath string, force bool) error
+
+	// RemoveWorktree removes a worktree.
+	RemoveWorktree(ctx context.Context, path string) error
+
+	// DeleteBranch deletes a branch.
+	DeleteBranch(ctx context.Context, branch string) error
+
+	// ContinueCherryPick continues a cherry-pick after conflict resolution.
+	ContinueCherryPick(ctx context.Context, worktreePath string) error
+
+	// AbortCherryPick aborts an in-progress cherry-pick.
+	AbortCherryPick(ctx context.Context, worktreePath string) error
+}
+
+// ConflictManager handles merge conflict detection and resolution.
+type ConflictManager interface {
+	// CheckCherryPick attempts a cherry-pick and reports any conflicts.
+	// Returns nil if the cherry-pick succeeds, or a ConflictInfo if conflicts occur.
+	CheckCherryPick(ctx context.Context, worktreePath, sourceBranch, taskID, taskTitle string) (*ConflictInfo, error)
+
+	// AbortCherryPick aborts an in-progress cherry-pick operation.
+	AbortCherryPick(ctx context.Context, worktreePath string) error
+
+	// ContinueCherryPick continues a cherry-pick after conflicts have been resolved.
+	ContinueCherryPick(ctx context.Context, worktreePath string) error
+
+	// GetConflictingFiles returns the files with conflicts in the given worktree.
+	GetConflictingFiles(ctx context.Context, worktreePath string) ([]string, error)
+}
+
+// EventEmitter notifies listeners of consolidation progress.
+type EventEmitter interface {
+	// Emit sends an event to all listeners.
+	Emit(event Event)
+}
+
+// Logger provides structured logging for consolidation operations.
+type Logger interface {
+	Debug(msg string, keysAndValues ...any)
+	Info(msg string, keysAndValues ...any)
+	Warn(msg string, keysAndValues ...any)
+	Error(msg string, keysAndValues ...any)
+}
+
+// GitExecutor executes git commands.
+type GitExecutor interface {
+	// Run executes a git command in the repository root.
+	Run(ctx context.Context, args ...string) (string, error)
+
+	// RunInDir executes a git command in the specified directory.
+	RunInDir(ctx context.Context, dir string, args ...string) (string, error)
+}

--- a/internal/orchestrator/consolidation/types_test.go
+++ b/internal/orchestrator/consolidation/types_test.go
@@ -1,0 +1,132 @@
+package consolidation
+
+import (
+	"testing"
+)
+
+func TestState_HasConflict(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    State
+		expected bool
+	}{
+		{
+			name: "paused with conflict files",
+			state: State{
+				Phase:         PhasePaused,
+				ConflictFiles: []string{"file1.go", "file2.go"},
+			},
+			expected: true,
+		},
+		{
+			name: "paused without conflict files",
+			state: State{
+				Phase:         PhasePaused,
+				ConflictFiles: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "paused with empty conflict files",
+			state: State{
+				Phase:         PhasePaused,
+				ConflictFiles: []string{},
+			},
+			expected: false,
+		},
+		{
+			name: "not paused with conflict files",
+			state: State{
+				Phase:         PhaseMergingTasks,
+				ConflictFiles: []string{"file1.go"},
+			},
+			expected: false,
+		},
+		{
+			name: "idle state",
+			state: State{
+				Phase: PhaseIdle,
+			},
+			expected: false,
+		},
+		{
+			name: "complete state",
+			state: State{
+				Phase: PhaseComplete,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.state.HasConflict()
+			if got != tt.expected {
+				t.Errorf("State.HasConflict() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMode_Values(t *testing.T) {
+	// Verify mode constants have expected string values
+	if ModeStacked != "stacked" {
+		t.Errorf("ModeStacked = %q, want %q", ModeStacked, "stacked")
+	}
+	if ModeSingle != "single" {
+		t.Errorf("ModeSingle = %q, want %q", ModeSingle, "single")
+	}
+}
+
+func TestPhase_Values(t *testing.T) {
+	// Verify all phases have unique non-empty values
+	phases := []Phase{
+		PhaseIdle,
+		PhaseDetecting,
+		PhaseCreatingBranches,
+		PhaseMergingTasks,
+		PhasePushing,
+		PhaseCreatingPRs,
+		PhasePaused,
+		PhaseComplete,
+		PhaseFailed,
+	}
+
+	seen := make(map[Phase]bool)
+	for _, p := range phases {
+		if p == "" {
+			t.Errorf("Phase constant has empty string value")
+		}
+		if seen[p] {
+			t.Errorf("Duplicate phase value: %q", p)
+		}
+		seen[p] = true
+	}
+}
+
+func TestEventType_Values(t *testing.T) {
+	// Verify all event types have unique non-empty values
+	events := []EventType{
+		EventStarted,
+		EventGroupStarted,
+		EventTaskMerging,
+		EventTaskMerged,
+		EventGroupComplete,
+		EventPRCreating,
+		EventPRCreated,
+		EventConflict,
+		EventComplete,
+		EventFailed,
+	}
+
+	seen := make(map[EventType]bool)
+	for _, e := range events {
+		if e == "" {
+			t.Errorf("EventType constant has empty string value")
+		}
+		if seen[e] {
+			t.Errorf("Duplicate event type value: %q", e)
+		}
+		seen[e] = true
+	}
+}


### PR DESCRIPTION
## Summary

- Extract consolidation logic from single file into modular package structure
- Add comprehensive tests achieving 93-100% coverage per subpackage
- Implement proper error logging for cleanup and metadata operations
- Remove unused fields and code paths

## Changes

### Package Structure

Created `internal/orchestrator/consolidation/` with:

- **types.go** - Shared types, interfaces, and compile-time checks
- **branch/** - Git branch operations with `NamingStrategy` for consistent branch naming
- **conflict/** - Merge conflict detection and handling via `Detector`
- **prbuilder/** - PR content generation (titles, bodies, labels) - pure data transformation
- **strategy/** - `Stacked` and `Single` consolidation strategies with common `Base`

### Key Design Decisions

1. **Interface Segregation** - Small, focused interfaces defined where used (e.g., `BranchOps`, `ConflictOps`, `PRBuilderOps`)
2. **Dependency Injection** - `Dependencies` struct allows easy mocking for tests
3. **Compile-time Checks** - `var _ Interface = (*Type)(nil)` patterns prevent interface drift
4. **Proper Error Logging** - Added logging for cleanup operations and metadata retrieval failures

### Test Coverage

| Package | Coverage |
|---------|----------|
| consolidation | 100% |
| branch | 98.2% |
| conflict | 100% |
| prbuilder | 100% |
| strategy | 93.5% |

## Test plan

- [x] All tests pass: `go test ./internal/orchestrator/consolidation/...`
- [x] Build passes: `go build ./...`
- [x] Linting passes: `go vet ./...`
- [x] Formatting is correct: `gofmt -d .`