### PR TITLE
Prevent TUI freeze when terminal pane tmux capture times out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Plan File Path in Subdirectories** - Fixed planning coordinators writing `.claudio-plan.json` to incorrect locations when Claudio is started from a repository subdirectory. The planning prompts now explicitly instruct Claude to write the plan file at the repository root, preventing path resolution issues during multi-pass planning.
 
+- **Terminal Pane Freeze** - Fixed an issue where the TUI could freeze when the terminal pane was visible and tmux became unresponsive. The `capture-pane` command now has a 500ms timeout, preventing the entire event loop from blocking. When the capture times out, the previous output is preserved so the display doesn't go blank.
+
 ## [0.12.0] - 2026-01-21
 
 This release brings **Dependency Graph View & Orchestration Guides** - a new DAG-based sidebar visualization for understanding task dependencies at a glance, plus comprehensive documentation for all orchestration modes.


### PR DESCRIPTION
## Summary

- Fixed an issue where the TUI could freeze when the terminal pane was visible and tmux became unresponsive
- The `capture-pane` command now has a 500ms timeout, preventing the entire event loop from blocking
- When the capture times out, the previous output is preserved so the display doesn't go blank

## Changes

### New Error Types
- `ErrCaptureTimeout` - returned when capture-pane command times out
- `ErrCaptureKilled` - returned when the process is killed (exit code -1)
- `ErrCaptureCancelled` - defensive code for cancelled context (future-proofing)

### Manager.UpdateOutput Improvements
- Uses `errors.Is()` for consistent error comparison
- Logs expected interruptions (timeout, cancelled, killed) at debug level
- Logs unexpected errors at warn level
- Adds fallback `log.Printf` when no logger is configured (unexpected errors should never be silent)
- Preserves previous output on any capture failure

### Test Improvements
- Fixed `TestUpdateOutput_PreservesPreviousOnError` to properly exercise the error handling path
- Added tests for `ErrCaptureTimeout` and `ErrCaptureKilled` paths
- Tests use real timeout behavior (500ms wait) to validate actual code paths

## Test plan

- [x] All existing tests pass
- [x] New tests verify specific error types are returned
- [x] `TestUpdateOutput_PreservesPreviousOnError` now properly exercises the timeout path
- [x] Build passes with `go build ./...`
- [x] Formatting passes with `gofmt -d .`
- [x] Linting passes with `go vet ./...`