### PR TITLE
Fix ultraplan file loading to preserve all task fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Ultraplan File Loading** - Fixed an issue where loading an ultraplan from a file (`:ultraplan --plan <file>`) would silently drop the `issue_url` and `no_code` fields during plan parsing. These optional fields are now correctly preserved, ensuring that external issue tracker links work properly and no-code tasks (verification/testing tasks) are handled correctly.
+
 - **Sidebar UI Duplication** - Fixed a bug where sidebar content could be duplicated or overflow when adding/removing tasks or groups. The issue was caused by a mismatch between item count and actual rendered line count in the sidebar. The sidebar now properly tracks actual line usage, preventing content from overflowing its container and causing visual artifacts.
 
 - **Plan File Path in Subdirectories** - Fixed planning coordinators writing `.claudio-plan.json` to incorrect locations when Claudio is started from a repository subdirectory. The planning prompts now explicitly instruct Claude to write the plan file at the repository root, preventing path resolution issues during multi-pass planning.


### PR DESCRIPTION
## Summary

- Fixed `ParsePlanFromFile()` to properly preserve `issue_url` and `no_code` fields that were being silently dropped during plan parsing
- Added support for nested `{"plan": {...}}` wrapper format for flexibility
- Added support for alternative field names (`depends`/`complexity`) that Claude may generate
- Improved error messages to indicate which formats were attempted when parsing fails

## Test plan

- [x] All existing tests pass
- [x] Added `TestParsePlanFromFile_AllFieldsPreserved` - verifies all PlannedTask fields are correctly parsed
- [x] Added `TestParsePlanFromFile_ComputesDependencyGraph` - verifies DependencyGraph and ExecutionOrder are built
- [x] Added `TestParsePlanFromFile_NestedFormatPreservesAllFields` - verifies nested format preserves insights/constraints
- [x] Added `TestParsePlanFromFile_NestedMalformedJSON` - verifies improved error messages for malformed nested JSON
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `gofmt -d .` shows no formatting issues