### PR TITLE
Fix session attachment output capture callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Session Attachment Output Capture** - Fixed a critical bug where attaching to an existing session would not configure instance callbacks, causing all instances to appear frozen with no output updates. The previous fix (#564) created instance managers but the reconnection code called `mgr.Reconnect()` directly instead of `orch.ReconnectInstance()`, which skipped the callback configuration (state changes, metrics, timeouts, bells). Now uses the proper high-level reconnection method that configures all necessary callbacks.
+
 ## [0.12.4] - 2026-01-21
 
 ### Fixed

--- a/internal/cmd/session/start.go
+++ b/internal/cmd/session/start.go
@@ -196,14 +196,13 @@ func AttachToSession(cwd, sessionID string, cfg *config.Config) error {
 
 		if mgr.TmuxSessionExists() {
 			// Tmux session still exists - reconnect to it
-			if err := mgr.Reconnect(); err != nil {
+			// Use ReconnectInstance to ensure callbacks are configured properly
+			if err := orch.ReconnectInstance(inst); err != nil {
 				logger.Warn("failed to reconnect to tmux session",
 					"instance_id", inst.ID,
 					"error", err.Error(),
 				)
 			} else {
-				inst.Status = orchestrator.StatusWorking
-				inst.PID = mgr.PID()
 				reconnected = append(reconnected, inst.ID)
 			}
 		} else if needsRecovery && inst.ClaudeSessionID != "" &&


### PR DESCRIPTION
## Summary

- Fixed a critical bug where attaching to an existing session would not configure instance callbacks, causing all instances to appear frozen with no output updates
- The previous fix (#564) created instance managers but the reconnection code called `mgr.Reconnect()` directly instead of `orch.ReconnectInstance()`, which skipped the callback configuration (state changes, metrics, timeouts, bells)
- Now uses the proper high-level reconnection method that configures all necessary callbacks

## Test plan

- [x] Build passes (`go build ./...`)
- [x] Tests pass (`go test ./...`)
- [x] Linting passes (`go vet ./...`)
- [ ] Manual test: Start a session, detach, reattach - output should continue updating