### PR TITLE
Add Previous Rounds container for adversarial mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Sidebar Scroll-Only Navigation** - Added `J` (Shift+j) and `K` (Shift+k) keybindings to scroll the sidebar viewport without changing the selected instance. This allows users to view instances "above the fold" (indicated by "▲ N more above") without losing their current selection. Previously, users had to cycle through all instances using `tab`/`h`/`l` to see items outside the viewport.
 
+- **Previous Rounds Container** - Adversarial mode now condenses all completed rounds into a single "Previous Rounds" container group, reducing sidebar clutter when tasks span many rounds. When round 2+ starts, the previous round is automatically moved into the "Previous Rounds" container, which is then collapsed. This means users see only two groups—"Previous Rounds" (collapsed) and the current round (expanded)—instead of navigating through many individual collapsed round groups. Users can expand "Previous Rounds" to access any historical round.
+
 ### Fixed
 
 - **Stale RUNNING Status After Tmux Server Death** - Fixed a race condition where instances would show as "RUNNING" indefinitely after the tmux server died. When the tmux server dies between the session status check and output capture, the capture error was logged but the session existence wasn't re-verified, leaving instances in a stale RUNNING state with no output updates. Now when capture fails, the code verifies the session still exists and properly marks it as completed if the server/session is gone (#403).

--- a/internal/orchestrator/workflows/adversarial/coordinator_test.go
+++ b/internal/orchestrator/workflows/adversarial/coordinator_test.go
@@ -1418,13 +1418,16 @@ type mockGroupWithSubGroups struct {
 	mockGroup
 	subGroups    map[string]GroupInterface
 	subGroupByID map[string]GroupInterface
+	// Track moved sub-groups for testing
+	movedSubGroups map[string]string // subGroupID -> targetID
 }
 
 func newMockGroupWithSubGroups() *mockGroupWithSubGroups {
 	return &mockGroupWithSubGroups{
-		mockGroup:    mockGroup{instances: []string{}},
-		subGroups:    make(map[string]GroupInterface),
-		subGroupByID: make(map[string]GroupInterface),
+		mockGroup:      mockGroup{instances: []string{}},
+		subGroups:      make(map[string]GroupInterface),
+		subGroupByID:   make(map[string]GroupInterface),
+		movedSubGroups: make(map[string]string),
 	}
 }
 
