### PR TITLE
Use system alert sound instead of hardcoded chime

### DIFF
--- a/.claude-prompt
+++ b/.claude-prompt
@@ -1,0 +1,1 @@
+Currently, we play a "Chime" sound from time to time. We should defer to the system sound, not a chime.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **System Alert Sound** - Notification sound now uses the macOS system alert sound (configured in System Settings > Sound) instead of the hardcoded Glass.aiff chime. Users who prefer a specific sound can still set `ultraplan.notifications.sound_path` to a custom audio file.
+
 - **Consolidation Module Extraction** - Refactored `internal/orchestrator/consolidation.go` into a modular package structure:
   - Created `internal/orchestrator/consolidation/` package with shared types and interfaces
   - Extracted `prbuilder/` subpackage for PR content generation (pure data transformation)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,7 +162,7 @@ type NotificationConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 	// UseSound plays system sound on macOS in addition to bell (default: false)
 	UseSound bool `mapstructure:"use_sound"`
-	// SoundPath custom sound file path (macOS only, default: system Glass sound)
+	// SoundPath custom sound file path (macOS only, default: system alert sound)
 	SoundPath string `mapstructure:"sound_path"`
 }
 

--- a/internal/tui/msg/commands.go
+++ b/internal/tui/msg/commands.go
@@ -57,10 +57,12 @@ func NotifyUser() tea.Cmd {
 		if runtime.GOOS == "darwin" && viper.GetBool("ultraplan.notifications.use_sound") {
 			soundPath := viper.GetString("ultraplan.notifications.sound_path")
 			if soundPath == "" {
-				soundPath = "/System/Library/Sounds/Glass.aiff"
+				// Use system alert sound (user's configured sound in System Settings)
+				_ = exec.Command("osascript", "-e", "beep").Start()
+			} else {
+				// Use custom sound file
+				_ = exec.Command("afplay", soundPath).Start()
 			}
-			// Start in background so it doesn't block
-			_ = exec.Command("afplay", soundPath).Start()
 		}
 		return nil
 	}

--- a/internal/tui/msg/commands_test.go
+++ b/internal/tui/msg/commands_test.go
@@ -312,7 +312,7 @@ func TestNotifyUserWithSoundPath(t *testing.T) {
 		}
 	})
 
-	t.Run("empty sound path uses default", func(t *testing.T) {
+	t.Run("empty sound path uses system alert sound", func(t *testing.T) {
 		viper.Set("ultraplan.notifications.enabled", true)
 		viper.Set("ultraplan.notifications.use_sound", true)
 		viper.Set("ultraplan.notifications.sound_path", "")
@@ -322,7 +322,7 @@ func TestNotifyUserWithSoundPath(t *testing.T) {
 			t.Fatal("NotifyUser() returned nil command")
 		}
 
-		// Execute - should use default Glass.aiff path
+		// Execute - should use system alert sound via osascript
 		result := cmd()
 		if result != nil {
 			t.Errorf("NotifyUser() returned %v, want nil", result)


### PR DESCRIPTION
## Summary

- Changes notification sound from hardcoded `/System/Library/Sounds/Glass.aiff` to the user's configured macOS system alert sound
- Uses `osascript -e 'beep'` which respects user preferences set in System Settings > Sound
- Preserves custom sound path option for users who want a specific audio file

## Test plan

- [ ] Enable sound notifications: `ultraplan.notifications.use_sound: true`
- [ ] Verify notification plays the system alert sound (same sound as other macOS alerts)
- [ ] Set a custom `sound_path` and verify it plays that file instead
- [ ] Run `go test ./internal/tui/msg/...` - all tests pass