### PR TITLE
Collapse multiplan planner instances to sub-group when manager starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated CLI reference with adversarial command documentation
   - Updated guide index with links to new guides
 
+- **MultiPlan Planner Collapse** - When the plan manager/evaluator starts in a MultiPlan session, the three planner instances are automatically collapsed into a sub-group called "Planning Instances". This keeps the sidebar clean during evaluation while preserving access to planner instances if needed. The sub-group is auto-collapsed in the UI but can be expanded to view the individual planners.
+
 ### Changed
 
 - **System Alert Sound** - Notification sound now uses the macOS system alert sound (configured in System Settings > Sound) instead of the hardcoded Glass.aiff chime. Users who prefer a specific sound can still set `ultraplan.notifications.sound_path` to a custom audio file.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -125,6 +125,10 @@ type InlinePlanSession struct {
 
 	// AwaitingPlanManager indicates we're waiting for the plan manager to complete
 	AwaitingPlanManager bool
+
+	// PlannerSubGroupID is the ID of the sub-group containing planner instances
+	// Set when the plan manager starts and planners are collapsed into a sub-group
+	PlannerSubGroupID string
 }
 
 // InlinePlanState holds the state for inline plan mode.


### PR DESCRIPTION
## Summary

- When the plan manager/evaluator starts running in a MultiPlan session, the three planner instances are now automatically collapsed into a sub-group called "Planning Instances"
- This keeps the sidebar clean during evaluation while preserving access to planner instances if needed
- The sub-group is auto-collapsed in the UI but can be expanded to view individual planners

## Changes

- Add `collapsePlannersToSubGroup` function in `inlineplan.go` that:
  - Creates a sub-group named "Planning Instances" 
  - Moves planner instances from main group to sub-group (non-destructive)
  - Auto-collapses the sub-group in the UI via `groupViewState`
  - Includes proper warning-level logging for unexpected states
- Add `PlannerSubGroupID` field to `InlinePlanSession` for tracking
- 11 comprehensive unit tests covering all edge cases:
  - Nil session, empty GroupID, no planner IDs
  - Nil orchestrator session, group not found
  - Sub-group creation, instance movement
  - UI auto-collapse, existing state preservation
  - Planner not in main group scenario

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New tests pass (`go test ./internal/tui/... -run TestCollapsePlannersToSubGroup -v`)
- [x] Build succeeds (`go build ./...`)
- [x] Linting passes (`go vet ./...`)
- [x] Code formatted (`gofmt -d .`)
- [ ] Manual testing: Run `:multiplan` command and verify planners collapse when manager starts