### PR TITLE
Fix adversarial increment filename for consistent naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Unified Multi-Workflow Header** - The header now displays status indicators for all active workflow types (UltraPlan, TripleShot, Adversarial) simultaneously. Previously, the header used exclusive priority-based selection, which meant users lost visibility into other running workflows when multiple task types were active.
 
+- **Adversarial Increment Filename** - Renamed the implementer's sentinel file from `.claudio-adversarial-increment.json` to `.claudio-adversarial-incremental.json` for consistent naming with agent search patterns.
+
 ## [0.11.0] - 2026-01-18
 
 This release brings **Major Architecture Refactoring & Platform Guides** - a comprehensive refactoring of the Coordinator into a thin facade with specialized orchestrators, plus detailed platform-specific documentation for all major development environments.

--- a/internal/orchestrator/workflows/adversarial/session_test.go
+++ b/internal/orchestrator/workflows/adversarial/session_test.go
@@ -323,7 +323,7 @@ func TestManager_Session(t *testing.T) {
 
 func TestIncrementFilePath(t *testing.T) {
 	path := IncrementFilePath("/tmp/worktree")
-	expected := "/tmp/worktree/.claudio-adversarial-increment.json"
+	expected := "/tmp/worktree/.claudio-adversarial-incremental.json"
 	if path != expected {
 		t.Errorf("IncrementFilePath() = %q, want %q", path, expected)
 	}

--- a/internal/orchestrator/workflows/adversarial/types.go
+++ b/internal/orchestrator/workflows/adversarial/types.go
@@ -56,7 +56,7 @@ type Round struct {
 }
 
 // IncrementFileName is the sentinel file the implementer writes when ready for review
-const IncrementFileName = ".claudio-adversarial-increment.json"
+const IncrementFileName = ".claudio-adversarial-incremental.json"
 
 // IncrementFile represents the implementer's work submission
 type IncrementFile struct {


### PR DESCRIPTION
## Summary

- Rename the implementer's sentinel file from `.claudio-adversarial-increment.json` to `.claudio-adversarial-incremental.json`
- Agents were searching for `*incremental*` patterns but the file used "increment", causing discovery failures

## Test plan

- [x] Verified tests pass: `go test ./internal/orchestrator/workflows/adversarial/...`
- [x] Verified build succeeds: `go build ./...`
- [ ] Test adversarial workflow in a worktree to confirm agents can find the file