### PR TITLE
Enhance UI with context-rich status displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Enhanced Sidebar Status Display** - Instance status lines in the sidebar now show additional context including elapsed time (e.g., "5m"), cost (e.g., "$0.05"), and files modified count (e.g., "3 files"). Running instances also display "last active" time (e.g., "30s ago"). This helps users quickly understand instance progress without navigating to the stats panel.
+
+- **Enhanced Instance Header** - The instance detail view header now shows files modified count and last activity time for running instances, providing immediate context about what the instance is working on.
+
+- **API Calls in Metrics Display** - The instance metrics line now includes API call count (e.g., "12 API calls") alongside tokens and cost, giving users more insight into instance resource usage.
+
+- **Session Recovery Status in Stats Panel** - The stats panel now displays session recovery state (recovered/interrupted) with the number of recovery attempts, helping users understand if a session was restored from an interruption.
+
+- **Total API Calls in Stats Panel** - Added aggregated API call count across all instances to the session statistics panel.
+
 ## [0.12.7] - 2026-01-23
 
 ### Fixed

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1543,6 +1543,17 @@ func (m Model) renderStatsPanel(width int) string {
 		state.SessionCreated = m.session.Created
 		state.SessionMetrics = m.orchestrator.GetSessionMetrics()
 		state.Instances = m.session.Instances
+		state.RecoveryState = m.session.RecoveryState
+		state.RecoveryAttempt = m.session.RecoveryAttempt
+
+		// Calculate total API calls across all instances
+		totalAPICalls := 0
+		for _, inst := range m.session.Instances {
+			if inst.Metrics != nil {
+				totalAPICalls += inst.Metrics.APICalls
+			}
+		}
+		state.TotalAPICalls = totalAPICalls
 	}
 
 	statsPanel := panel.NewStatsPanel()

--- a/internal/tui/panel/renderer.go
+++ b/internal/tui/panel/renderer.go
@@ -154,6 +154,18 @@ type RenderState struct {
 	// IntelligentNamingEnabled indicates if intelligent naming feature is enabled.
 	// Used to expand the selected instance name in the sidebar.
 	IntelligentNamingEnabled bool
+
+	// RecoveryState indicates if the session was recovered from an interruption.
+	// Used by the stats panel to show recovery status.
+	RecoveryState orchestrator.RecoveryState
+
+	// RecoveryAttempt is the number of times the session has been recovered.
+	// Used by the stats panel to show recovery count.
+	RecoveryAttempt int
+
+	// TotalAPICalls is the aggregated API call count across all instances.
+	// Used by the stats panel for API usage display.
+	TotalAPICalls int
 }
 
 // Validate checks that the RenderState has valid values for rendering.

--- a/internal/tui/panel/stats.go
+++ b/internal/tui/panel/stats.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	instmetrics "github.com/Iron-Ham/claudio/internal/instance/metrics"
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
 	"github.com/Iron-Ham/claudio/internal/util"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -64,6 +65,30 @@ func (p *StatsPanel) Render(state *RenderState) string {
 		b.WriteString(fmt.Sprintf("  Session Started: %s\n",
 			state.SessionCreated.Format("2006-01-02 15:04:05")))
 	}
+
+	// Show recovery state if applicable
+	switch state.RecoveryState {
+	case orchestrator.RecoveryRecovered:
+		recoveryText := fmt.Sprintf("  Status: Recovered (attempt %d)", state.RecoveryAttempt)
+		if state.Theme != nil {
+			recoveryText = state.Theme.Warning().Render(recoveryText)
+		}
+		b.WriteString(recoveryText)
+		b.WriteString("\n")
+	case orchestrator.RecoveryInterrupted:
+		interruptText := "  Status: Interrupted - press 'r' to resume"
+		if state.Theme != nil {
+			interruptText = state.Theme.Warning().Render(interruptText)
+		}
+		b.WriteString(interruptText)
+		b.WriteString("\n")
+	}
+
+	// Show total API calls if available
+	if state.TotalAPICalls > 0 {
+		b.WriteString(fmt.Sprintf("  Total API Calls: %d\n", state.TotalAPICalls))
+	}
+
 	b.WriteString("\n")
 
 	// Token usage


### PR DESCRIPTION
## Summary

- Enhanced sidebar status lines to show elapsed time, cost, files modified, and "last active" indicators for running instances
- Added files modified count and last activity time to instance header view
- Added API call count to instance metrics display
- Added session recovery state (recovered/interrupted) and total API calls to stats panel
- Introduced `FormatDurationCompact` helper for consistent duration formatting across views

## Details

This PR makes the TUI more informative by surfacing existing but hidden data throughout the UI:

**Sidebar Status Lines** (`dashboard.go`, `group.go`)
- Status lines now show: `●WORK 5m | $0.05 | 3 files`
- Running instances show "last active" time to help identify stuck tasks: `30s ago | 5m | $0.05`

**Instance Header** (`instance.go`)
- Header now shows: `Branch: feature-x | 3 files modified | Active 2m ago`

**Stats Panel** (`stats.go`)
- Shows recovery state: "Status: Recovered (attempt 2)" or "Status: Interrupted - press 'r' to resume"
- Shows total API calls across all instances

**Code Quality Improvements**
- Added `FormatDurationCompact()` helper to eliminate duration formatting duplication
- Fixed magic number `60*1000000000` in `group.go` (now uses `time.Minute`)
- Updated `stats.go` to use `orchestrator.RecoveryRecovered` constants instead of string literals
- Refactored `instance.go` to reuse `FormatTimeAgo()` from `dashboard.go`

## Test plan

- [x] All existing tests pass
- [x] Added new `TestFormatDurationCompact` test with edge cases
- [x] `go vet ./...` passes
- [x] `gofmt -d .` shows no issues
- [x] Build succeeds