### PR TITLE
Add adversarial flag to tripleshot and ultraplan workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Adversarial Review Mode for Tripleshot** - Added `--adversarial` flag to the `tripleshot` command. When enabled, each of the three implementers is paired with a critical reviewer and won't be considered complete until the reviewer approves the work (score >= 8/10). The adversarial phase runs between the working phase and evaluation phase. If a reviewer rejects an attempt, it's marked as failed. The setting can also be configured as a default in `config.yaml` under `tripleshot.adversarial`.
+
+- **Adversarial Flag Infrastructure for Ultraplan (Experimental)** - Added `--adversarial` flag configuration infrastructure to the `ultraplan` command. The flag can be set via CLI or configured in `config.yaml` under `ultraplan.adversarial`. This is marked as EXPERIMENTAL and disabled by default. Note: The workflow integration (spawning reviewers, waiting for approval) is not yet implemented for ultraplan; this is plumbing-only for a follow-up PR.
+
 - **Background Cleanup Jobs** - The `claudio cleanup` command now runs in the background by default, significantly improving performance when there are many worktrees. Resources are snapshotted at command invocation time, ensuring that new worktrees created during cleanup are not affected—even when using `--all-sessions --force --deep-clean`. Use `--foreground` to run synchronously as before. Check job status with `--job-status <job-id>`. Old job files are automatically cleaned up after 24 hours.
 
 - **Triple-Shot Implementers Auto-Collapse** - When the judge (fourth session) starts running in a tripleshot workflow, the implementers sub-group is now automatically collapsed in the TUI sidebar. This focuses attention on the judge instance while keeping the three implementer instances accessible via manual expand.

