### PR TITLE
Fix TUI freeze on :D and :d commands

### DIFF
--- a/.claude-prompt
+++ b/.claude-prompt
@@ -1,0 +1,1 @@
+When a user types `:D`, the TUI can stall. This seems like a synchronous operation?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **TUI Freeze on `:D` and `:d` Commands** - Fixed the TUI freezing when using the `:D` (remove instance) and `:d` (show diff) commands. These commands now execute git operations asynchronously, keeping the UI responsive while the worktree removal or diff computation runs in the background.
+
 ## [0.12.2] - 2026-01-21
 
 ### Added

--- a/internal/tui/msg/commands.go
+++ b/internal/tui/msg/commands.go
@@ -95,6 +95,41 @@ func AddDependentTaskAsync(o *orchestrator.Orchestrator, session *orchestrator.S
 	}
 }
 
+// RemoveInstanceAsync returns a command that removes an instance asynchronously.
+// This prevents the UI from blocking while git removes the worktree and branch.
+func RemoveInstanceAsync(o *orchestrator.Orchestrator, session *orchestrator.Session, instanceID string) tea.Cmd {
+	return func() tea.Msg {
+		if o == nil {
+			return InstanceRemovedMsg{InstanceID: instanceID, Err: fmt.Errorf("orchestrator is nil")}
+		}
+		if session == nil {
+			return InstanceRemovedMsg{InstanceID: instanceID, Err: fmt.Errorf("session is nil")}
+		}
+		err := o.RemoveInstance(session, instanceID, true)
+		return InstanceRemovedMsg{InstanceID: instanceID, Err: err}
+	}
+}
+
+// LoadDiffAsync returns a command that loads a git diff asynchronously.
+// This prevents the UI from blocking while git computes the diff.
+func LoadDiffAsync(o *orchestrator.Orchestrator, worktreePath string, instanceID string) tea.Cmd {
+	return func() tea.Msg {
+		if o == nil {
+			return DiffLoadedMsg{
+				InstanceID:  instanceID,
+				DiffContent: "",
+				Err:         fmt.Errorf("orchestrator is nil"),
+			}
+		}
+		diff, err := o.GetInstanceDiff(worktreePath)
+		return DiffLoadedMsg{
+			InstanceID:  instanceID,
+			DiffContent: diff,
+			Err:         err,
+		}
+	}
+}
+
 // CheckTripleShotCompletionAsync returns a command that checks tripleshot completion files
 // in a goroutine, avoiding blocking the UI event loop with file I/O.
 func CheckTripleShotCompletionAsync(

--- a/internal/tui/msg/commands_test.go
+++ b/internal/tui/msg/commands_test.go
@@ -348,3 +348,58 @@ func TestCommandsAreIdempotent(t *testing.T) {
 // Note: Testing with an uninitialized Coordinator that returns nil session
 // requires complex internal setup as the Session() method accesses internal
 // pointers. The nil coordinator cases above verify nil-safety at the outer level.
+
+func TestRemoveInstanceAsync(t *testing.T) {
+	t.Run("returns non-nil command", func(t *testing.T) {
+		cmd := RemoveInstanceAsync(nil, nil, "test-instance-id")
+		if cmd == nil {
+			t.Fatal("RemoveInstanceAsync() returned nil command")
+		}
+	})
+
+	t.Run("returns error when orchestrator is nil", func(t *testing.T) {
+		cmd := RemoveInstanceAsync(nil, nil, "test-instance-id")
+		msg := cmd()
+
+		removedMsg, ok := msg.(InstanceRemovedMsg)
+		if !ok {
+			t.Fatalf("RemoveInstanceAsync()() returned %T, want InstanceRemovedMsg", msg)
+		}
+
+		if removedMsg.Err == nil {
+			t.Error("expected error when orchestrator is nil")
+		}
+		if removedMsg.InstanceID != "test-instance-id" {
+			t.Errorf("InstanceID = %q, want %q", removedMsg.InstanceID, "test-instance-id")
+		}
+	})
+}
+
+func TestLoadDiffAsync(t *testing.T) {
+	t.Run("returns non-nil command", func(t *testing.T) {
+		cmd := LoadDiffAsync(nil, "/path/to/worktree", "test-instance-id")
+		if cmd == nil {
+			t.Fatal("LoadDiffAsync() returned nil command")
+		}
+	})
+
+	t.Run("returns error when orchestrator is nil", func(t *testing.T) {
+		cmd := LoadDiffAsync(nil, "/path/to/worktree", "test-instance-id")
+		msg := cmd()
+
+		diffMsg, ok := msg.(DiffLoadedMsg)
+		if !ok {
+			t.Fatalf("LoadDiffAsync()() returned %T, want DiffLoadedMsg", msg)
+		}
+
+		if diffMsg.Err == nil {
+			t.Error("expected error when orchestrator is nil")
+		}
+		if diffMsg.InstanceID != "test-instance-id" {
+			t.Errorf("InstanceID = %q, want %q", diffMsg.InstanceID, "test-instance-id")
+		}
+		if diffMsg.DiffContent != "" {
+			t.Errorf("DiffContent = %q, want empty string on error", diffMsg.DiffContent)
+		}
+	})
+}

--- a/internal/tui/msg/types.go
+++ b/internal/tui/msg/types.go
@@ -58,6 +58,19 @@ type DependentTaskAddedMsg struct {
 	Err       error
 }
 
+// InstanceRemovedMsg is sent when async instance removal completes.
+type InstanceRemovedMsg struct {
+	InstanceID string
+	Err        error
+}
+
+// DiffLoadedMsg is sent when async diff loading completes.
+type DiffLoadedMsg struct {
+	InstanceID  string
+	DiffContent string
+	Err         error
+}
+
 // UltraPlanInitMsg signals that ultra-plan mode should initialize.
 type UltraPlanInitMsg struct{}
 

--- a/internal/tui/msg/types_test.go
+++ b/internal/tui/msg/types_test.go
@@ -669,3 +669,97 @@ func TestInlineMultiPlanFileCheckResultMsg(t *testing.T) {
 		})
 	}
 }
