### PR TITLE
Fix false positive stuck detection in state detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **TUI Tripleshot Config Settings** - The `:tripleshot` command in the TUI now properly respects the `tripleshot.auto_approve` and `tripleshot.adversarial` settings from the config file. Previously, starting a tripleshot from the TUI always used hardcoded defaults, ignoring user configuration.
 
+- **False Positive Stale Detection** - Fixed instances being incorrectly marked as "stuck" in two scenarios: (1) When Claude was actively working but the output wasn't changing (e.g., running explore agents with collapsed output, or showing a static spinner during thinking phase) - the stale counter now only increments when no working indicators (spinners, "Reading...", "Analyzing...", etc.) are present. (2) When Claude was waiting for user input but the patterns didn't match Claude Code's actual UI - the state detection patterns now correctly recognize Claude Code's input prompt (`❯`), plan/auto/focus mode indicators (`⏸`), and case variations in mode cycling hints.
+
 ## [0.13.0] - 2026-01-29
 
 This release introduces **Adversarial Review Mode** and **Color Themes** - two major features that enhance workflow quality and user experience.


### PR DESCRIPTION
## Summary

Fixes false positive stale detection that incorrectly marked instances as "stuck" when Claude was actually waiting for user input.

- **Root cause**: State detection patterns didn't match Claude Code's actual terminal UI output
- **False positive mechanism**: Detector returned `StateWorking` instead of `StateWaitingInput`, causing stale counter to accumulate while Claude waited for input
- **Fix**: Updated patterns to match Claude Code's actual UI elements

## Changes

| Issue | Old Pattern | New Pattern |
|-------|-------------|-------------|
| Mode cycling hint | `\(shift\+tab to cycle\)` | `(?i)\(shift\+tab to cycle\)` (case-insensitive) |
| Input prompt | `>\s+.*↵` | `❯\s+.*↵` (Unicode U+276F) |
| Mode indicators | (missing) | `⏸\s*(?:plan\|auto\|focus)\s+mode(?:\s+on)?` |

## Details

1. **Case-insensitive mode cycling hint**: Claude Code shows `(shift+Tab to cycle)` with capital T, but the old pattern was lowercase-only

2. **Unicode prompt character**: Claude Code uses `❯` (U+276F Heavy Right-Pointing Angle Quotation Mark), not ASCII `>`. Three patterns now cover prompt variations.

3. **Mode indicators**: Added detection for `⏸ plan mode`, `⏸ auto mode`, and `⏸ focus mode` indicators (with optional "on" suffix)

## Test plan

- [x] All existing tests pass
- [x] Added 15 input waiting test cases including:
  - Real Claude Code output from the stuck instance
  - Unicode prompt variations
  - Mode indicators with and without "on" suffix
  - Case variations in mode cycling hints
- [x] `go vet` passes
- [x] `gofmt` clean
- [x] Full test suite passes