--- a/internal/cmd/planning/ultraplan_test.go
+++ b/internal/cmd/planning/ultraplan_test.go
@@ -1,0 +1,177 @@
+package planning
+
+import (
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/spf13/cobra"
+)
+
+// TestApplyUltraplanFlagOverrides tests the flag override behavior.
+// When a flag is explicitly set via CLI, it should override the config file value.
+// When a flag is NOT set via CLI, the config file value should be preserved.
+func TestApplyUltraplanFlagOverrides(t *testing.T) {
+	tests := []struct {
+		name           string
+		configValue    bool // initial value from config
+		flagValue      bool // value set on the flag variable
+		flagChanged    bool // whether the flag was explicitly set via CLI
+		expectedResult bool // expected final value
+	}{
+		{
+			name:           "flag not set, config true - preserves config value",
+			configValue:    true,
+			flagValue:      false, // default flag value
+			flagChanged:    false,
+			expectedResult: true, // config value preserved
+		},
+		{
+			name:           "flag not set, config false - preserves config value",
+			configValue:    false,
+			flagValue:      false,
+			flagChanged:    false,
+			expectedResult: false,
+		},
+		{
+			name:           "flag explicitly set to true - overrides config",
+			configValue:    false,
+			flagValue:      true,
+			flagChanged:    true,
+			expectedResult: true, // flag value used
+		},
+		{
+			name:           "flag explicitly set to false - overrides config",
+			configValue:    true,
+			flagValue:      false,
+			flagChanged:    true,
+			expectedResult: false, // flag value used
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fresh command for each test
+			cmd := &cobra.Command{Use: "test"}
+
+			// Add the adversarial flag
+			var adversarialFlag bool
+			cmd.Flags().BoolVar(&adversarialFlag, "adversarial", tt.flagValue, "test flag")
+
+			// Mark flag as changed if test case requires it
+			if tt.flagChanged {
+				_ = cmd.Flags().Set("adversarial", boolToString(tt.flagValue))
+			}
+
+			// Create config with initial value
+			cfg := &orchestrator.UltraPlanConfig{
+				Adversarial: tt.configValue,
+			}
+
+			// Apply the override logic (same logic as applyUltraplanFlagOverrides)
+			if cmd.Flags().Changed("adversarial") {
+				cfg.Adversarial = adversarialFlag
+			}
+
+			// Verify result
+			if cfg.Adversarial != tt.expectedResult {
+				t.Errorf("Adversarial = %v, want %v", cfg.Adversarial, tt.expectedResult)
+			}
+		})
+	}
+}
+
+// TestApplyUltraplanFlagOverrides_AllFlags tests all flags in applyUltraplanFlagOverrides
+func TestApplyUltraplanFlagOverrides_AllFlags(t *testing.T) {
+	t.Run("max-parallel override", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		var maxParallel int
+		cmd.Flags().IntVar(&maxParallel, "max-parallel", 3, "test flag")
+		_ = cmd.Flags().Set("max-parallel", "5")
+
+		cfg := &orchestrator.UltraPlanConfig{MaxParallel: 3}
+		if cmd.Flags().Changed("max-parallel") {
+			cfg.MaxParallel = maxParallel
+		}
+
+		if cfg.MaxParallel != 5 {
+			t.Errorf("MaxParallel = %v, want 5", cfg.MaxParallel)
+		}
+	})
+
+	t.Run("multi-pass override", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		var multiPass bool
+		cmd.Flags().BoolVar(&multiPass, "multi-pass", false, "test flag")
+		_ = cmd.Flags().Set("multi-pass", "true")
+
+		cfg := &orchestrator.UltraPlanConfig{MultiPass: false}
+		if cmd.Flags().Changed("multi-pass") {
+			cfg.MultiPass = multiPass
+		}
+
+		if !cfg.MultiPass {
+			t.Errorf("MultiPass = %v, want true", cfg.MultiPass)
+		}
+	})
+
+	t.Run("adversarial override", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		var adversarial bool
+		cmd.Flags().BoolVar(&adversarial, "adversarial", false, "test flag")
+		_ = cmd.Flags().Set("adversarial", "true")
+
+		cfg := &orchestrator.UltraPlanConfig{Adversarial: false}
+		if cmd.Flags().Changed("adversarial") {
+			cfg.Adversarial = adversarial
+		}
+
+		if !cfg.Adversarial {
+			t.Errorf("Adversarial = %v, want true", cfg.Adversarial)
+		}
+	})
+
+	t.Run("unchanged flags preserve config", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		var maxParallel int
+		var multiPass, adversarial bool
+		cmd.Flags().IntVar(&maxParallel, "max-parallel", 3, "")
+		cmd.Flags().BoolVar(&multiPass, "multi-pass", false, "")
+		cmd.Flags().BoolVar(&adversarial, "adversarial", false, "")
+
+		// Config has specific values
+		cfg := &orchestrator.UltraPlanConfig{
+			MaxParallel: 10,
+			MultiPass:   true,
+			Adversarial: true,
+		}
+
+		// Apply overrides (but no flags were changed)
+		if cmd.Flags().Changed("max-parallel") {
+			cfg.MaxParallel = maxParallel
+		}
+		if cmd.Flags().Changed("multi-pass") {
+			cfg.MultiPass = multiPass
+		}
+		if cmd.Flags().Changed("adversarial") {
+			cfg.Adversarial = adversarial
+		}
+
+		// Values should remain unchanged
+		if cfg.MaxParallel != 10 {
+			t.Errorf("MaxParallel = %v, want 10", cfg.MaxParallel)
+		}
+		if !cfg.MultiPass {
+			t.Errorf("MultiPass = %v, want true", cfg.MultiPass)
+		}
+		if !cfg.Adversarial {
+			t.Errorf("Adversarial = %v, want true", cfg.Adversarial)
+		}
+	})
+}
+
+func boolToString(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -684,3 +684,71 @@ func TestSparseCheckoutConfig_GetSparseDirectories(t *testing.T) {
 		}
 	})
 }