+
+func TestInstanceRemovedMsg(t *testing.T) {
+	tests := []struct {
+		name       string
+		instanceID string
+		err        error
+	}{
+		{
+			name:       "successful removal",
+			instanceID: "inst-123",
+			err:        nil,
+		},
+		{
+			name:       "failed removal",
+			instanceID: "inst-456",
+			err:        errors.New("worktree still in use"),
+		},
+		{
+			name:       "empty instance ID",
+			instanceID: "",
+			err:        errors.New("instance not found"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := InstanceRemovedMsg{
+				InstanceID: tt.instanceID,
+				Err:        tt.err,
+			}
+
+			if msg.InstanceID != tt.instanceID {
+				t.Errorf("InstanceRemovedMsg.InstanceID = %q, want %q", msg.InstanceID, tt.instanceID)
+			}
+			if msg.Err != tt.err {
+				t.Errorf("InstanceRemovedMsg.Err = %v, want %v", msg.Err, tt.err)
+			}
+		})
+	}
+}
+
+func TestDiffLoadedMsg(t *testing.T) {
+	tests := []struct {
+		name        string
+		instanceID  string
+		diffContent string
+		err         error
+	}{
+		{
+			name:        "successful with content",
+			instanceID:  "inst-123",
+			diffContent: "diff --git a/foo.go b/foo.go\n--- a/foo.go\n+++ b/foo.go",
+			err:         nil,
+		},
+		{
+			name:        "successful empty diff (no changes)",
+			instanceID:  "inst-456",
+			diffContent: "",
+			err:         nil,
+		},
+		{
+			name:        "failed to get diff",
+			instanceID:  "inst-789",
+			diffContent: "",
+			err:         errors.New("not a git repository"),
+		},
+		{
+			name:        "large diff content",
+			instanceID:  "inst-large",
+			diffContent: "diff --git a/large.go b/large.go\n" + string(make([]byte, 10000)),
+			err:         nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := DiffLoadedMsg{
+				InstanceID:  tt.instanceID,
+				DiffContent: tt.diffContent,
+				Err:         tt.err,
+			}
+
+			if msg.InstanceID != tt.instanceID {
+				t.Errorf("DiffLoadedMsg.InstanceID = %q, want %q", msg.InstanceID, tt.instanceID)
+			}
+			if msg.DiffContent != tt.diffContent {
+				t.Errorf("DiffLoadedMsg.DiffContent length = %d, want %d", len(msg.DiffContent), len(tt.diffContent))
+			}
+			if msg.Err != tt.err {
+				t.Errorf("DiffLoadedMsg.Err = %v, want %v", msg.Err, tt.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Fix TUI freeze on `:D` and `:d` commands** - The `:D` (remove instance) and `:d` (show diff) commands were executing synchronous git operations that blocked the TUI event loop. They now use the established async pattern with `tea.Cmd` and result messages, keeping the UI responsive.

## Changes

- Add `InstanceRemovedMsg` and `DiffLoadedMsg` message types
- Add `RemoveInstanceAsync()` and `LoadDiffAsync()` command factories with nil-safety checks
- Modify `cmdRemove` and `cmdDiff` to return async commands with "Loading..." feedback
- Add `handleInstanceRemoved` and `handleDiffLoaded` message handlers in `app.go`
- Add comprehensive tests for new message types and commands

## Test plan

- [ ] Run `claudio` with multiple instances
- [ ] Type `:d` - should show "Loading diff..." then display diff without freezing
- [ ] Type `:D` - should show "Removing instance..." then remove without freezing
- [ ] Verify UI remains responsive during operations
- [ ] Test error cases (no instance selected, diff on clean worktree)
- [ ] Run `go test ./internal/tui/...` - all tests pass