### PR TITLE
Show status abbreviation for regular instances in sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`:D` and `:d` Command Error Display** - Fixed an issue where the `:D` (remove instance) and `:d` (show diff) commands would appear to freeze the TUI with a "Removing instance..." or "Loading diff..." message when an error occurred. The error message was being set but not displayed because the info message wasn't cleared first. Now errors from async operations properly clear the progress message before displaying the error.
 
+- **Regular Instance Status Display** - Fixed the status abbreviation (WAIT, WORK, DONE, etc.) not being shown for regular ungrouped instances in the sidebar. Grouped instances showed the status on a second line, but regular instances only displayed the colored dot without the status text. Both now consistently show the status indicator on a second line below the instance name.
+
 ## [0.12.3] - 2026-01-21
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Fixed the status abbreviation (WAIT, WORK, DONE, etc.) not being shown for regular ungrouped instances in the sidebar
- Grouped instances were showing the status on a second line, but regular instances only displayed the colored dot
- Both now consistently show the status indicator on a second line below the instance name

## Test plan

- [ ] Start Claudio with regular (ungrouped) instances
- [ ] Verify status abbreviations (WAIT, WORK, DONE, etc.) appear on a second line below instance names
- [ ] Verify grouped instances continue to show status correctly
- [ ] Test with expanded instance names (intelligent naming enabled) to verify status appears there too