### PR TITLE
Exit input mode when plan editor opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Input Mode Not Exited When Plan Editor Opens** - Fixed a UI bug where users in input mode (tmux passthrough) would remain stuck in input mode when an ultraplan became ready and the plan editor opened. Keystrokes intended for plan editor navigation (j/k, Enter, etc.) would be sent to the tmux session instead of being handled by the plan editor. The plan editor now automatically exits input mode when entering, ensuring users can immediately interact with the plan.
+
 - **Plan File Written to Wrong Location in Worktrees** - Fixed a bug where ultraplan coordinators would write `.claudio-plan.json` to the main repository root instead of the worktree directory. The planning prompt instructed Claude to write "at the repository root", which was ambiguous when running in a git worktree—Claude would follow the worktree's `.git` reference and write to the main repo. Changed the prompt to explicitly say "in your current working directory" with the `./` prefix, ensuring the plan file is written to the correct worktree location where the detection code expects it.
 - **Theme Persistence** - Theme selection now persists across application restarts. The TUI's `Init()` function now applies the user's saved theme preference from config at startup.
 - **Theme Config Validation** - Invalid theme names in config are now caught during validation and reported with a clear error message listing valid theme options.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -460,6 +460,9 @@ func (m *Model) autoEnableGroupedMode() {
 
 // enterPlanEditor initializes the plan editor state when entering edit mode
 func (m *Model) enterPlanEditor() {
+	// Exit input mode so keystrokes go to the plan editor, not the tmux session
+	m.inputMode = false
+
 	m.planEditor = &PlanEditorState{
 		active:              true,
 		inlineMode:          false, // Default to ultraplan mode
@@ -477,6 +480,9 @@ func (m *Model) enterPlanEditor() {
 
 // enterInlinePlanEditor initializes the plan editor for inline plan mode
 func (m *Model) enterInlinePlanEditor() {
+	// Exit input mode so keystrokes go to the plan editor, not the tmux session
+	m.inputMode = false
+
 	m.planEditor = &PlanEditorState{
 		active:              true,
 		inlineMode:          true,

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -1163,6 +1163,7 @@ func TestIsPlanEditorActive(t *testing.T) {
 func TestEnterPlanEditor(t *testing.T) {
 	m := Model{
 		planEditor: nil,
+		inputMode:  true, // Start in input mode to verify it gets disabled
 	}
 
 	m.enterPlanEditor()
@@ -1181,6 +1182,10 @@ func TestEnterPlanEditor(t *testing.T) {
 
 	if !m.planEditor.showValidationPanel {
 		t.Error("expected showValidationPanel to be true by default")
+	}
+
+	if m.inputMode {
+		t.Error("expected inputMode to be false after entering plan editor")
 	}
 }
 
@@ -1533,6 +1538,7 @@ func TestEnterInlinePlanEditor(t *testing.T) {
 	m := Model{
 		inlinePlan:      state,
 		terminalManager: terminal.NewManager(),
+		inputMode:       true, // Start in input mode to verify it gets disabled
 	}
 
 	m.enterInlinePlanEditor()
@@ -1548,6 +1554,9 @@ func TestEnterInlinePlanEditor(t *testing.T) {
 	}
 	if m.planEditor.selectedTaskIdx != 0 {
 		t.Error("expected selectedTaskIdx to be 0")
+	}
+	if m.inputMode {
+		t.Error("expected inputMode to be false after entering inline plan editor")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes UI bug where users in input mode (tmux passthrough) would remain stuck when an ultraplan becomes ready and the plan editor opens
- Keystrokes intended for plan editor navigation (j/k, Enter, etc.) were being sent to tmux instead of being handled by the plan editor
- Added `m.inputMode = false` at the start of both `enterPlanEditor()` and `enterInlinePlanEditor()` to ensure immediate plan editor interaction

## Test plan

- [x] Added assertion to `TestEnterPlanEditor` verifying inputMode is disabled
- [x] Added assertion to `TestEnterInlinePlanEditor` verifying inputMode is disabled
- [x] All existing tests pass (`go test ./...`)
- [x] Pre-commit checks pass (`gofmt -d .`, `go vet ./...`, `go build ./...`)

## Manual testing

1. Start Claudio and enter input mode (`i`)
2. Run `:ultraplan` command with an objective
3. Wait for plan to be generated and plan editor to open
4. Verify keystrokes (j/k for navigation, Enter for selection) work in plan editor