### PR TITLE
Auto-collapse completed adversarial rounds into sub-groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Total API Calls in Stats Panel** - Added aggregated API call count across all instances to the session statistics panel.
 
+- **Adversarial Round Auto-Collapse** - Completed rounds in adversarial mode now automatically collapse into sub-groups, keeping the sidebar clean while preserving access to round history. Each round (implementer + reviewer instances) is organized into a "Round N" sub-group. When a round is rejected and a new round starts, the completed round's sub-group automatically collapses. The final approved round remains expanded so users can see the successful review. Users can manually toggle any round's expansion state.
+
 ### Fixed
 
 - **Plan File Written to Wrong Location in Worktrees** - Fixed a bug where ultraplan coordinators would write `.claudio-plan.json` to the main repository root instead of the worktree directory. The planning prompt instructed Claude to write "at the repository root", which was ambiguous when running in a git worktree—Claude would follow the worktree's `.git` reference and write to the main repo. Changed the prompt to explicitly say "in your current working directory" with the `./` prefix, ensuring the plan file is written to the correct worktree location where the detection code expects it.
 - **Theme Persistence** - Theme selection now persists across application restarts. The TUI's `Init()` function now applies the user's saved theme preference from config at startup.
 - **Theme Config Validation** - Invalid theme names in config are now caught during validation and reported with a clear error message listing valid theme options.
+- **Adversarial Sub-Group ID Edge Case** - Fixed an edge case where sub-group IDs would be malformed (e.g., `-round-1` instead of `session-id-round-1`) when the adversarial session's GroupID was empty. Now falls back to using the session ID as the prefix.
+
+### Changed
+
+- **Removed Dead Code from Adversarial Workflow** - Removed `AdversarialRoundCompleteMsg` message type and `OnRoundSubGroupCreated`/`OnRoundComplete` callbacks that were defined but never used. The TUI handles round completion directly via `collapseAdversarialRound` method.
 
 ## [0.12.7] - 2026-01-23
 

--- a/internal/orchestrator/instance_group.go
+++ b/internal/orchestrator/instance_group.go
@@ -26,6 +26,12 @@ func NewInstanceGroup(name string) *InstanceGroup {
 	return grouptypes.NewInstanceGroup(generateID(), name)
 }
 
