### PR TITLE
Add async task addition with stub sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Previous Rounds Container** - Adversarial mode now condenses all completed rounds into a single "Previous Rounds" container group, reducing sidebar clutter when tasks span many rounds. When round 2+ starts, the previous round is automatically moved into the "Previous Rounds" container, which is then collapsed. This means users see only two groups—"Previous Rounds" (collapsed) and the current round (expanded)—instead of navigating through many individual collapsed round groups. Users can expand "Previous Rounds" to access any historical round.
 
+- **Async Task Addition** - Task addition via `:a` is now significantly faster. When adding a task, a stub instance appears immediately in the sidebar with "PREP" status while the git worktree is created in the background. Once the worktree is ready, the instance transitions to pending (or auto-starts if configured). This two-phase async approach eliminates UI freezes during worktree creation, which can be slow in large repositories.
+
 ### Fixed
 
 - **Stale RUNNING Status After Tmux Server Death** - Fixed a race condition where instances would show as "RUNNING" indefinitely after the tmux server died. When the tmux server dies between the session status check and output capture, the capture error was logged but the session existence wasn't re-verified, leaving instances in a stale RUNNING state with no output updates. Now when capture fails, the code verifies the session still exists and properly marks it as completed if the server/session is gone (#403).

--- a/internal/orchestrator/session.go
+++ b/internal/orchestrator/session.go
@@ -17,6 +17,7 @@ type InstanceStatus string
 
 const (
 	StatusPending      InstanceStatus = "pending"
+	StatusPreparing    InstanceStatus = "preparing" // Worktree creation in progress (async setup)
 	StatusWorking      InstanceStatus = "working"
 	StatusWaitingInput InstanceStatus = "waiting_input"
 	StatusPaused       InstanceStatus = "paused"
@@ -292,6 +293,11 @@ func (s *Session) MarkInstancesInterrupted() {
 		if inst.Status == StatusWorking || inst.Status == StatusWaitingInput {
 			inst.Status = StatusInterrupted
 			inst.InterruptedAt = &now
+		}
+		// StatusPreparing instances have incomplete worktrees - mark as error
+		// so they can be cleaned up or retried
+		if inst.Status == StatusPreparing {
+			inst.Status = StatusError
 		}
 	}
 	s.InterruptedAt = &now

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -542,6 +542,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		update.HandleDependentTaskAdded(m.newUpdateContext(), msg)
 		return m, nil
 
+	case tuimsg.InstanceStubCreatedMsg:
+		// Fast first phase of async task addition completed - stub is now visible
+		update.HandleInstanceStubCreated(m.newUpdateContext(), msg)
+		// Kick off the slow second phase (worktree creation)
+		if msg.Instance != nil && msg.Err == nil {
+			return m, tuimsg.CompleteInstanceSetupAsync(m.orchestrator, m.session, msg.Instance)
+		}
+		return m, nil
+
+	case tuimsg.InstanceSetupCompleteMsg:
+		// Slow second phase completed - worktree is ready, optionally auto-start
+		update.HandleInstanceSetupComplete(m.newUpdateContext(), msg)
+		return m, nil
+
 	case tuimsg.TripleShotStartedMsg:
 		// Triple-shot attempts started successfully
 		m.infoMessage = "Triple-shot started: 3 instances working on the task"

--- a/internal/tui/keyhandler.go
+++ b/internal/tui/keyhandler.go
@@ -290,8 +290,12 @@ func (m Model) submitTaskInput() (tea.Model, tea.Cmd) {
 			m.infoMessage = "Adding task from branch " + baseBranch + "..."
 			return m, tuimsg.AddTaskFromBranchAsync(m.orchestrator, m.session, task, baseBranch)
 		}
+
+		// Use two-phase async task addition for faster UI feedback:
+		// Phase 1: Create stub immediately (fast) - instance appears with "preparing" status
+		// Phase 2: Create worktree in background (slow) - then auto-start if configured
 		m.infoMessage = "Adding task..."
-		return m, tuimsg.AddTaskAsync(m.orchestrator, m.session, task)
+		return m, tuimsg.AddTaskStubAsync(m.orchestrator, m.session, task)
 	}
 	return m.cancelTaskInput(), nil
 }

--- a/internal/tui/msg/commands_test.go
+++ b/internal/tui/msg/commands_test.go
@@ -178,6 +178,88 @@ func TestAddDependentTaskAsync(t *testing.T) {
 	})
 }
 