+
+func TestConfig_TripleshotConfig_Defaults(t *testing.T) {
+	cfg := Default()
+
+	// AutoApprove should default to false
+	if cfg.Tripleshot.AutoApprove {
+		t.Error("Tripleshot.AutoApprove should be false by default")
+	}
+
+	// Adversarial should default to false
+	if cfg.Tripleshot.Adversarial {
+		t.Error("Tripleshot.Adversarial should be false by default")
+	}
+}
+
+func TestConfig_TripleshotConfig_ViperLoading(t *testing.T) {
+	// Test that tripleshot config is properly loaded via viper
+	viper.Reset()
+	SetDefaults()
+
+	// After SetDefaults, tripleshot values should be the defaults
+	if viper.GetBool("tripleshot.auto_approve") {
+		t.Error("viper.GetBool('tripleshot.auto_approve') should be false by default")
+	}
+	if viper.GetBool("tripleshot.adversarial") {
+		t.Error("viper.GetBool('tripleshot.adversarial') should be false by default")
+	}
+
+	// Test setting via viper (simulates config file or environment)
+	viper.Set("tripleshot.auto_approve", true)
+	viper.Set("tripleshot.adversarial", true)
+
+	cfg := Get()
+	if !cfg.Tripleshot.AutoApprove {
+		t.Error("Tripleshot.AutoApprove should be true after viper.Set(true)")
+	}
+	if !cfg.Tripleshot.Adversarial {
+		t.Error("Tripleshot.Adversarial should be true after viper.Set(true)")
+	}
+}
+
+func TestConfig_UltraplanConfig_Adversarial_Defaults(t *testing.T) {
+	cfg := Default()
+
+	// Adversarial should default to false
+	if cfg.Ultraplan.Adversarial {
+		t.Error("Ultraplan.Adversarial should be false by default")
+	}
+}
+
+func TestConfig_UltraplanConfig_Adversarial_ViperLoading(t *testing.T) {
+	// Test that ultraplan adversarial config is properly loaded via viper
+	viper.Reset()
+	SetDefaults()
+
+	// After SetDefaults, adversarial should be false
+	if viper.GetBool("ultraplan.adversarial") {
+		t.Error("viper.GetBool('ultraplan.adversarial') should be false by default")
+	}
+
+	// Test setting via viper (simulates config file or CLI flag)
+	viper.Set("ultraplan.adversarial", true)
+
+	cfg := Get()
+	if !cfg.Ultraplan.Adversarial {
+		t.Error("Ultraplan.Adversarial should be true after viper.Set(true)")
+	}
+}