@@ -1442,6 +1445,31 @@ func (m *mockGroupWithSubGroups) GetOrCreateSubGroup(id, name string) GroupInter
 
 func (m *mockGroupWithSubGroups) GetSubGroupByName(name string) GroupInterface {
 	return m.subGroups[name]
+}
+
+func (m *mockGroupWithSubGroups) GetSubGroupByID(id string) GroupInterface {
+	return m.subGroupByID[id]
+}
+
+func (m *mockGroupWithSubGroups) MoveSubGroupUnder(subGroupID, targetID, targetName string) bool {
+	// Check if the sub-group exists
+	if m.subGroupByID[subGroupID] == nil {
+		return false
+	}
+
+	// Create target if it doesn't exist
+	if m.subGroupByID[targetID] == nil {
+		newTarget := &mockGroup{instances: []string{}}
+		m.subGroups[targetName] = newTarget
+		m.subGroupByID[targetID] = newTarget
+	}
+
+	// Track the move (for test verification)
+	m.movedSubGroups[subGroupID] = targetID
+
+	// In a real implementation, we'd remove from subGroups and add to target's subGroups
+	// For testing, we just track that the move was requested
+	return true
 }
 
 func TestCoordinator_GetOrCreateRoundSubGroup_EmptyGroupIDFallback(t *testing.T) {
@@ -1567,5 +1595,136 @@ func TestCoordinator_GetOrCreateRoundSubGroup_GroupWithoutSubGroupSupport(t *tes
 	// SubGroupID should be empty
 	if subGroupID != "" {
 		t.Errorf("subGroupID should be empty when sub-groups not supported, got %q", subGroupID)
+	}
+}
+
+func TestCoordinator_GetOrCreateRoundSubGroup_MovesPreviousRoundToContainer(t *testing.T) {
+	// Test that when creating round 2+, the previous round is moved to "Previous Rounds"
+
+	advSession := NewSession("test-session-123", "test task", DefaultConfig())
+	advSession.GroupID = "adv-group-456"
+
+	cfg := CoordinatorConfig{
+		Orchestrator: &mockOrchestrator{},
+		BaseSession:  newMockSession(),
+		AdvSession:   advSession,
+		SessionType:  "adversarial",
+	}
+	coord := NewCoordinator(cfg)
+
+	mockGroup := newMockGroupWithSubGroups()
+
+	// Create round 1 first
+	_, round1ID := coord.getOrCreateRoundSubGroup(mockGroup, 1)
+
+	// Verify round 1 was created
+	if mockGroup.GetSubGroupByID(round1ID) == nil {
+		t.Fatal("round 1 sub-group should have been created")
+	}
+
+	// Now create round 2 - should trigger move of round 1 to "Previous Rounds"
+	_, round2ID := coord.getOrCreateRoundSubGroup(mockGroup, 2)
+
+	// Verify round 2 was created
+	if mockGroup.GetSubGroupByID(round2ID) == nil {
+		t.Fatal("round 2 sub-group should have been created")
+	}
+
+	// Verify round 1 was moved to "Previous Rounds" container
+	expectedContainerID := "adv-group-456-previous-rounds"
+	if targetID, moved := mockGroup.movedSubGroups[round1ID]; !moved {
+		t.Error("round 1 should have been moved to Previous Rounds container")
+	} else if targetID != expectedContainerID {
+		t.Errorf("round 1 should have been moved to %q, but was moved to %q", expectedContainerID, targetID)
+	}
+
+	// Verify "Previous Rounds" container was created
+	if mockGroup.GetSubGroupByName(PreviousRoundsGroupName) == nil {
+		t.Error("Previous Rounds container should have been created")
+	}
+}
+
+func TestCoordinator_GetOrCreateRoundSubGroup_MovesMultipleRounds(t *testing.T) {
+	// Test that when creating round 3, round 2 is moved (round 1 was already moved)
+
+	advSession := NewSession("test-session-123", "test task", DefaultConfig())
+	advSession.GroupID = "adv-group"
+
+	cfg := CoordinatorConfig{
+		Orchestrator: &mockOrchestrator{},
+		BaseSession:  newMockSession(),
+		AdvSession:   advSession,
+		SessionType:  "adversarial",
+	}
+	coord := NewCoordinator(cfg)
+
+	mockGroup := newMockGroupWithSubGroups()
+
+	// Create round 1
+	_, round1ID := coord.getOrCreateRoundSubGroup(mockGroup, 1)
+
+	// Create round 2 - moves round 1 to container
+	_, round2ID := coord.getOrCreateRoundSubGroup(mockGroup, 2)
+
+	// Verify round 1 was moved
+	if _, moved := mockGroup.movedSubGroups[round1ID]; !moved {
+		t.Error("round 1 should have been moved")
+	}
+
+	// Create round 3 - should move round 2 to container
+	_, _ = coord.getOrCreateRoundSubGroup(mockGroup, 3)
+
+	// Verify round 2 was moved
+	expectedContainerID := "adv-group-previous-rounds"
+	if targetID, moved := mockGroup.movedSubGroups[round2ID]; !moved {
+		t.Error("round 2 should have been moved to Previous Rounds container")
+	} else if targetID != expectedContainerID {
+		t.Errorf("round 2 should have been moved to %q, but was moved to %q", expectedContainerID, targetID)
+	}
+}
+
+func TestGetPreviousRoundsGroupID(t *testing.T) {
+	tests := []struct {
+		name    string
+		session *Session
+		want    string
+	}{
+		{
+			name:    "nil session returns empty",
+			session: nil,
+			want:    "",
+		},
+		{
+			name: "uses GroupID when set",
+			session: &Session{
+				ID:      "session-123",
+				GroupID: "adv-group-456",
+			},
+			want: "adv-group-456-previous-rounds",
+		},
+		{
+			name: "uses session ID when GroupID empty",
+			session: &Session{
+				ID:      "session-123",
+				GroupID: "",
+			},
+			want: "session-123-previous-rounds",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetPreviousRoundsGroupID(tt.session)
+			if got != tt.want {
+				t.Errorf("GetPreviousRoundsGroupID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPreviousRoundsGroupName(t *testing.T) {
+	// Verify the constant has the expected value
+	if PreviousRoundsGroupName != "Previous Rounds" {
+		t.Errorf("PreviousRoundsGroupName = %q, want %q", PreviousRoundsGroupName, "Previous Rounds")
 	}
 }

--- a/internal/tui/adversarial.go
+++ b/internal/tui/adversarial.go
@@ -305,9 +305,14 @@ func (m *Model) handleAdversarialReviewProcessed(msg tuimsg.AdversarialReviewPro
 	return m, nil
 }
 
-// collapseAdversarialRound collapses the sub-group for a completed adversarial round.
-// This keeps the UI clean by hiding completed rounds while preserving the ability
-// for users to expand them manually if needed.
+// collapseAdversarialRound collapses the "Previous Rounds" container group when
+// a round is rejected. This keeps the UI clean by hiding all completed rounds
+// in a single collapsed group while preserving the ability for users to expand
+// them manually if needed.
+//
+// Note: Individual rounds are now moved into the "Previous Rounds" container
+// by the coordinator when a new round starts. This function just ensures the
+// container is collapsed.
 func (m *Model) collapseAdversarialRound(session *adversarial.Session, round int) {
 	if session == nil {
 		return
@@ -318,24 +323,24 @@ func (m *Model) collapseAdversarialRound(session *adversarial.Session, round int
 		m.groupViewState = view.NewGroupViewState()
 	}
 
-	// Find the round in history
-	if round < 1 || round > len(session.History) {
+	// Guard against invalid round numbers
+	if round < 1 {
 		return
 	}
 
-	// Get the sub-group ID for this round
-	subGroupID := session.History[round-1].SubGroupID
-	if subGroupID == "" {
+	// Get the "Previous Rounds" container group ID
+	previousRoundsID := adversarial.GetPreviousRoundsGroupID(session)
+	if previousRoundsID == "" {
 		return
 	}
 
-	// Collapse the sub-group (user can toggle to expand)
-	m.groupViewState.CollapsedGroups[subGroupID] = true
+	// Collapse the "Previous Rounds" container (user can toggle to expand)
+	m.groupViewState.CollapsedGroups[previousRoundsID] = true
 
 	if m.logger != nil {
-		m.logger.Info("auto-collapsed adversarial round sub-group",
+		m.logger.Info("auto-collapsed previous rounds container",
 			"round", round,
-			"sub_group_id", subGroupID,
+			"container_id", previousRoundsID,
 		)
 	}
 }


### PR DESCRIPTION
## Summary

- Condenses all completed rounds into a single "Previous Rounds" container group in adversarial mode
- Reduces sidebar clutter when tasks span many rounds (O(n) collapsed groups → 1 container)
- When round 2+ starts, the previous round is automatically moved into the "Previous Rounds" container
- The container is collapsed after each rejection, so users see only two groups: "Previous Rounds" (collapsed) + current round (expanded)
- Users can expand "Previous Rounds" to access any historical round

## Changes

- Extended `GroupWithSubGroupsInterface` with `GetSubGroupByID` and `MoveSubGroupUnder` methods
- Added `movePreviousRoundToContainer` helper in the coordinator
- Updated `collapseAdversarialRound` to collapse the container instead of individual rounds
- Added `GetPreviousRoundsGroupID` helper function and `PreviousRoundsGroupName` constant

## Test plan

- [x] All existing tests pass
- [x] New tests added for `GetSubGroupByID`, `MoveSubGroupUnder`, and round container logic
- [x] Verified build succeeds with `go build ./...`
- [x] Verified formatting with `gofmt -d .`
- [x] Verified linting with `go vet ./...`