+func TestAddTaskStubAsync(t *testing.T) {
+	t.Run("returns non-nil command", func(t *testing.T) {
+		cmd := AddTaskStubAsync(nil, nil, "test task")
+		if cmd == nil {
+			t.Fatal("AddTaskStubAsync() returned nil command")
+		}
+	})
+
+	t.Run("returns error when orchestrator is nil", func(t *testing.T) {
+		cmd := AddTaskStubAsync(nil, nil, "test task")
+		msg := cmd()
+
+		stubMsg, ok := msg.(InstanceStubCreatedMsg)
+		if !ok {
+			t.Fatalf("AddTaskStubAsync()() returned %T, want InstanceStubCreatedMsg", msg)
+		}
+
+		if stubMsg.Err == nil {
+			t.Error("expected error when orchestrator is nil")
+		}
+		if stubMsg.Instance != nil {
+			t.Error("expected nil instance on error")
+		}
+	})
+
+	t.Run("returns error when session is nil", func(t *testing.T) {
+		// Can't test with real orchestrator, but we can verify nil session handling
+		cmd := AddTaskStubAsync(nil, nil, "test task")
+		msg := cmd()
+
+		stubMsg, ok := msg.(InstanceStubCreatedMsg)
+		if !ok {
+			t.Fatalf("AddTaskStubAsync()() returned %T, want InstanceStubCreatedMsg", msg)
+		}
+
+		// Either orchestrator or session nil should produce an error
+		if stubMsg.Err == nil {
+			t.Error("expected error when session is nil")
+		}
+	})
+}
+
+func TestCompleteInstanceSetupAsync(t *testing.T) {
+	t.Run("returns non-nil command", func(t *testing.T) {
+		cmd := CompleteInstanceSetupAsync(nil, nil, nil)
+		if cmd == nil {
+			t.Fatal("CompleteInstanceSetupAsync() returned nil command")
+		}
+	})
+
+	t.Run("returns error when orchestrator is nil", func(t *testing.T) {
+		cmd := CompleteInstanceSetupAsync(nil, nil, nil)
+		msg := cmd()
+
+		completeMsg, ok := msg.(InstanceSetupCompleteMsg)
+		if !ok {
+			t.Fatalf("CompleteInstanceSetupAsync()() returned %T, want InstanceSetupCompleteMsg", msg)
+		}
+
+		if completeMsg.Err == nil {
+			t.Error("expected error when orchestrator is nil")
+		}
+	})
+
+	t.Run("returns error when instance is nil", func(t *testing.T) {
+		cmd := CompleteInstanceSetupAsync(nil, nil, nil)
+		msg := cmd()
+
+		completeMsg, ok := msg.(InstanceSetupCompleteMsg)
+		if !ok {
+			t.Fatalf("CompleteInstanceSetupAsync()() returned %T, want InstanceSetupCompleteMsg", msg)
+		}
+
+		if completeMsg.Err == nil {
+			t.Error("expected error when instance is nil")
+		}
+		if completeMsg.InstanceID != "" {
+			t.Errorf("expected empty InstanceID on error, got %q", completeMsg.InstanceID)
+		}
+	})
+}
+
 func TestCheckTripleShotCompletionAsync(t *testing.T) {
 	t.Run("nil coordinator", func(t *testing.T) {
 		// With nil coordinator, should handle gracefully

--- a/internal/tui/msg/types.go
+++ b/internal/tui/msg/types.go
@@ -51,6 +51,22 @@ type TaskAddedMsg struct {
 	Err      error
 }
 
+// InstanceStubCreatedMsg is sent when the fast first phase of async task
+// addition completes. The instance is now visible in the UI with StatusPreparing,
+// but the worktree is not yet created.
+type InstanceStubCreatedMsg struct {
+	Instance *orchestrator.Instance
+	Err      error
+}
+
+// InstanceSetupCompleteMsg is sent when the slow second phase of async task
+// addition completes. The worktree is now created and the instance is ready
+// to be started (status changed to StatusPending).
+type InstanceSetupCompleteMsg struct {
+	InstanceID string
+	Err        error
+}
+
 // DependentTaskAddedMsg is sent when async dependent task addition completes.
 type DependentTaskAddedMsg struct {
 	Instance  *orchestrator.Instance

--- a/internal/tui/msg/types_test.go
+++ b/internal/tui/msg/types_test.go
@@ -264,6 +264,81 @@ func TestDependentTaskAddedMsg(t *testing.T) {
 	}
 }
 
+func TestInstanceStubCreatedMsg(t *testing.T) {
+	tests := []struct {
+		name     string
+		instance *orchestrator.Instance
+		err      error
+	}{
+		{
+			name:     "successful stub creation",
+			instance: &orchestrator.Instance{ID: "stub-1", Status: orchestrator.StatusPreparing},
+			err:      nil,
+		},
+		{
+			name:     "failed stub creation",
+			instance: nil,
+			err:      errors.New("failed to create stub"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := InstanceStubCreatedMsg{
+				Instance: tt.instance,
+				Err:      tt.err,
+			}
+
+			if msg.Instance != tt.instance {
+				t.Errorf("InstanceStubCreatedMsg.Instance = %v, want %v", msg.Instance, tt.instance)
+			}
+			if msg.Err != tt.err {
+				t.Errorf("InstanceStubCreatedMsg.Err = %v, want %v", msg.Err, tt.err)
+			}
+		})
+	}
+}
+
+func TestInstanceSetupCompleteMsg(t *testing.T) {
+	tests := []struct {
+		name       string
+		instanceID string
+		err        error
+	}{
+		{
+			name:       "successful setup completion",
+			instanceID: "inst-1",
+			err:        nil,
+		},
+		{
+			name:       "failed setup completion",
+			instanceID: "inst-2",
+			err:        errors.New("worktree creation failed"),
+		},
+		{
+			name:       "empty instance ID on early error",
+			instanceID: "",
+			err:        errors.New("instance is nil"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := InstanceSetupCompleteMsg{
+				InstanceID: tt.instanceID,
+				Err:        tt.err,
+			}
+
+			if msg.InstanceID != tt.instanceID {
+				t.Errorf("InstanceSetupCompleteMsg.InstanceID = %q, want %q", msg.InstanceID, tt.instanceID)
+			}
+			if msg.Err != tt.err {
+				t.Errorf("InstanceSetupCompleteMsg.Err = %v, want %v", msg.Err, tt.err)
+			}
+		})
+	}
+}
+
 func TestUltraPlanInitMsg(t *testing.T) {
 	// This is a zero-value struct used as a signal
 	msg := UltraPlanInitMsg{}

--- a/internal/tui/styles/loader.go
+++ b/internal/tui/styles/loader.go
@@ -57,6 +57,7 @@ type ThemeColors struct {
 type ThemeStatusColors struct {
 	Working     string `yaml:"working,omitempty"`
 	Pending     string `yaml:"pending,omitempty"`
+	Preparing   string `yaml:"preparing,omitempty"`
 	Input       string `yaml:"input,omitempty"`
 	Paused      string `yaml:"paused,omitempty"`
 	Complete    string `yaml:"complete,omitempty"`
@@ -209,6 +210,7 @@ func (t *ThemeFile) ToPalette() *ColorPalette {
 	// Apply status colors (with defaults)
 	p.StatusWorking = colorOrDefault(t.Colors.Status.Working, t.Colors.Secondary)
 	p.StatusPending = colorOrDefault(t.Colors.Status.Pending, t.Colors.Muted)
+	p.StatusPreparing = colorOrDefault(t.Colors.Status.Preparing, t.Colors.Primary)
 	p.StatusInput = colorOrDefault(t.Colors.Status.Input, t.Colors.Warning)
 	p.StatusPaused = colorOrDefault(t.Colors.Status.Paused, t.Colors.Primary)
 	p.StatusComplete = colorOrDefault(t.Colors.Status.Complete, t.Colors.Primary)
@@ -406,6 +408,7 @@ func paletteToThemeFile(name string, p *ColorPalette) *ThemeFile {
 			Status: ThemeStatusColors{
 				Working:     string(p.StatusWorking),
 				Pending:     string(p.StatusPending),
+				Preparing:   string(p.StatusPreparing),
 				Input:       string(p.StatusInput),
 				Paused:      string(p.StatusPaused),
 				Complete:    string(p.StatusComplete),

--- a/internal/tui/styles/palette.go
+++ b/internal/tui/styles/palette.go
@@ -87,6 +87,7 @@ type ColorPalette struct {
 	// Status-specific colors
 	StatusWorking     lipgloss.Color
 	StatusPending     lipgloss.Color
+	StatusPreparing   lipgloss.Color
 	StatusInput       lipgloss.Color
 	StatusPaused      lipgloss.Color
 	StatusComplete    lipgloss.Color
@@ -132,6 +133,7 @@ func DefaultPalette() *ColorPalette {
 
 		StatusWorking:     lipgloss.Color("#10B981"), // Green
 		StatusPending:     lipgloss.Color("#9CA3AF"), // Gray
+		StatusPreparing:   lipgloss.Color("#60A5FA"), // Blue - async setup
 		StatusInput:       lipgloss.Color("#F59E0B"), // Amber
 		StatusPaused:      lipgloss.Color("#60A5FA"), // Blue
 		StatusComplete:    lipgloss.Color("#A78BFA"), // Purple
@@ -175,6 +177,7 @@ func MonokaiPalette() *ColorPalette {
 
 		StatusWorking:     lipgloss.Color("#A6E22E"), // Green
 		StatusPending:     lipgloss.Color("#75715E"), // Comment gray
+		StatusPreparing:   lipgloss.Color("#66D9EF"), // Cyan - async setup
 		StatusInput:       lipgloss.Color("#E6DB74"), // Yellow
 		StatusPaused:      lipgloss.Color("#66D9EF"), // Cyan
 		StatusComplete:    lipgloss.Color("#AE81FF"), // Purple
@@ -218,6 +221,7 @@ func DraculaPalette() *ColorPalette {
 
 		StatusWorking:     lipgloss.Color("#50FA7B"), // Green
 		StatusPending:     lipgloss.Color("#6272A4"), // Comment
+		StatusPreparing:   lipgloss.Color("#8BE9FD"), // Cyan - async setup
 		StatusInput:       lipgloss.Color("#F1FA8C"), // Yellow
 		StatusPaused:      lipgloss.Color("#8BE9FD"), // Cyan
 		StatusComplete:    lipgloss.Color("#BD93F9"), // Purple
@@ -261,6 +265,7 @@ func NordPalette() *ColorPalette {
 
 		StatusWorking:     lipgloss.Color("#A3BE8C"), // Green
 		StatusPending:     lipgloss.Color("#4C566A"), // Gray
+		StatusPreparing:   lipgloss.Color("#81A1C1"), // Frost blue - async setup
 		StatusInput:       lipgloss.Color("#EBCB8B"), // Yellow
 		StatusPaused:      lipgloss.Color("#81A1C1"), // Frost blue
 		StatusComplete:    lipgloss.Color("#B48EAD"), // Aurora purple
@@ -304,6 +309,7 @@ func ClaudeCodePalette() *ColorPalette {
 
 		StatusWorking:     lipgloss.Color("#7DCEA0"), // Green
 		StatusPending:     lipgloss.Color("#7F8C8D"), // Gray
+		StatusPreparing:   lipgloss.Color("#5DADE2"), // Blue - async setup
 		StatusInput:       lipgloss.Color("#F5B041"), // Amber
 		StatusPaused:      lipgloss.Color("#5DADE2"), // Blue
 		StatusComplete:    lipgloss.Color("#DA7756"), // Orange
@@ -347,6 +353,7 @@ func SolarizedDarkPalette() *ColorPalette {
 
 		StatusWorking:     lipgloss.Color("#859900"), // Green
 		StatusPending:     lipgloss.Color("#586E75"), // Gray
+		StatusPreparing:   lipgloss.Color("#2AA198"), // Cyan - async setup
 		StatusInput:       lipgloss.Color("#B58900"), // Yellow
 		StatusPaused:      lipgloss.Color("#2AA198"), // Cyan
 		StatusComplete:    lipgloss.Color("#6C71C4"), // Violet
@@ -390,6 +397,7 @@ func SolarizedLightPalette() *ColorPalette {
 
 		StatusWorking:     lipgloss.Color("#859900"), // Green
 		StatusPending:     lipgloss.Color("#93A1A1"), // Gray
+		StatusPreparing:   lipgloss.Color("#2AA198"), // Cyan - async setup
 		StatusInput:       lipgloss.Color("#B58900"), // Yellow
 		StatusPaused:      lipgloss.Color("#2AA198"), // Cyan
 		StatusComplete:    lipgloss.Color("#6C71C4"), // Violet
@@ -433,6 +441,7 @@ func OneDarkPalette() *ColorPalette {
 
 		StatusWorking:     lipgloss.Color("#98C379"), // Green
 		StatusPending:     lipgloss.Color("#5C6370"), // Gray
+		StatusPreparing:   lipgloss.Color("#56B6C2"), // Cyan - async setup
 		StatusInput:       lipgloss.Color("#E5C07B"), // Yellow
 		StatusPaused:      lipgloss.Color("#56B6C2"), // Cyan
 		StatusComplete:    lipgloss.Color("#C678DD"), // Purple
@@ -476,6 +485,7 @@ func GitHubDarkPalette() *ColorPalette {
 
 		StatusWorking:     lipgloss.Color("#3FB950"), // Green
 		StatusPending:     lipgloss.Color("#8B949E"), // Gray
+		StatusPreparing:   lipgloss.Color("#58A6FF"), // Blue - async setup
 		StatusInput:       lipgloss.Color("#D29922"), // Yellow
 		StatusPaused:      lipgloss.Color("#58A6FF"), // Blue
 		StatusComplete:    lipgloss.Color("#A371F7"), // Purple
@@ -519,6 +529,7 @@ func GruvboxPalette() *ColorPalette {
 
 		StatusWorking:     lipgloss.Color("#B8BB26"), // Green
 		StatusPending:     lipgloss.Color("#928374"), // Gray
+		StatusPreparing:   lipgloss.Color("#83A598"), // Aqua - async setup
 		StatusInput:       lipgloss.Color("#FABD2F"), // Yellow
 		StatusPaused:      lipgloss.Color("#83A598"), // Aqua
 		StatusComplete:    lipgloss.Color("#D3869B"), // Purple
@@ -562,6 +573,7 @@ func TokyoNightPalette() *ColorPalette {
 
 		StatusWorking:     lipgloss.Color("#9ECE6A"), // Green
 		StatusPending:     lipgloss.Color("#565F89"), // Gray
+		StatusPreparing:   lipgloss.Color("#7DCFFF"), // Cyan - async setup
 		StatusInput:       lipgloss.Color("#E0AF68"), // Yellow
 		StatusPaused:      lipgloss.Color("#7DCFFF"), // Cyan
 		StatusComplete:    lipgloss.Color("#BB9AF7"), // Purple
@@ -605,6 +617,7 @@ func CatppuccinPalette() *ColorPalette {
 
 		StatusWorking:     lipgloss.Color("#A6E3A1"), // Green
 		StatusPending:     lipgloss.Color("#6C7086"), // Gray
+		StatusPreparing:   lipgloss.Color("#94E2D5"), // Teal - async setup
 		StatusInput:       lipgloss.Color("#F9E2AF"), // Yellow
 		StatusPaused:      lipgloss.Color("#94E2D5"), // Teal
 		StatusComplete:    lipgloss.Color("#CBA6F7"), // Mauve
@@ -648,6 +661,7 @@ func SynthwavePalette() *ColorPalette {
 
 		StatusWorking:     lipgloss.Color("#72F1B8"), // Green
 		StatusPending:     lipgloss.Color("#848BBD"), // Gray
+		StatusPreparing:   lipgloss.Color("#36F9F6"), // Cyan - async setup
 		StatusInput:       lipgloss.Color("#FEDE5D"), // Yellow
 		StatusPaused:      lipgloss.Color("#36F9F6"), // Cyan
 		StatusComplete:    lipgloss.Color("#FF7EDB"), // Pink
@@ -691,6 +705,7 @@ func AyuPalette() *ColorPalette {
 
 		StatusWorking:     lipgloss.Color("#7FD962"), // Green
 		StatusPending:     lipgloss.Color("#626A73"), // Gray
+		StatusPreparing:   lipgloss.Color("#39BAE6"), // Blue - async setup
 		StatusInput:       lipgloss.Color("#E6B450"), // Yellow
 		StatusPaused:      lipgloss.Color("#39BAE6"), // Blue
 		StatusComplete:    lipgloss.Color("#D2A6FF"), // Purple

--- a/internal/tui/styles/styles.go
+++ b/internal/tui/styles/styles.go
@@ -54,6 +54,7 @@ var (
 	// Status colors - all meet WCAG AA contrast (4.5:1) on both black and dark surfaces
 	StatusWorking     = lipgloss.Color("#10B981") // Green
 	StatusPending     = lipgloss.Color("#9CA3AF") // Gray (brighter for readability)
+	StatusPreparing   = lipgloss.Color("#60A5FA") // Blue - for async worktree creation in progress
 	StatusInput       = lipgloss.Color("#F59E0B") // Amber
 	StatusPaused      = lipgloss.Color("#60A5FA") // Blue (brighter for readability)
 	StatusComplete    = lipgloss.Color("#A78BFA") // Purple (brighter for readability)
@@ -349,6 +350,8 @@ func StatusColor(status string) lipgloss.Color {
 		return StatusWorking
 	case "pending":
 		return StatusPending
+	case "preparing":
+		return StatusPreparing
 	case "waiting_input":
 		return StatusInput
 	case "paused":
@@ -377,6 +380,8 @@ func StatusIcon(status string) string {
 		return "●"
 	case "pending":
 		return "○"
+	case "preparing":
+		return "◐" // Half-filled circle for async setup in progress
 	case "waiting_input":
 		return "?"
 	case "paused":

--- a/internal/tui/styles/themed.go
+++ b/internal/tui/styles/themed.go
@@ -25,6 +25,7 @@ type ThemedStyles struct {
 	// Status colors
 	StatusWorking     lipgloss.Color
 	StatusPending     lipgloss.Color
+	StatusPreparing   lipgloss.Color
 	StatusInput       lipgloss.Color
 	StatusPaused      lipgloss.Color
 	StatusComplete    lipgloss.Color
@@ -163,6 +164,7 @@ func NewThemedStyles(p *ColorPalette) *ThemedStyles {
 		// Status colors
 		StatusWorking:     p.StatusWorking,
 		StatusPending:     p.StatusPending,
+		StatusPreparing:   p.StatusPreparing,
 		StatusInput:       p.StatusInput,
 		StatusPaused:      p.StatusPaused,
 		StatusComplete:    p.StatusComplete,
@@ -455,6 +457,8 @@ func (s *ThemedStyles) StatusColor(status string) lipgloss.Color {
 		return s.StatusWorking
 	case "pending":
 		return s.StatusPending
+	case "preparing":
+		return s.StatusPreparing
 	case "waiting_input":
 		return s.StatusInput
 	case "paused":
@@ -539,6 +543,7 @@ func syncGlobalStyles() {
 	// Update status colors
 	StatusWorking = activeTheme.StatusWorking
 	StatusPending = activeTheme.StatusPending
+	StatusPreparing = activeTheme.StatusPreparing
 	StatusInput = activeTheme.StatusInput
 	StatusPaused = activeTheme.StatusPaused
 	StatusComplete = activeTheme.StatusComplete

--- a/internal/tui/view/group.go
+++ b/internal/tui/view/group.go
@@ -572,6 +572,8 @@ func instanceStatusAbbrev(status orchestrator.InstanceStatus) string {
 	switch status {
 	case orchestrator.StatusPending:
 		return "PEND"
+	case orchestrator.StatusPreparing:
+		return "PREP"
 	case orchestrator.StatusWorking:
 		return "WORK"
 	case orchestrator.StatusWaitingInput:


### PR DESCRIPTION
## Summary

Implements two-phase async task creation for faster `:a` command:

- **Phase 1 (fast)**: `AddInstanceStub` creates minimal instance metadata with `StatusPreparing` - appears in UI immediately
- **Phase 2 (slow)**: `CompleteInstanceSetup` creates git worktree in background - transitions to `StatusPending` when done

This eliminates UI freezes during worktree creation in large repositories.

### Changes

- Add `StatusPreparing` instance status with appropriate styling (blue color, half-filled circle icon) across all 14 themes
- Add `InstanceStubCreatedMsg` and `InstanceSetupCompleteMsg` message types for the two-phase flow
- Add `AddTaskStubAsync` and `CompleteInstanceSetupAsync` commands
- Add `HandleInstanceStubCreated` and `HandleInstanceSetupComplete` handlers with comprehensive tests
- Add safeguards:
  - `StartInstance`/`ReconnectInstance` reject instances still preparing
  - Recovery logic marks preparing instances as error (incomplete worktree)
  - Nil check for instance before accessing fields in handlers

### Files Modified

- `internal/orchestrator/orchestrator.go` - AddInstanceStub, CompleteInstanceSetup methods
- `internal/orchestrator/session.go` - StatusPreparing handling in recovery
- `internal/tui/msg/types.go` - New message types
- `internal/tui/msg/commands.go` - New async commands
- `internal/tui/update/handlers.go` - Message handlers
- `internal/tui/view/group.go` - StatusPreparing abbreviation ("PREP")
- `internal/tui/styles/*` - StatusPreparing color/icon across all themes
- `CHANGELOG.md` - Feature documentation

## Test plan

- [x] All existing tests pass
- [x] New tests for `HandleInstanceStubCreated` and `HandleInstanceSetupComplete`
- [x] Tests cover error cases, nil checks, auto-start configuration
- [x] Build succeeds
- [x] Linting passes