+// NewInstanceGroupWithID creates a new instance group with a specified ID.
+// Use this when you need a predictable ID (e.g., for round sub-groups).
+func NewInstanceGroupWithID(id, name string) *InstanceGroup {
+	return grouptypes.NewInstanceGroup(id, name)
+}
+
 // NewInstanceGroupWithType creates a new instance group with a session type and objective.
 // The objective is used for LLM-based name generation.
 func NewInstanceGroupWithType(name string, sessionType SessionType, objective string) *InstanceGroup {

--- a/internal/orchestrator/workflows/adversarial/types.go
+++ b/internal/orchestrator/workflows/adversarial/types.go
@@ -50,11 +50,14 @@ func DefaultConfig() Config {
 
 // Round represents one implement-review cycle
 type Round struct {
-	Round      int            `json:"round"`
-	Increment  *IncrementFile `json:"increment,omitempty"`
-	Review     *ReviewFile    `json:"review,omitempty"`
-	StartedAt  time.Time      `json:"started_at"`
-	ReviewedAt *time.Time     `json:"reviewed_at,omitempty"`
+	Round         int            `json:"round"`
+	Increment     *IncrementFile `json:"increment,omitempty"`
+	Review        *ReviewFile    `json:"review,omitempty"`
+	StartedAt     time.Time      `json:"started_at"`
+	ReviewedAt    *time.Time     `json:"reviewed_at,omitempty"`
+	SubGroupID    string         `json:"sub_group_id,omitempty"`   // Sub-group ID for this round's instances
+	ImplementerID string         `json:"implementer_id,omitempty"` // Instance ID of implementer for this round
+	ReviewerID    string         `json:"reviewer_id,omitempty"`    // Instance ID of reviewer for this round
 }
 
 // IncrementFileName is the sentinel file the implementer writes when ready for review

--- a/internal/tui/adversarial_test.go
+++ b/internal/tui/adversarial_test.go
@@ -1,0 +1,183 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator/workflows/adversarial"
+	"github.com/Iron-Ham/claudio/internal/tui/view"
+)
+
+func TestCollapseAdversarialRound(t *testing.T) {
+	tests := []struct {
+		name                  string
+		session               *adversarial.Session
+		round                 int
+		initialGroupViewState *view.GroupViewState
+		wantCollapsed         bool
+		wantSubGroupID        string
+	}{
+		{
+			name:          "nil session",
+			session:       nil,
+			round:         1,
+			wantCollapsed: false,
+		},
+		{
+			name: "valid round with sub-group ID",
+			session: &adversarial.Session{
+				ID: "test-session",
+				History: []adversarial.Round{
+					{
+						Round:      1,
+						SubGroupID: "adv-123-round-1",
+						StartedAt:  time.Now(),
+					},
+				},
+			},
+			round:          1,
+			wantCollapsed:  true,
+			wantSubGroupID: "adv-123-round-1",
+		},
+		{
+			name: "valid round with existing groupViewState",
+			session: &adversarial.Session{
+				ID: "test-session",
+				History: []adversarial.Round{
+					{
+						Round:      1,
+						SubGroupID: "adv-123-round-1",
+						StartedAt:  time.Now(),
+					},
+				},
+			},
+			round:                 1,
+			initialGroupViewState: view.NewGroupViewState(),
+			wantCollapsed:         true,
+			wantSubGroupID:        "adv-123-round-1",
+		},
+		{
+			name: "round number too low",
+			session: &adversarial.Session{
+				ID: "test-session",
+				History: []adversarial.Round{
+					{Round: 1, SubGroupID: "adv-123-round-1"},
+				},
+			},
+			round:         0, // Invalid round number
+			wantCollapsed: false,
+		},
+		{
+			name: "round number too high",
+			session: &adversarial.Session{
+				ID: "test-session",
+				History: []adversarial.Round{
+					{Round: 1, SubGroupID: "adv-123-round-1"},
+				},
+			},
+			round:         5, // Higher than history length
+			wantCollapsed: false,
+		},
+		{
+			name: "empty sub-group ID in history",
+			session: &adversarial.Session{
+				ID: "test-session",
+				History: []adversarial.Round{
+					{Round: 1, SubGroupID: ""}, // Empty sub-group ID
+				},
+			},
+			round:         1,
+			wantCollapsed: false,
+		},
+		{
+			name: "multiple rounds collapse second round",
+			session: &adversarial.Session{
+				ID: "test-session",
+				History: []adversarial.Round{
+					{Round: 1, SubGroupID: "adv-123-round-1"},
+					{Round: 2, SubGroupID: "adv-123-round-2"},
+					{Round: 3, SubGroupID: "adv-123-round-3"},
+				},
+			},
+			round:          2,
+			wantCollapsed:  true,
+			wantSubGroupID: "adv-123-round-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Model{
+				groupViewState: tt.initialGroupViewState,
+			}
+
+			m.collapseAdversarialRound(tt.session, tt.round)
+
+			if tt.wantCollapsed {
+				if m.groupViewState == nil {
+					t.Fatal("groupViewState should have been initialized")
+				}
+				if !m.groupViewState.CollapsedGroups[tt.wantSubGroupID] {
+					t.Errorf("expected sub-group %q to be collapsed", tt.wantSubGroupID)
+				}
+			} else if tt.wantSubGroupID != "" {
+				// If we expected no collapse but had a sub-group ID, verify it's not collapsed
+				if m.groupViewState != nil && m.groupViewState.CollapsedGroups[tt.wantSubGroupID] {
+					t.Errorf("expected sub-group %q to NOT be collapsed", tt.wantSubGroupID)
+				}
+			}
+		})
+	}
+}
+
+func TestCollapseAdversarialRoundInitializesGroupViewState(t *testing.T) {
+	m := &Model{
+		groupViewState: nil, // Start with nil
+	}
+
+	session := &adversarial.Session{
+		ID: "test-session",
+		History: []adversarial.Round{
+			{Round: 1, SubGroupID: "adv-123-round-1"},
+		},
+	}
+
+	m.collapseAdversarialRound(session, 1)
+
+	if m.groupViewState == nil {
+		t.Fatal("groupViewState should have been initialized")
+	}
+	if m.groupViewState.CollapsedGroups == nil {
+		t.Fatal("CollapsedGroups map should have been initialized")
+	}
+	if !m.groupViewState.CollapsedGroups["adv-123-round-1"] {
+		t.Error("expected sub-group to be collapsed")
+	}
+}
+
+func TestCollapseAdversarialRoundPreservesExistingState(t *testing.T) {
+	// Pre-populate with existing collapsed group
+	existingState := view.NewGroupViewState()
+	existingState.CollapsedGroups["other-group"] = true
+
+	m := &Model{
+		groupViewState: existingState,
+	}
+
+	session := &adversarial.Session{
+		ID: "test-session",
+		History: []adversarial.Round{
+			{Round: 1, SubGroupID: "adv-123-round-1"},
+		},
+	}
+
+	m.collapseAdversarialRound(session, 1)
+
+	// Verify both groups are collapsed
+	if !m.groupViewState.CollapsedGroups["other-group"] {
+		t.Error("existing collapsed group should be preserved")
+	}
+	if !m.groupViewState.CollapsedGroups["adv-123-round-1"] {
+		t.Error("new group should be collapsed")
+	}
+}


### PR DESCRIPTION
## Summary

- Completed rounds in adversarial mode now automatically collapse into sub-groups, keeping the sidebar clean while preserving access to round history
- Each round (implementer + reviewer instances) is organized into a "Round N" sub-group
- When a round is rejected and a new round starts, the completed round's sub-group automatically collapses
- The final approved round remains expanded so users can see the successful review
- Users can manually toggle any round's expansion state

## Bug Fixes

- Fixed an edge case where sub-group IDs would be malformed (e.g., `-round-1` instead of `session-id-round-1`) when the adversarial session's GroupID was empty. Now falls back to using the session ID as the prefix.

## Code Quality

- Removed dead code: `AdversarialRoundCompleteMsg` message type and `OnRoundSubGroupCreated`/`OnRoundComplete` callbacks that were defined but never used
- Added comprehensive test coverage for `collapseAdversarialRound` (TUI) and `getOrCreateRoundSubGroup` (coordinator)
- 91.4% test coverage in the adversarial package

## Test plan

- [x] All tests pass (`go test ./...`)
- [x] Code passes `go vet ./...`
- [x] Code passes `gofmt -d .`
- [x] Verified auto-collapse behavior in adversarial mode
- [x] Verified final approved round stays expanded
- [x] Verified empty GroupID fallback works correctly