### PR TITLE
Fix plan file written to wrong location in worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Plan File Written to Wrong Location in Worktrees** - Fixed a bug where ultraplan coordinators would write `.claudio-plan.json` to the main repository root instead of the worktree directory. The planning prompt instructed Claude to write "at the repository root", which was ambiguous when running in a git worktree—Claude would follow the worktree's `.git` reference and write to the main repo. Changed the prompt to explicitly say "in your current working directory" with the `./` prefix, ensuring the plan file is written to the correct worktree location where the detection code expects it.
 - **Theme Persistence** - Theme selection now persists across application restarts. The TUI's `Init()` function now applies the user's saved theme preference from config at startup.
 - **Theme Config Validation** - Invalid theme names in config are now caught during validation and reported with a clear error message listing valid theme options.
 

--- a/internal/orchestrator/prompt/planning.go
+++ b/internal/orchestrator/prompt/planning.go
@@ -227,7 +227,7 @@ You must either:
 
 ## Output
 
-Write your final plan to ` + "`" + PlanFileName + "`" + ` **at the repository root** (not in any subdirectory) using the JSON schema below.
+Write your final plan to ` + "`" + "./" + PlanFileName + "`" + ` **in your current working directory** using the JSON schema below.
 
 ### Plan JSON Schema
 

--- a/internal/orchestrator/ultraplan.go
+++ b/internal/orchestrator/ultraplan.go
@@ -1499,7 +1499,7 @@ const PlanningPromptTemplate = `You are a senior software architect planning a c
 
 1. **Explore** the codebase to understand its structure and patterns
 2. **Decompose** the objective into discrete, parallelizable tasks
-3. **Write your plan** to ` + "`" + PlanFileName + "`" + ` **at the repository root** (not in any subdirectory) in JSON format
+3. **Write your plan** to ` + "`" + "./" + PlanFileName + "`" + ` **in your current working directory** in JSON format
 
 ## Plan JSON Schema
 

--- a/internal/ultraplan/planner.go
+++ b/internal/ultraplan/planner.go
@@ -17,7 +17,7 @@ const PlanningPromptTemplate = `You are a senior software architect planning a c
 
 1. **Explore** the codebase to understand its structure and patterns
 2. **Decompose** the objective into discrete, parallelizable tasks
-3. **Write your plan** to ` + "`" + PlanFileName + "`" + ` **at the repository root** (not in any subdirectory) in JSON format
+3. **Write your plan** to ` + "`" + "./" + PlanFileName + "`" + ` **in your current working directory** in JSON format
 
 ## Plan JSON Schema
 


### PR DESCRIPTION
## Summary

- Fixed a bug where ultraplan coordinators would write `.claudio-plan.json` to the main repository root instead of the worktree directory
- The planning prompt instructed Claude to write "at the repository root", which was ambiguous when running in a git worktree
- Claude would follow the worktree's `.git` reference and write to the main repo, causing plan detection to fail silently

## Changes

- Changed planning prompts from "at the repository root" to "in your current working directory"
- Added `./` prefix to the filename so it renders as `./.claudio-plan.json`
- Updated prompts in 3 locations: `internal/ultraplan/planner.go`, `internal/orchestrator/ultraplan.go`, `internal/orchestrator/prompt/planning.go`

## Test plan

- [ ] Start an ultraplan session (`:ultraplan "test objective"`)
- [ ] Verify `.claudio-plan.json` is written to the worktree directory, not the main repo
- [ ] Verify plan detection triggers correctly when the file is written