### PR TITLE
Fix frozen output from transient tmux errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Frozen Output from Transient Tmux Errors** - Fixed a critical bug where tmux sessions would appear frozen (no output updates, input not showing) due to transient tmux errors being misinterpreted as "session doesn't exist". Previously, any non-timeout error from tmux `display-message` or `has-session` commands would cause the capture loop to think the session had ended, setting `running = false` and stopping all output updates. Now, only definitive "session gone" errors (socket doesn't exist, session not found, no server running, tmux not installed) are treated as terminal—all other errors (broken pipe, signal killed, generic exit status) are assumed to be transient and the capture loop continues retrying. Also fixed `checkSessionExists` to properly capture stderr using `CombinedOutput()` for accurate error message detection.
+
 ## [0.12.6] - 2026-01-22
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Fixes critical bug where some Claudio sessions would appear frozen (no output updates, input not showing)
- Root cause: transient tmux errors (broken pipe, signal killed, etc.) were misinterpreted as "session doesn't exist"
- The capture loop would exit prematurely, setting `running = false` and stopping all updates

## Changes

- **`getSessionStatus()`** - Now only treats specific error patterns as terminal:
  - `"error connecting to"` - socket doesn't exist
  - `"can't find session:"` - session not found  
  - `"no server running"` - tmux server not running
- **`checkSessionExists()`** - Same error pattern matching, plus changed from `cmd.Run()` to `cmd.CombinedOutput()` so stderr is captured
- **New test** - `TestSessionGoneErrorPatterns` documents which errors are terminal vs transient

## Test plan

- [x] All existing tests pass
- [x] New `TestSessionGoneErrorPatterns` test verifies error classification logic
- [x] `TestManager_CheckSessionExists_NoSession` and `TestManager_GetSessionStatus_NoSession` verify non-existent sessions are still correctly detected