### PR TITLE
Preserve sidebar view mode when toggling dependency graph view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Adversarial Increment Filename** - Renamed the implementer's sentinel file from `.claudio-adversarial-increment.json` to `.claudio-adversarial-incremental.json` for consistent naming with agent search patterns.
 
+- **View Mode Preservation** - Switching from dependency graph view back to list view now correctly restores the previous sidebar mode (flat or grouped). Previously, toggling the dependency view always returned to flat mode, causing users to lose their grouped view state.
+
 ## [0.11.0] - 2026-01-18
 
 This release brings **Major Architecture Refactoring & Platform Guides** - a comprehensive refactoring of the Coordinator into a thin facade with specialized orchestrators, plus detailed platform-specific documentation for all major development environments.

--- a/internal/tui/inlineplan.go
+++ b/internal/tui/inlineplan.go
@@ -251,16 +251,22 @@ func (m *Model) toggleGroupedView() {
 	}
 }
 
-// toggleGraphView toggles between the dependency graph view and flat view.
+// toggleGraphView toggles between the dependency graph view and the previous view mode.
 // The graph view displays instances organized by their dependency levels.
+// When exiting graph view, it restores the previous mode (flat or grouped).
 func (m *Model) toggleGraphView() {
 	switch m.sidebarMode {
 	case view.SidebarModeGraph:
-		// Switch back to flat mode
-		m.sidebarMode = view.SidebarModeFlat
-		m.infoMessage = "List view enabled"
+		// Switch back to previous mode (flat or grouped)
+		m.sidebarMode = m.previousSidebarMode
+		if m.sidebarMode == view.SidebarModeGrouped {
+			m.infoMessage = "Grouped view enabled"
+		} else {
+			m.infoMessage = "List view enabled"
+		}
 	default:
-		// Switch to graph mode
+		// Save current mode and switch to graph mode
+		m.previousSidebarMode = m.sidebarMode
 		m.sidebarMode = view.SidebarModeGraph
 		m.infoMessage = "Dependency graph view enabled"
 	}

--- a/internal/tui/inlineplan_test.go
+++ b/internal/tui/inlineplan_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Iron-Ham/claudio/internal/orchestrator"
 	tuimsg "github.com/Iron-Ham/claudio/internal/tui/msg"
+	"github.com/Iron-Ham/claudio/internal/tui/view"
 )
 
 // Helper to create a session-based InlinePlanState for tests
@@ -446,5 +447,93 @@ func TestInlinePlanState_GetAwaitingObjectiveSession(t *testing.T) {
 	result := state.GetAwaitingObjectiveSession()
 	if result != session2 {
 		t.Error("should return session awaiting objective")
+	}
+}
+
+func TestToggleGraphView_FromFlatToGraph(t *testing.T) {
+	m := &Model{
+		sidebarMode: view.SidebarModeFlat,
+	}
+
+	m.toggleGraphView()
+
+	if m.sidebarMode != view.SidebarModeGraph {
+		t.Errorf("sidebarMode = %v, want %v", m.sidebarMode, view.SidebarModeGraph)
+	}
+	if m.previousSidebarMode != view.SidebarModeFlat {
+		t.Errorf("previousSidebarMode = %v, want %v", m.previousSidebarMode, view.SidebarModeFlat)
+	}
+	if m.infoMessage != "Dependency graph view enabled" {
+		t.Errorf("infoMessage = %q, want %q", m.infoMessage, "Dependency graph view enabled")
+	}
+}
+
+func TestToggleGraphView_FromGroupedToGraph(t *testing.T) {
+	m := &Model{
+		sidebarMode: view.SidebarModeGrouped,
+	}
+
+	m.toggleGraphView()
+
+	if m.sidebarMode != view.SidebarModeGraph {
+		t.Errorf("sidebarMode = %v, want %v", m.sidebarMode, view.SidebarModeGraph)
+	}
+	if m.previousSidebarMode != view.SidebarModeGrouped {
+		t.Errorf("previousSidebarMode = %v, want %v", m.previousSidebarMode, view.SidebarModeGrouped)
+	}
+	if m.infoMessage != "Dependency graph view enabled" {
+		t.Errorf("infoMessage = %q, want %q", m.infoMessage, "Dependency graph view enabled")
+	}
+}
+
+func TestToggleGraphView_FromGraphBackToFlat(t *testing.T) {
+	m := &Model{
+		sidebarMode:         view.SidebarModeGraph,
+		previousSidebarMode: view.SidebarModeFlat,
+	}
+
+	m.toggleGraphView()
+
+	if m.sidebarMode != view.SidebarModeFlat {
+		t.Errorf("sidebarMode = %v, want %v", m.sidebarMode, view.SidebarModeFlat)
+	}
+	if m.infoMessage != "List view enabled" {
+		t.Errorf("infoMessage = %q, want %q", m.infoMessage, "List view enabled")
+	}
+}
+
+func TestToggleGraphView_FromGraphBackToGrouped(t *testing.T) {
+	m := &Model{
+		sidebarMode:         view.SidebarModeGraph,
+		previousSidebarMode: view.SidebarModeGrouped,
+	}
+
+	m.toggleGraphView()
+
+	if m.sidebarMode != view.SidebarModeGrouped {
+		t.Errorf("sidebarMode = %v, want %v", m.sidebarMode, view.SidebarModeGrouped)
+	}
+	if m.infoMessage != "Grouped view enabled" {
+		t.Errorf("infoMessage = %q, want %q", m.infoMessage, "Grouped view enabled")
+	}
+}
+
+func TestToggleGraphView_RoundTripFromGrouped(t *testing.T) {
+	// This test verifies the full round-trip: grouped -> graph -> grouped
+	// This is the bug scenario reported by the user
+	m := &Model{
+		sidebarMode: view.SidebarModeGrouped,
+	}
+
+	// Toggle to graph view
+	m.toggleGraphView()
+	if m.sidebarMode != view.SidebarModeGraph {
+		t.Errorf("after first toggle: sidebarMode = %v, want %v", m.sidebarMode, view.SidebarModeGraph)
+	}
+
+	// Toggle back - should return to grouped, not flat
+	m.toggleGraphView()
+	if m.sidebarMode != view.SidebarModeGrouped {
+		t.Errorf("after second toggle: sidebarMode = %v, want %v (groups should be preserved)", m.sidebarMode, view.SidebarModeGrouped)
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -331,8 +331,9 @@ type Model struct {
 	sidebarScrollOffset int // Index of the first visible instance in sidebar
 
 	// Grouped sidebar view state
-	groupViewState *view.GroupViewState // State for group collapse/selection (nil until grouped mode is used)
-	sidebarMode    view.SidebarMode     // Current sidebar display mode (flat or grouped)
+	groupViewState      *view.GroupViewState // State for group collapse/selection (nil until grouped mode is used)
+	sidebarMode         view.SidebarMode     // Current sidebar display mode (flat or grouped)
+	previousSidebarMode view.SidebarMode     // Mode to restore when exiting graph view
 
 	// Resource metrics display
 	showStats bool // When true, show the stats panel


### PR DESCRIPTION
## Summary

- Fixes a bug where switching from dependency graph view back to list view always returned to flat mode
- Groups now persist when toggling dependency view on/off - previously they would seemingly disappear
- Adds `previousSidebarMode` field to track the mode before entering graph view

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `gofmt -d .` shows no formatting issues
- [ ] Manual test: Create groups, switch to dependency view with `d`, switch back - groups should remain
- [ ] Manual test: Start in flat mode, switch to dependency view, switch back - should return to flat mode