### PR TITLE
Add nil-safety checks to async task commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **TUI Freeze on `:D` and `:d` Commands** - Fixed the TUI freezing when using the `:D` (remove instance) and `:d` (show diff) commands. These commands now execute git operations asynchronously, keeping the UI responsive while the worktree removal or diff computation runs in the background.
 
+- **Async Command Nil Safety** - Added nil-safety checks to all async task commands (`AddTaskAsync`, `AddTaskFromBranchAsync`, `AddDependentTaskAsync`, `RemoveInstanceAsync`, `LoadDiffAsync`) to prevent panics if orchestrator or session is nil. These edge cases now return proper error messages instead of crashing.
+
 - **TripleShot Completion File Detection** - Fixed an issue where tripleshot completion files were not detected when Claude instances wrote them to a subdirectory instead of the worktree root. This could happen in monorepos where Claude `cd`'d into a project subdirectory before writing the completion file. The detection now searches immediate subdirectories as a fallback, ensuring completion files are found regardless of where they were written.
 
 ## [0.12.2] - 2026-01-21

--- a/internal/tui/msg/commands.go
+++ b/internal/tui/msg/commands.go
@@ -72,6 +72,12 @@ func NotifyUser() tea.Cmd {
 // This prevents the UI from blocking while git creates the worktree.
 func AddTaskAsync(o *orchestrator.Orchestrator, session *orchestrator.Session, task string) tea.Cmd {
 	return func() tea.Msg {
+		if o == nil {
+			return TaskAddedMsg{Instance: nil, Err: fmt.Errorf("orchestrator is nil")}
+		}
+		if session == nil {
+			return TaskAddedMsg{Instance: nil, Err: fmt.Errorf("session is nil")}
+		}
 		inst, err := o.AddInstance(session, task)
 		return TaskAddedMsg{Instance: inst, Err: err}
 	}
@@ -81,6 +87,12 @@ func AddTaskAsync(o *orchestrator.Orchestrator, session *orchestrator.Session, t
 // The baseBranch parameter specifies which branch the new worktree should be created from.
 func AddTaskFromBranchAsync(o *orchestrator.Orchestrator, session *orchestrator.Session, task string, baseBranch string) tea.Cmd {
 	return func() tea.Msg {
+		if o == nil {
+			return TaskAddedMsg{Instance: nil, Err: fmt.Errorf("orchestrator is nil")}
+		}
+		if session == nil {
+			return TaskAddedMsg{Instance: nil, Err: fmt.Errorf("session is nil")}
+		}
 		inst, err := o.AddInstanceFromBranch(session, task, baseBranch)
 		return TaskAddedMsg{Instance: inst, Err: err}
 	}
@@ -90,6 +102,12 @@ func AddTaskFromBranchAsync(o *orchestrator.Orchestrator, session *orchestrator.
 // The new task will depend on the specified instance and auto-start when it completes.
 func AddDependentTaskAsync(o *orchestrator.Orchestrator, session *orchestrator.Session, task string, dependsOn string) tea.Cmd {
 	return func() tea.Msg {
+		if o == nil {
+			return DependentTaskAddedMsg{Instance: nil, DependsOn: dependsOn, Err: fmt.Errorf("orchestrator is nil")}
+		}
+		if session == nil {
+			return DependentTaskAddedMsg{Instance: nil, DependsOn: dependsOn, Err: fmt.Errorf("session is nil")}
+		}
 		inst, err := o.AddInstanceWithDependencies(session, task, []string{dependsOn}, true)
 		return DependentTaskAddedMsg{Instance: inst, DependsOn: dependsOn, Err: err}
 	}

--- a/internal/tui/msg/commands_test.go
+++ b/internal/tui/msg/commands_test.go
@@ -98,31 +98,84 @@ func TestNotifyUser(t *testing.T) {
 }
 
 func TestAddTaskAsync(t *testing.T) {
-	// Test with nil orchestrator and session - should not panic
-	cmd := AddTaskAsync(nil, nil, "test task")
+	t.Run("returns non-nil command", func(t *testing.T) {
+		cmd := AddTaskAsync(nil, nil, "test task")
+		if cmd == nil {
+			t.Fatal("AddTaskAsync() returned nil command")
+		}
+	})
 
-	if cmd == nil {
-		t.Fatal("AddTaskAsync() returned nil command")
-	}
+	t.Run("returns error when orchestrator is nil", func(t *testing.T) {
+		cmd := AddTaskAsync(nil, nil, "test task")
+		msg := cmd()
 
-	// Note: We can't fully test this without a real orchestrator,
-	// but we verify the command is constructed
+		taskMsg, ok := msg.(TaskAddedMsg)
+		if !ok {
+			t.Fatalf("AddTaskAsync()() returned %T, want TaskAddedMsg", msg)
+		}
+
+		if taskMsg.Err == nil {
+			t.Error("expected error when orchestrator is nil")
+		}
+		if taskMsg.Instance != nil {
+			t.Error("expected nil instance on error")
+		}
+	})
 }
 
 func TestAddTaskFromBranchAsync(t *testing.T) {
-	cmd := AddTaskFromBranchAsync(nil, nil, "test task", "main")
+	t.Run("returns non-nil command", func(t *testing.T) {
+		cmd := AddTaskFromBranchAsync(nil, nil, "test task", "main")
+		if cmd == nil {
+			t.Fatal("AddTaskFromBranchAsync() returned nil command")
+		}
+	})
 
-	if cmd == nil {
-		t.Fatal("AddTaskFromBranchAsync() returned nil command")
-	}
+	t.Run("returns error when orchestrator is nil", func(t *testing.T) {
+		cmd := AddTaskFromBranchAsync(nil, nil, "test task", "main")
+		msg := cmd()
+
+		taskMsg, ok := msg.(TaskAddedMsg)
+		if !ok {
+			t.Fatalf("AddTaskFromBranchAsync()() returned %T, want TaskAddedMsg", msg)
+		}
+
+		if taskMsg.Err == nil {
+			t.Error("expected error when orchestrator is nil")
+		}
+		if taskMsg.Instance != nil {
+			t.Error("expected nil instance on error")
+		}
+	})
 }
 
 func TestAddDependentTaskAsync(t *testing.T) {
-	cmd := AddDependentTaskAsync(nil, nil, "test task", "parent-id")
+	t.Run("returns non-nil command", func(t *testing.T) {
+		cmd := AddDependentTaskAsync(nil, nil, "test task", "parent-id")
+		if cmd == nil {
+			t.Fatal("AddDependentTaskAsync() returned nil command")
+		}
+	})
 
-	if cmd == nil {
-		t.Fatal("AddDependentTaskAsync() returned nil command")
-	}
+	t.Run("returns error when orchestrator is nil", func(t *testing.T) {
+		cmd := AddDependentTaskAsync(nil, nil, "test task", "parent-id")
+		msg := cmd()
+
+		depMsg, ok := msg.(DependentTaskAddedMsg)
+		if !ok {
+			t.Fatalf("AddDependentTaskAsync()() returned %T, want DependentTaskAddedMsg", msg)
+		}
+
+		if depMsg.Err == nil {
+			t.Error("expected error when orchestrator is nil")
+		}
+		if depMsg.Instance != nil {
+			t.Error("expected nil instance on error")
+		}
+		if depMsg.DependsOn != "parent-id" {
+			t.Errorf("DependsOn = %q, want %q", depMsg.DependsOn, "parent-id")
+		}
+	})
 }
 
 func TestCheckTripleShotCompletionAsync(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Async Command Nil Safety** - Added nil-safety checks to `AddTaskAsync`, `AddTaskFromBranchAsync`, and `AddDependentTaskAsync` to prevent panics if orchestrator or session is nil. These edge cases now return proper error messages instead of crashing.

This follows up on #562 which added nil-safety checks to `RemoveInstanceAsync` and `LoadDiffAsync`.

## Changes

- Add nil checks to `AddTaskAsync()` - returns `TaskAddedMsg` with error if orchestrator/session is nil
- Add nil checks to `AddTaskFromBranchAsync()` - same pattern
- Add nil checks to `AddDependentTaskAsync()` - returns `DependentTaskAddedMsg` with error
- Update tests to verify nil handling for all three functions

## Test plan

- [ ] Run `go test ./internal/tui/msg/...` - all tests pass
- [ ] Verify commands don't panic with nil orchestrator
- [ ] Verify error messages are clear and actionable