### PR TITLE
TUI tripleshot command respects config file settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **TUI Tripleshot Config Settings** - The `:tripleshot` command in the TUI now properly respects the `tripleshot.auto_approve` and `tripleshot.adversarial` settings from the config file. Previously, starting a tripleshot from the TUI always used hardcoded defaults, ignoring user configuration.
+
 ## [0.13.0] - 2026-01-29
 
 This release introduces **Adversarial Review Mode** and **Color Themes** - two major features that enhance workflow quality and user experience.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1635,8 +1635,11 @@ func (m Model) initiateTripleShotMode(task string) (Model, tea.Cmd) {
 	// Request intelligent name generation for the group
 	m.orchestrator.RequestGroupRename(tripleGroup.ID, task)
 
-	// Create triple-shot session with default config
+	// Create triple-shot session with config from user settings
 	tripleConfig := orchestrator.DefaultTripleShotConfig()
+	cfg := config.Get()
+	tripleConfig.AutoApprove = cfg.Tripleshot.AutoApprove
+	tripleConfig.Adversarial = cfg.Tripleshot.Adversarial
 	tripleSession := orchestrator.NewTripleShotSession(task, tripleConfig)
 
 	// Link group ID to session for multi-tripleshot support


### PR DESCRIPTION
## Summary

- The `:tripleshot` command in the TUI now properly reads `tripleshot.auto_approve` and `tripleshot.adversarial` settings from the config file
- Previously, starting a tripleshot from the TUI always used hardcoded defaults (both `false`), ignoring user configuration
- This makes TUI behavior consistent with the CLI `tripleshot` command

## Test plan

- [x] Added `TestTripleshotConfig_UsesConfigFileSettings` - verifies config values flow through to session
- [x] Added `TestTripleshotConfig_DefaultsWhenNotConfigured` - verifies defaults work when not configured
- [x] All existing tests pass
- [x] Build succeeds, `go vet` clean, `gofmt` clean

Closes #584