### PR TITLE
Add J/K keybindings for sidebar-only scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Adversarial Round Auto-Collapse** - Completed rounds in adversarial mode now automatically collapse into sub-groups, keeping the sidebar clean while preserving access to round history. Each round (implementer + reviewer instances) is organized into a "Round N" sub-group. When a round is rejected and a new round starts, the completed round's sub-group automatically collapses. The final approved round remains expanded so users can see the successful review. Users can manually toggle any round's expansion state.
 
+- **Sidebar Scroll-Only Navigation** - Added `J` (Shift+j) and `K` (Shift+k) keybindings to scroll the sidebar viewport without changing the selected instance. This allows users to view instances "above the fold" (indicated by "▲ N more above") without losing their current selection. Previously, users had to cycle through all instances using `tab`/`h`/`l` to see items outside the viewport.
+
 ### Fixed
 
 - **Input Mode Not Exited When Plan Editor Opens** - Fixed a UI bug where users in input mode (tmux passthrough) would remain stuck in input mode when an ultraplan became ready and the plan editor opened. Keystrokes intended for plan editor navigation (j/k, Enter, etc.) would be sent to the tmux session instead of being handled by the plan editor. The plan editor now automatically exits input mode when entering, ensuring users can immediately interact with the plan.

--- a/internal/tui/keyhandler.go
+++ b/internal/tui/keyhandler.go
@@ -506,6 +506,12 @@ func (m Model) handleNormalModeKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "k", "up":
 		return m.handleScrollUp()
 
+	case "J":
+		return m.handleSidebarScrollDown()
+
+	case "K":
+		return m.handleSidebarScrollUp()
+
 	case "ctrl+u":
 		return m.handleHalfPageUp()
 
@@ -933,6 +939,28 @@ func (m Model) handleGoToBottom() (tea.Model, tea.Cmd) {
 	}
 	if inst := m.activeInstance(); inst != nil {
 		m.scrollOutputToBottom(inst.ID)
+	}
+	return m, nil
+}
+
+// handleSidebarScrollUp scrolls the sidebar viewport up without changing selection.
+// This allows viewing instances above the current viewport while keeping the
+// currently selected instance unchanged.
+func (m Model) handleSidebarScrollUp() (tea.Model, tea.Cmd) {
+	if m.sidebarScrollOffset > 0 {
+		m.sidebarScrollOffset--
+	}
+	return m, nil
+}
+
+// handleSidebarScrollDown scrolls the sidebar viewport down without changing selection.
+// This allows viewing instances below the current viewport while keeping the
+// currently selected instance unchanged.
+func (m Model) handleSidebarScrollDown() (tea.Model, tea.Cmd) {
+	// Calculate max scroll offset based on number of items and visible space
+	maxOffset := m.calculateSidebarMaxScrollOffset()
+	if m.sidebarScrollOffset < maxOffset {
+		m.sidebarScrollOffset++
 	}
 	return m, nil
 }

--- a/internal/tui/panel/help.go
+++ b/internal/tui/panel/help.go
@@ -132,7 +132,8 @@ func DefaultHelpSections() []HelpSection {
 			Title: "Navigation",
 			Items: []HelpItem{
 				{Key: "Tab/l  Shift+Tab/h", Description: "Next / Previous instance"},
-				{Key: "j/↓  k/↑", Description: "Scroll down / up one line"},
+				{Key: "j/↓  k/↑", Description: "Scroll output down / up"},
+				{Key: "J  K", Description: "Scroll sidebar down / up (view only)"},
 				{Key: "Ctrl+D/U  Ctrl+F/B", Description: "Scroll half / full page"},
 				{Key: "0  G", Description: "Jump to top / bottom"},
 			},

--- a/internal/tui/view/sidebar.go
+++ b/internal/tui/view/sidebar.go
@@ -221,7 +221,7 @@ func (sv *SidebarView) RenderGroupedSidebar(state SidebarState, width, height in
 	if len(items) > 0 {
 		hintStyle := styles.Muted
 		helpHint := hintStyle.Render("[h/l]") + " " + hintStyle.Render("nav") + "  " +
-			hintStyle.Render("[gn/gp]") + " " + hintStyle.Render("groups") + "  " +
+			hintStyle.Render("[J/K]") + " " + hintStyle.Render("scroll") + "  " +
 			hintStyle.Render("[gc]") + " " + hintStyle.Render("toggle")
 		b.WriteString(helpHint)
 	} else {

--- a/internal/tui/view/sidebar_test.go
+++ b/internal/tui/view/sidebar_test.go
@@ -234,9 +234,12 @@ func TestSidebarView_GroupNavHints(t *testing.T) {
 	sv := NewSidebarView()
 	result := sv.RenderSidebar(state, 50, 25)
 
-	// Should contain group navigation hints
-	if !strings.Contains(result, "[gn/gp]") {
-		t.Errorf("should show [gn/gp] hint for group navigation, got:\n%s", result)
+	// Should contain navigation and sidebar scroll hints
+	if !strings.Contains(result, "[h/l]") || !strings.Contains(result, "nav") {
+		t.Errorf("should show [h/l] nav hint for instance navigation, got:\n%s", result)
+	}
+	if !strings.Contains(result, "[J/K]") || !strings.Contains(result, "scroll") {
+		t.Errorf("should show [J/K] scroll hint for sidebar scrolling, got:\n%s", result)
 	}
 	if !strings.Contains(result, "[gc]") || !strings.Contains(result, "toggle") {
 		t.Errorf("should show [gc] toggle hint, got:\n%s", result)


### PR DESCRIPTION
## Summary
- Add J/K keys to scroll the sidebar viewport up/down without changing the selected instance
- This allows users to view instances "above the fold" while keeping their current selection
- Mirrors the j/k pattern used for output scrolling

## Changes
- Add `handleSidebarScrollUp` and `handleSidebarScrollDown` handlers in keyhandler.go
- Add `calculateSidebarMaxScrollOffset` helper in model.go for bounds checking
- Update help panel with new keybindings documentation
- Update sidebar hints to show `[J/K] scroll`
- Add comprehensive tests verifying scroll behavior and selection preservation

## Test plan
- [x] Verify J scrolls sidebar down (towards higher indices)
- [x] Verify K scrolls sidebar up (towards lower indices)
- [x] Verify scrolling does NOT change the selected instance (activeTab)
- [x] Verify scroll stops at boundaries (can't scroll past top or bottom)
- [x] Verify works in both flat and grouped sidebar modes
- [x] All existing tests pass
- [x] New tests pass: `go test ./internal/tui/...`