### PR TITLE
Fix sidebar UI duplication during overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Sidebar UI Duplication** - Fixed a bug where sidebar content could be duplicated or overflow when adding/removing tasks or groups. The issue was caused by a mismatch between item count and actual rendered line count in the sidebar. The sidebar now properly tracks actual line usage, preventing content from overflowing its container and causing visual artifacts.
+
 - **Plan File Path in Subdirectories** - Fixed planning coordinators writing `.claudio-plan.json` to incorrect locations when Claudio is started from a repository subdirectory. The planning prompts now explicitly instruct Claude to write the plan file at the repository root, preventing path resolution issues during multi-pass planning.
 
 - **Terminal Pane Freeze** - Fixed an issue where the TUI could freeze when the terminal pane was visible and tmux became unresponsive. The `capture-pane` command now has a 500ms timeout, preventing the entire event loop from blocking. When the capture times out, the previous output is preserved so the display doesn't go blank.


### PR DESCRIPTION
## Summary

- Fix bug where sidebar content could be duplicated when items overflow available height
- Track actual line usage instead of item counts during rendering
- Add 6 comprehensive regression tests for overflow scenarios

## Problem

The sidebar was using a slot-based calculation that assumed fixed-size items, but instances and group headers render as multi-line content (2-3 lines each). This mismatch caused content duplication when there were more items than could fit.

## Solution

Track actual line usage during rendering by counting newlines in rendered content:

- `dashboard.go`: Track `linesUsed` and `lastRenderedIdx`, break loop when space runs out
- `sidebar.go`: Same pattern for grouped sidebar mode  
- `model.go`: Update `ensureActiveVisible` to estimate lines per item for scroll positioning

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New regression tests verify no duplication in:
  - Grouped mode with overflow
  - Flat mode with overflow
  - Scroll offset scenarios
  - Collapsed group scenarios
  - Extremely small heights
- [x] Formatting and linting pass (`gofmt`, `go vet`)