### PR TITLE
Improve tripleshot completion file detection with subdirectory fallback

### DIFF
--- a/.claude-prompt
+++ b/.claude-prompt
@@ -1,1 +1,0 @@
-When a user types `:D`, the TUI can stall. This seems like a synchronous operation?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **TUI Freeze on `:D` and `:d` Commands** - Fixed the TUI freezing when using the `:D` (remove instance) and `:d` (show diff) commands. These commands now execute git operations asynchronously, keeping the UI responsive while the worktree removal or diff computation runs in the background.
 
+- **TripleShot Completion File Detection** - Fixed an issue where tripleshot completion files were not detected when Claude instances wrote them to a subdirectory instead of the worktree root. This could happen in monorepos where Claude `cd`'d into a project subdirectory before writing the completion file. The detection now searches immediate subdirectories as a fallback, ensuring completion files are found regardless of where they were written.
+
 ## [0.12.2] - 2026-01-21
 
 ### Added


### PR DESCRIPTION
## Summary

- Fixed an issue where tripleshot completion files were not detected when Claude instances wrote them to a subdirectory instead of the worktree root
- This commonly occurs in monorepos where Claude cd's into a project subdirectory before writing the completion file
- Added fallback detection that searches immediate subdirectories when file isn't found at worktree root
- Properly distinguishes between "file not found" and other filesystem errors

## Test plan

- [x] All existing tests pass
- [x] Added 14 new tests covering the fallback detection scenarios
- [x] Verified completion file detection works in worktree root
- [x] Verified completion file detection works in subdirectories
- [x] Verified hidden directories (like .git) are skipped
- [x] Verified root path is preferred when files exist in both locations
- [x] Verified filesystem errors (permissions, I/O) are properly propagated rather than swallowed