### PR TITLE
Fix instance manager creation when attaching to existing sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **TripleShot Completion File Detection** - Fixed an issue where tripleshot completion files were not detected when Claude instances wrote them to a subdirectory instead of the worktree root. This could happen in monorepos where Claude `cd`'d into a project subdirectory before writing the completion file. The detection now searches immediate subdirectories as a fallback, ensuring completion files are found regardless of where they were written.
 
+- **Session Attachment Instance Manager Creation** - Fixed a critical bug where attaching to an existing session would not create instance managers for loaded instances. This caused instances to appear in the TUI but be non-functional - they couldn't be restarted, and their output wouldn't be captured. The fix adds `EnsureInstanceManagers()` which is called after loading a session to ensure all instances have proper managers. Additionally, `ReconnectInstance` and `ResumeInstance` now always call `ClearTimeout()` to prevent stale detection from immediately re-triggering after restart.
+
 ## [0.12.2] - 2026-01-21
 
 ### Added

--- a/internal/cmd/session/start.go
+++ b/internal/cmd/session/start.go
@@ -169,6 +169,11 @@ func AttachToSession(cwd, sessionID string, cfg *config.Config) error {
 		return fmt.Errorf("failed to load session: %w", err)
 	}
 
+	// Create instance managers for all instances in the session.
+	// This is necessary because LoadSession only loads the session data from disk
+	// but doesn't create the instance managers needed for interaction.
+	orch.EnsureInstanceManagers()
+
 	// Check for interrupted session that needs recovery
 	needsRecovery := sess.NeedsRecovery()
 	if needsRecovery {


### PR DESCRIPTION
## Summary

- Fixed a critical bug where attaching to an existing session would not create instance managers for loaded instances
- Instances appeared in the TUI but were non-functional (couldn't be restarted, no output capture)
- Added `EnsureInstanceManagers()` method called after loading a session
- Added `ClearTimeout()` calls in `ReconnectInstance` and `ResumeInstance` to prevent stale detection from immediately re-triggering

## Test plan

- [x] Build passes
- [x] All existing tests pass
- [x] New tests for `EnsureInstanceManagers` pass (including nil session handling and idempotency)
- [x] `go vet` passes
- [x] `gofmt` reports no issues
- [ ] Manual verification: attach to a session with a stuck instance and verify restart works