### PR TITLE
Fix documentation bullet rendering in tutorial lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Semantic Validation**: Ensures non-empty values for required fields when status is "ready_for_review" (summary, approach, files_modified), while allowing empty fields for "failed" status
   - **Enhanced Prompts**: Updated implementer prompt with explicit field requirements, type specifications, and a "COMMON MISTAKES TO AVOID" section to prevent issues at the source
 
+- **Documentation Bullet Rendering** - Fixed tutorial section lists in the home page not rendering bullets correctly due to missing blank lines between bold headers and list items.
+
 ## [0.11.0] - 2026-01-18
 
 This release brings **Major Architecture Refactoring & Platform Guides** - a comprehensive refactoring of the Coordinator into a thin facade with specialized orchestrators, plus detailed platform-specific documentation for all major development environments.

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,12 +61,14 @@ Comprehensive documentation covering concepts, workflows, and configuration.
 Step-by-step guides for common workflows.
 
 **Workflow Tutorials:**
+
 - [Quick Start](tutorials/quick-start.md) - 5-minute introduction
 - [Feature Development](tutorials/feature-development.md) - Build features in parallel
 - [Code Review Workflow](tutorials/code-review-workflow.md) - Parallel reviews
 - [Large Refactor](tutorials/large-refactor.md) - Coordinate major changes
 
 **Platform-Specific Guides:**
+
 - [Web Development](tutorials/web-development.md) - Node.js, React, Vue, Angular
 - [Go Development](tutorials/go-development.md) - Go modules and workspaces
 - [Python Development](tutorials/python-development.md) - Django, Flask, FastAPI
@@ -75,6 +77,7 @@ Step-by-step guides for common workflows.
 - [Android Development](tutorials/android-development.md) - Gradle and Kotlin
 
 **Architecture Guides:**
+
 - [Full-Stack Development](tutorials/fullstack-development.md) - Docker and microservices
 - [Monorepo Development](tutorials/monorepo-development.md) - Turborepo, Nx, sparse checkout
 - [Data Science & ML](tutorials/datascience-development.md) - Jupyter, experiments, GPUs


### PR DESCRIPTION
## Summary
- Fixed tutorial section lists in the docs home page not rendering bullets correctly

The bold section headers (Workflow Tutorials, Platform-Specific Guides, Architecture Guides) were immediately followed by list items without a blank line, causing markdown parsers to treat the `-` characters as literal text rather than list markers.

## Test plan
- [ ] Verify bullets render correctly on the docs site