### PR TITLE
Make adversarial review score threshold a mandatory requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Adversarial Review Score Threshold** - Updated the reviewer prompt to make the minimum score threshold a mandatory requirement for approval. The prompt now uses emphatic language ("CRITICAL: Approval MUST meet a minimum score of X") to clearly communicate that the score threshold is a hard requirement, not a suggestion.
+
 ### Fixed
 
 - **Ultraplan File Loading** - Fixed an issue where loading an ultraplan from a file (`:ultraplan --plan <file>`) would silently drop the `issue_url` and `no_code` fields during plan parsing. These optional fields are now correctly preserved, ensuring that external issue tracker links work properly and no-code tasks (verification/testing tasks) are handled correctly.

--- a/internal/orchestrator/workflows/adversarial/prompt.go
+++ b/internal/orchestrator/workflows/adversarial/prompt.go
@@ -118,13 +118,13 @@ The system is waiting for this file to continue the workflow.
 ` + "```" + `
 
 **Rules:**
-- Set approved to true ONLY if the implementation is truly ready (score >= %d, no critical issues)
+- **CRITICAL: Approval MUST meet a minimum score of %[5]d.** Set approved to true ONLY when BOTH conditions are met: (1) score >= %[5]d AND (2) no critical issues remain.
 - Score from 1-10: 1-4 = major problems, 5-6 = needs work, 7-8 = good, 9-10 = excellent
 - Issues should list specific problems that MUST be fixed
 - Suggestions are optional improvements (not required for approval)
 - required_changes should be specific and actionable
 
-**IMPORTANT:** Do NOT approve work that has any significant issues. The implementer can iterate.
+**IMPORTANT:** Do NOT approve work that has any significant issues or scores below %[5]d. The implementer can iterate.
 
 **REMINDER: Write ` + "`" + ReviewFileName + "`" + ` when your review is complete.**`
 


### PR DESCRIPTION
## Summary

- Updated the reviewer prompt in the adversarial workflow to use emphatic language making the minimum score threshold a hard requirement for approval
- The prompt now states "CRITICAL: Approval MUST meet a minimum score of X" and references the threshold in multiple places
- Ensures the AI reviewer understands the score threshold is mandatory, not merely a suggestion

## Test plan

- [x] Verified all existing tests pass (`go test ./internal/orchestrator/workflows/adversarial/...`)
- [x] Verified build succeeds (`go build ./...`)
- [x] Verified `go vet` passes
- [ ] Manual testing: Run an adversarial review session and verify the reviewer respects the score threshold