--- a/internal/orchestrator/ultraplan.go
+++ b/internal/orchestrator/ultraplan.go
@@ -166,6 +166,12 @@ type UltraPlanConfig struct {
 	AutoApprove bool `json:"auto_approve"` // Auto-approve spawned tasks without confirmation
 	Review      bool `json:"review"`       // Force plan editor to open for review (overrides AutoApprove)
 	MultiPass   bool `json:"multi_pass"`   // Enable multi-pass planning with plan comparison
+	// Adversarial enables adversarial review mode where each task must pass review before completion.
+	// NOTE: This flag is currently infrastructure-only for ultraplan. The configuration is plumbed through
+	// but the workflow integration (spawning reviewers, waiting for approval) is not yet implemented.
+	// See tripleshot.Config.Adversarial for a fully functional implementation.
+	// TODO: Implement ultraplan adversarial review in follow-up PR.
+	Adversarial bool `json:"adversarial"`
 
 	// Consolidation settings
 	ConsolidationMode ConsolidationMode `json:"consolidation_mode,omitempty"` // "stacked" or "single"
@@ -186,6 +192,7 @@ func DefaultUltraPlanConfig() UltraPlanConfig {
 		NoSynthesis:            false,
 		AutoApprove:            false,
 		MultiPass:              false,
+		Adversarial:            false,
 		ConsolidationMode:      ModeStackedPRs,
 		CreateDraftPRs:         true,
 		PRLabels:               []string{"ultraplan"},

--- a/internal/orchestrator/workflow_adapters.go
+++ b/internal/orchestrator/workflow_adapters.go
@@ -21,6 +21,12 @@ func (a *orchestratorAdapter) AddInstance(session tripleshot.SessionInterface, t
 	return a.orch.AddInstance(s, task)
 }
 
+func (a *orchestratorAdapter) AddInstanceToWorktree(session tripleshot.SessionInterface, task, worktreePath, branch string) (tripleshot.InstanceInterface, error) {
+	// Convert session interface back to concrete Session
+	s := session.(*sessionAdapter).session
+	return a.orch.AddInstanceToWorktree(s, task, worktreePath, branch)
+}
+
 func (a *orchestratorAdapter) StartInstance(inst tripleshot.InstanceInterface) error {
 	// The inst should be an *Instance which already satisfies the interface
 	i := inst.(*Instance)

--- a/internal/orchestrator/workflows/tripleshot/session.go
+++ b/internal/orchestrator/workflows/tripleshot/session.go
@@ -45,9 +45,12 @@ func NewSession(task string, config Config) *Session {
 }
 
 // AllAttemptsComplete returns true if all three attempts have completed (success or failure)
+// Note: AttemptStatusUnderReview is NOT considered complete - the attempt must either
+// pass review (AttemptStatusCompleted) or fail review (AttemptStatusFailed).
 func (s *Session) AllAttemptsComplete() bool {
 	for _, attempt := range s.Attempts {
-		if attempt.Status == AttemptStatusWorking || attempt.Status == AttemptStatusPending {
+		switch attempt.Status {
+		case AttemptStatusPending, AttemptStatusWorking, AttemptStatusUnderReview:
 			return false
 		}
 	}

--- a/internal/tui/config/config.go
+++ b/internal/tui/config/config.go
@@ -306,6 +306,13 @@ func New() Model {
 					Category:    "ultraplan",
 				},
 				{
+					Key:         "ultraplan.adversarial",
+					Label:       "Adversarial Mode",
+					Description: "Each task must pass reviewer approval before completion",
+					Type:        "bool",
+					Category:    "ultraplan",
+				},
+				{
 					Key:         "ultraplan.consolidation_mode",
 					Label:       "Consolidation Mode",
 					Description: "How to consolidate completed work: stacked or single PR",
@@ -402,6 +409,25 @@ func New() Model {
 					Description: "Default JSON output file path",
 					Type:        "string",
 					Category:    "plan",
+				},
+			},
+		},
+		{
+			Name: "Tripleshot",
+			Items: []ConfigItem{
+				{
+					Key:         "tripleshot.auto_approve",
+					Label:       "Auto Approve",
+					Description: "Skip confirmation for applying winning solution",
+					Type:        "bool",
+					Category:    "tripleshot",
+				},
+				{
+					Key:         "tripleshot.adversarial",
+					Label:       "Adversarial Mode",
+					Description: "Each implementer must pass reviewer approval before completion",
+					Type:        "bool",
+					Category:    "tripleshot",
 				},
 			},
 		},
@@ -1190,6 +1216,7 @@ func (m *Model) resetCurrentToDefault() {
 		// Ultraplan
 		"ultraplan.max_parallel":             defaults.Ultraplan.MaxParallel,
 		"ultraplan.multi_pass":               defaults.Ultraplan.MultiPass,
+		"ultraplan.adversarial":              defaults.Ultraplan.Adversarial,
 		"ultraplan.consolidation_mode":       defaults.Ultraplan.ConsolidationMode,
 		"ultraplan.create_draft_prs":         defaults.Ultraplan.CreateDraftPRs,
 		"ultraplan.pr_labels":                strings.Join(defaults.Ultraplan.PRLabels, ","),
@@ -1204,6 +1231,9 @@ func (m *Model) resetCurrentToDefault() {
 		"plan.multi_pass":    defaults.Plan.MultiPass,
 		"plan.labels":        strings.Join(defaults.Plan.Labels, ","),
 		"plan.output_file":   defaults.Plan.OutputFile,
+		// Tripleshot
+		"tripleshot.auto_approve": defaults.Tripleshot.AutoApprove,
+		"tripleshot.adversarial":  defaults.Tripleshot.Adversarial,
 		// Adversarial
 		"adversarial.max_iterations":    defaults.Adversarial.MaxIterations,
 		"adversarial.min_passing_score": defaults.Adversarial.MinPassingScore,

--- a/internal/ultraplan/init.go
+++ b/internal/ultraplan/init.go
@@ -27,6 +27,7 @@ func BuildConfigFromFile() orchestrator.UltraPlanConfig {
 // The function applies config file settings to the default UltraPlanConfig:
 //   - MaxParallel: maximum concurrent child sessions
 //   - MultiPass: enable multi-pass planning
+//   - Adversarial: enable adversarial review mode per task
 //   - ConsolidationMode: "stacked" or "single" PR mode
 //   - CreateDraftPRs: create PRs as drafts
 //   - PRLabels: labels to add to created PRs
@@ -43,6 +44,7 @@ func BuildConfigFromAppConfig(cfg *config.Config) orchestrator.UltraPlanConfig {
 	// Apply config file settings
 	ultraCfg.MaxParallel = cfg.Ultraplan.MaxParallel
 	ultraCfg.MultiPass = cfg.Ultraplan.MultiPass
+	ultraCfg.Adversarial = cfg.Ultraplan.Adversarial
 
 	if cfg.Ultraplan.ConsolidationMode != "" {
 		ultraCfg.ConsolidationMode = orchestrator.ConsolidationMode(cfg.Ultraplan.ConsolidationMode)

--- a/internal/ultraplan/init_test.go
+++ b/internal/ultraplan/init_test.go
@@ -165,11 +165,25 @@ func TestBuildConfigFromAppConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "applies Adversarial from config",
+			cfg: &config.Config{
+				Ultraplan: config.UltraplanConfig{
+					Adversarial: true,
+				},
+			},
+			validate: func(t *testing.T, got orchestrator.UltraPlanConfig) {
+				if !got.Adversarial {
+					t.Errorf("Adversarial = false, want true")
+				}
+			},
+		},
+		{
 			name: "applies all settings from config",
 			cfg: &config.Config{
 				Ultraplan: config.UltraplanConfig{
 					MaxParallel:            10,
 					MultiPass:              true,
+					Adversarial:            true,
 					ConsolidationMode:      "single",
 					CreateDraftPRs:         false,
 					PRLabels:               []string{"label1"},
@@ -184,6 +198,9 @@ func TestBuildConfigFromAppConfig(t *testing.T) {
 				}
 				if !got.MultiPass {
 					t.Errorf("MultiPass = false, want true")
+				}
+				if !got.Adversarial {
+					t.Errorf("Adversarial = false, want true")
 				}
 				if got.ConsolidationMode != orchestrator.ModeSinglePR {
 					t.Errorf("ConsolidationMode = %s, want %s", got.ConsolidationMode, orchestrator.ModeSinglePR)


### PR DESCRIPTION
## Summary

- Add `--adversarial` flag to `tripleshot` command that enables adversarial review mode where each implementer must pass review before completion
- Add `--adversarial` flag infrastructure to `ultraplan` command (experimental, plumbing-only)
- Add configurable defaults via `tripleshot.adversarial` and `ultraplan.adversarial` in config

## Key Changes

### Tripleshot Adversarial Mode
- Each of the three implementers is paired with a critical reviewer
- Implementation won't be considered complete until reviewer approves (score >= configured threshold)
- Adversarial phase runs between working phase and evaluation phase
- If reviewer rejects an attempt, it's marked as failed

### Configuration
- `tripleshot.adversarial` - Enable adversarial mode by default for tripleshot
- `ultraplan.adversarial` - Enable adversarial mode by default for ultraplan (experimental)
- `adversarial.min_passing_score` - Minimum score (1-10) required for approval (default: 8)

### Technical Details
- Added `MinPassingScore` to `tripleshot.Config` for configurable threshold
- Added `FindAdversarialReviewFile` with subdirectory search for consistency
- Added `AdversarialReviewFile.Validate()` to catch malformed LLM output
- Consolidated duplicate file-finding logic into `findSentinelFile` helper
- Comprehensive test coverage for adversarial workflow code paths

## Test plan

- [x] `go test ./...` passes
- [x] `go build ./...` succeeds  
- [x] `go vet ./...` has no errors
- [x] `gofmt -d .` shows no formatting issues
- [x] New adversarial workflow tests cover approval/rejection flows
- [x] Config tests verify default values and viper loading
- [x] `AdversarialReviewFile.Validate()` catches invalid scores, rounds, and attempt indices