### PR TITLE
Fix plan file path when starting from subdirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Plan File Path in Subdirectories** - Fixed planning coordinators writing `.claudio-plan.json` to incorrect locations when Claudio is started from a repository subdirectory. The planning prompts now explicitly instruct Claude to write the plan file at the repository root, preventing path resolution issues during multi-pass planning.
+
 ## [0.12.0] - 2026-01-21
 
 This release brings **Dependency Graph View & Orchestration Guides** - a new DAG-based sidebar visualization for understanding task dependencies at a glance, plus comprehensive documentation for all orchestration modes.

--- a/internal/orchestrator/prompt/planning.go
+++ b/internal/orchestrator/prompt/planning.go
@@ -227,7 +227,7 @@ You must either:
 
 ## Output
 
-Write your final plan to ` + "`" + PlanFileName + "`" + ` using the JSON schema below.
+Write your final plan to ` + "`" + PlanFileName + "`" + ` **at the repository root** (not in any subdirectory) using the JSON schema below.
 
 ### Plan JSON Schema
 

--- a/internal/orchestrator/ultraplan.go
+++ b/internal/orchestrator/ultraplan.go
@@ -1434,7 +1434,7 @@ const PlanningPromptTemplate = `You are a senior software architect planning a c
 
 1. **Explore** the codebase to understand its structure and patterns
 2. **Decompose** the objective into discrete, parallelizable tasks
-3. **Write your plan** to the file ` + "`" + PlanFileName + "`" + ` in JSON format
+3. **Write your plan** to ` + "`" + PlanFileName + "`" + ` **at the repository root** (not in any subdirectory) in JSON format
 
 ## Plan JSON Schema
 

--- a/internal/ultraplan/planner.go
+++ b/internal/ultraplan/planner.go
@@ -17,7 +17,7 @@ const PlanningPromptTemplate = `You are a senior software architect planning a c
 
 1. **Explore** the codebase to understand its structure and patterns
 2. **Decompose** the objective into discrete, parallelizable tasks
-3. **Write your plan** to the file ` + "`" + PlanFileName + "`" + ` in JSON format
+3. **Write your plan** to ` + "`" + PlanFileName + "`" + ` **at the repository root** (not in any subdirectory) in JSON format
 
 ## Plan JSON Schema
 


### PR DESCRIPTION
## Summary

- Fixed planning coordinators writing `.claudio-plan.json` to incorrect locations when Claudio is started from a repository subdirectory
- Updated planning prompts to explicitly instruct Claude to write the plan file at the repository root

## Problem

When Claudio is started from a subdirectory (e.g., `mail-ios` within a larger repo), the planning agents would sometimes write their `.claudio-plan.json` files to the wrong location. This caused the multi-pass planning detection to fail because it couldn't find the plan files at the expected worktree root paths.

**Example of the bug:**
```
✓ .../worktrees/2fc8c261/.claudio-plan.json
✓ .../worktrees/778689c8/.claudio-plan.json
✗ .../worktrees/e4b7ed28/mail-ios/.claudio-plan.json  ← written to subdirectory instead of root
```

## Solution

Updated the planning prompts to explicitly specify that the plan file should be written **at the repository root**, not in any subdirectory. This is a prompt engineering fix - the path resolution logic was correct, but the agent wasn't being told the correct location.

**Change:**
```diff
- 3. **Write your plan** to the file `.claudio-plan.json` in JSON format
+ 3. **Write your plan** to `.claudio-plan.json` **at the repository root** (not in any subdirectory) in JSON format
```

## Test plan

- [x] Build succeeds: `go build ./...`
- [x] All tests pass: `go test ./...`
- [x] Linting passes: `go vet ./...`
- [ ] Manual test: Start multiplan from a subdirectory and verify all plan files are written to worktree roots