### PR TITLE
Auto-collapse tripleshot implementers when judge starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Triple-Shot Implementers Auto-Collapse** - When the judge (fourth session) starts running in a tripleshot workflow, the implementers sub-group is now automatically collapsed in the TUI sidebar. This focuses attention on the judge instance while keeping the three implementer instances accessible via manual expand.
+
 - **Color Themes** - Added support for user-selectable color themes in the TUI. Available themes: `default` (original purple/green), `monokai` (classic Monokai editor colors), `dracula` (Dracula theme), and `nord` (cool blue-gray Nord theme). Configure via `tui.theme` in config or select interactively via `:config` command. Theme changes apply immediately with live preview.
 
 - **Enhanced Sidebar Status Display** - Instance status lines in the sidebar now show additional context including elapsed time (e.g., "5m"), cost (e.g., "$0.05"), and files modified count (e.g., "3 files"). Running instances also display "last active" time (e.g., "30s ago"). This helps users quickly understand instance progress without navigating to the stats panel.

--- a/internal/orchestrator/workflow_adapters.go
+++ b/internal/orchestrator/workflow_adapters.go
@@ -82,6 +82,10 @@ func (a *groupAdapter) SetInstances(instances []string) {
 	a.group.Instances = instances
 }
 
+func (a *groupAdapter) GetID() string {
+	return a.group.ID
+}
+
 // DefaultTripleShotConfig returns the default tripleshot configuration
 func DefaultTripleShotConfig() tripleshot.Config {
 	return tripleshot.DefaultConfig()

--- a/internal/orchestrator/workflows/tripleshot/coordinator.go
+++ b/internal/orchestrator/workflows/tripleshot/coordinator.go
@@ -38,6 +38,7 @@ type GroupInterface interface {
 	AddSubGroup(subGroup GroupInterface)
 	GetInstances() []string
 	SetInstances(instances []string)
+	GetID() string
 }
 
 // NewGroupFunc is a function type for creating new instance groups.
@@ -403,6 +404,9 @@ func (c *Coordinator) StartJudge() error {
 		// Clear the parent group's instances and add the sub-group
 		tripleGroup.SetInstances(nil)
 		tripleGroup.AddSubGroup(implementersGroup)
+
+		// Store the implementers group ID for TUI collapse behavior
+		session.ImplementersGroupID = implementersGroup.GetID()
 
 		// Add the judge to the parent group (so it appears at the top level)
 		tripleGroup.AddInstance(inst.GetID())

--- a/internal/orchestrator/workflows/tripleshot/coordinator_test.go
+++ b/internal/orchestrator/workflows/tripleshot/coordinator_test.go
@@ -92,6 +92,7 @@ func (m *mockInstance) GetWorktreePath() string { return m.worktreePath }
 func (m *mockInstance) GetBranch() string       { return m.branch }
 
 type mockGroup struct {
+	id          string
 	instances   []string
 	subGroups   []GroupInterface
 	sessionType string
@@ -111,6 +112,10 @@ func (m *mockGroup) GetInstances() []string {
 
 func (m *mockGroup) SetInstances(instances []string) {
 	m.instances = instances
+}
+
+func (m *mockGroup) GetID() string {
+	return m.id
 }
 
 // Test cases

--- a/internal/orchestrator/workflows/tripleshot/session.go
+++ b/internal/orchestrator/workflows/tripleshot/session.go
@@ -11,18 +11,19 @@ import (
 
 // Session represents a triple-shot orchestration session
 type Session struct {
-	ID          string      `json:"id"`
-	GroupID     string      `json:"group_id,omitempty"` // Link to InstanceGroup for multi-tripleshot support
-	Task        string      `json:"task"`               // The original task/problem
-	Phase       Phase       `json:"phase"`
-	Config      Config      `json:"config"`
-	Attempts    [3]Attempt  `json:"attempts"`           // Exactly 3 attempts
-	JudgeID     string      `json:"judge_id,omitempty"` // Instance ID of the judge
-	Created     time.Time   `json:"created"`
-	StartedAt   *time.Time  `json:"started_at,omitempty"`
-	CompletedAt *time.Time  `json:"completed_at,omitempty"`
-	Evaluation  *Evaluation `json:"evaluation,omitempty"` // Judge's evaluation
-	Error       string      `json:"error,omitempty"`      // Error message if failed
+	ID                  string      `json:"id"`
+	GroupID             string      `json:"group_id,omitempty"`              // Link to InstanceGroup for multi-tripleshot support
+	ImplementersGroupID string      `json:"implementers_group_id,omitempty"` // ID of the Implementers sub-group (for TUI collapse)
+	Task                string      `json:"task"`                            // The original task/problem
+	Phase               Phase       `json:"phase"`
+	Config              Config      `json:"config"`
+	Attempts            [3]Attempt  `json:"attempts"`           // Exactly 3 attempts
+	JudgeID             string      `json:"judge_id,omitempty"` // Instance ID of the judge
+	Created             time.Time   `json:"created"`
+	StartedAt           *time.Time  `json:"started_at,omitempty"`
+	CompletedAt         *time.Time  `json:"completed_at,omitempty"`
+	Evaluation          *Evaluation `json:"evaluation,omitempty"` // Judge's evaluation
+	Error               string      `json:"error,omitempty"`      // Error message if failed
 }
 
 // generateID creates a unique identifier for the session

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -550,7 +550,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Judge started evaluating the attempts
 		m.infoMessage = "All attempts complete - judge is evaluating solutions..."
 		if m.logger != nil {
-			m.logger.Info("triple-shot judge started")
+			m.logger.Info("triple-shot judge started", "implementers_group_id", msg.ImplementersGroupID)
+		}
+		// Auto-collapse the implementers sub-group when the judge starts.
+		// This focuses attention on the judge instance while keeping
+		// implementers accessible via manual expand.
+		if msg.ImplementersGroupID != "" {
+			if m.groupViewState == nil {
+				m.groupViewState = view.NewGroupViewState()
+			}
+			m.groupViewState.SetLockedCollapsed(msg.ImplementersGroupID, true)
 		}
 		return m, nil
 

--- a/internal/tui/msg/types.go
+++ b/internal/tui/msg/types.go
@@ -78,7 +78,11 @@ type UltraPlanInitMsg struct{}
 type TripleShotStartedMsg struct{}
 
 // TripleShotJudgeStartedMsg indicates the judge has started evaluating.
-type TripleShotJudgeStartedMsg struct{}
+type TripleShotJudgeStartedMsg struct {
+	// ImplementersGroupID is the ID of the Implementers sub-group, used by TUI
+	// to auto-collapse the implementers when the judge starts running.
+	ImplementersGroupID string
+}
 
 // TripleShotErrorMsg indicates an error during triple-shot operation.
 type TripleShotErrorMsg struct {

--- a/internal/tui/msg/types_test.go
+++ b/internal/tui/msg/types_test.go
@@ -276,8 +276,15 @@ func TestTripleShotStartedMsg(t *testing.T) {
 }
 
 func TestTripleShotJudgeStartedMsg(t *testing.T) {
+	// Test empty struct
 	msg := TripleShotJudgeStartedMsg{}
 	_ = msg // Just verify it can be constructed
+
+	// Test with implementers group ID
+	msgWithID := TripleShotJudgeStartedMsg{ImplementersGroupID: "group-123"}
+	if msgWithID.ImplementersGroupID != "group-123" {
+		t.Errorf("ImplementersGroupID = %q, want %q", msgWithID.ImplementersGroupID, "group-123")
+	}
 }
 
 func TestTripleShotErrorMsg(t *testing.T) {

--- a/internal/tui/tripleshot.go
+++ b/internal/tui/tripleshot.go
@@ -158,7 +158,11 @@ func (m *Model) handleTripleShotAttemptProcessed(msg tuimsg.TripleShotAttemptPro
 				if err := coordinator.StartJudge(); err != nil {
 					return tuimsg.TripleShotErrorMsg{Err: fmt.Errorf("failed to start judge: %w", err)}
 				}
-				return tuimsg.TripleShotJudgeStartedMsg{}
+				// Get the implementers group ID from the session (set by StartJudge)
+				implementersGroupID := coordinator.Session().ImplementersGroupID
+				return tuimsg.TripleShotJudgeStartedMsg{
+					ImplementersGroupID: implementersGroupID,
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- When the judge (fourth session) starts running in a tripleshot workflow, the implementers sub-group is now automatically collapsed in the TUI sidebar
- This focuses attention on the judge instance while keeping the three implementer instances accessible via manual expand
- Uses the existing `SetLockedCollapsed` mechanism (same pattern as multiplan mode)

## Changes

- Added `GetID()` method to `tripleshot.GroupInterface` for retrieving the sub-group ID
- Added `ImplementersGroupID` field to `tripleshot.Session` to store the sub-group ID
- Updated `TripleShotJudgeStartedMsg` to pass the implementers group ID to the TUI
- TUI calls `SetLockedCollapsed()` when receiving the message to collapse the group

## Test plan

- [ ] Run a tripleshot session (`:tripleshot` command)
- [ ] Wait for all 3 implementers to complete
- [ ] When the judge starts, verify the "Implementers" sub-group auto-collapses in the sidebar
- [ ] Verify manual expand still works (click or navigate to the group)
- [ ] Verify `go test ./...` passes