### PR TITLE
Prevent auto-expansion of locked collapsed groups during navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **MultiPlan Planner Navigation** - Auto-collapsed multiplan planner instances are no longer navigable via tab/shift-tab or h/l keys. Previously, navigating to a collapsed instance would auto-expand the group, unintentionally exposing the planner instances. Now, locked-collapsed groups (like the "Planning Instances" sub-group) remain collapsed during navigation, keeping the sidebar clean. Users can still manually expand locked groups via group toggle (gc), which clears the lock and allows normal navigation afterward.
+
 - **Ultraplan File Loading** - Fixed an issue where loading an ultraplan from a file (`:ultraplan --plan <file>`) would silently drop the `issue_url` and `no_code` fields during plan parsing. These optional fields are now correctly preserved, ensuring that external issue tracker links work properly and no-code tasks (verification/testing tasks) are handled correctly.
 
 - **Sidebar UI Duplication** - Fixed a bug where sidebar content could be duplicated or overflow when adding/removing tasks or groups. The issue was caused by a mismatch between item count and actual rendered line count in the sidebar. The sidebar now properly tracks actual line usage, preventing content from overflowing its container and causing visual artifacts.

--- a/internal/tui/inlineplan.go
+++ b/internal/tui/inlineplan.go
@@ -727,11 +727,13 @@ func (m *Model) collapsePlannersToSubGroup(session *InlinePlanSession) {
 	// Store the sub-group ID in the session for reference
 	session.PlannerSubGroupID = subGroupID
 
-	// Auto-collapse the sub-group in the UI
+	// Auto-collapse and lock the sub-group in the UI.
+	// Using SetLockedCollapsed ensures the group cannot be auto-expanded during
+	// tab/shift-tab navigation - the planner instances should remain hidden.
 	if m.groupViewState == nil {
 		m.groupViewState = view.NewGroupViewState()
 	}
-	m.groupViewState.CollapsedGroups[subGroupID] = true
+	m.groupViewState.SetLockedCollapsed(subGroupID, true)
 
 	if m.logger != nil {
 		m.logger.Info("collapsed planner instances to sub-group",


### PR DESCRIPTION
## Summary

- Auto-collapsed multiplan planner instances are no longer navigable via tab/shift-tab or h/l keys
- Previously, navigating to an instance inside a collapsed group would auto-expand the group, unintentionally exposing the planner instances
- Now, locked-collapsed groups (like the "Planning Instances" sub-group) remain collapsed during navigation, keeping the sidebar clean
- Users can still manually expand locked groups via group toggle (gc), which clears the lock and allows normal navigation afterward

## Changes

- Add `LockedCollapsed` state to `GroupViewState` for groups that should not auto-expand during navigation
- Modify `AutoExpand()` to check `IsLockedCollapsed()` and refuse to expand locked groups
- Modify `ToggleCollapse()` to clear locked state when user manually toggles (user action takes precedence)
- Use `SetLockedCollapsed()` in `collapsePlannersToSubGroup()` to lock the "Planning Instances" sub-group

## Test plan

- [x] All existing tests pass
- [x] Added `TestGroupViewState_LockedCollapsed` - verifies locked/unlocked state transitions
- [x] Added `TestGroupViewState_AutoExpand_RespectsLockedCollapsed` - verifies auto-expand is blocked for locked groups
- [x] Added `TestGroupViewState_ToggleCollapse_ClearsLockedCollapsed` - verifies manual toggle clears lock
- [x] `gofmt` and `go vet` pass