### PR TITLE
Fix sidebar auto-scroll when navigating to off-screen instances or groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **False Positive Stale Detection** - Fixed instances being incorrectly marked as "stuck" in two scenarios: (1) When Claude was actively working but the output wasn't changing (e.g., running explore agents with collapsed output, or showing a static spinner during thinking phase) - the stale counter now only increments when no working indicators (spinners, "Reading...", "Analyzing...", etc.) are present. (2) When Claude was waiting for user input but the patterns didn't match Claude Code's actual UI - the state detection patterns now correctly recognize Claude Code's input prompt (`❯`), plan/auto/focus mode indicators (`⏸`), and case variations in mode cycling hints.
 
+- **Sidebar Auto-Scroll on Navigation** - Fixed sidebar not scrolling when navigating to instances or groups that are off-screen. When using h/l (tab/shift+tab) to switch instances or gn/gp to navigate between groups, the sidebar now automatically scrolls to ensure the selected item is visible. This also fixes a bug where `ensureActiveVisible()` used the wrong position in grouped mode due to not accounting for group headers.
+
 ## [0.13.0] - 2026-01-29
 
 This release introduces **Adversarial Review Mode** and **Color Themes** - two major features that enhance workflow quality and user experience.

--- a/internal/tui/keyhandler.go
+++ b/internal/tui/keyhandler.go
@@ -431,6 +431,8 @@ func (m Model) handleGroupCommand(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case GroupActionNextGroup, GroupActionPrevGroup:
 			if result.GroupID != "" {
 				m.groupViewState.SelectedGroupID = result.GroupID
+				// Ensure the selected group is visible in the sidebar
+				m.ensureSelectedGroupVisible()
 			}
 		case GroupActionSkipGroup:
 			m.infoMessage = "Group skipped"


### PR DESCRIPTION
## Summary

- Fixed sidebar not scrolling when navigating to instances that are off-screen using h/l (tab/shift+tab)
- Fixed sidebar not scrolling when navigating to groups that are off-screen using gn/gp
- Fixed `ensureActiveVisible()` using wrong position in grouped mode (array index instead of display position)

## Root Cause

In grouped sidebar mode, `ensureActiveVisible()` was using `activeTab` (the array index in `session.Instances`) as the display position. However, in grouped mode, group headers are interspersed in the display list, so the actual display position differs from the array index.

## Solution

- Added `findActiveDisplayPosition()` to calculate the actual display position by iterating through the flattened display list (which includes group headers)
- Added `ensureSelectedGroupVisible()` with `findGroupDisplayPosition()` for group navigation (gn/gp)
- Extracted common scroll logic into helper functions (`sidebarVisibleItemCount`, `adjustScrollToShowPosition`) for better maintainability
- Added named constants for sidebar layout values (`sidebarReservedLines`, `sidebarLinesPerItemFlat`, `sidebarLinesPerItemGrouped`)
- Added debug logging for edge cases when instance is not found in flattened list

## Test plan

- [x] Added `TestFindActiveDisplayPosition` with 5 test cases covering flat mode, grouped mode, and edge cases
- [x] Added `TestFindGroupDisplayPosition` with 5 test cases covering various group positions and edge cases
- [x] Added `TestEnsureSelectedGroupVisible` with 3 test cases including nil/empty state handling
- [x] Added `TestEnsureActiveVisible_GroupedMode` testing group header position accounting
- [x] All existing tests pass
- [x] Manual testing: h/l navigation scrolls to show selected instance in grouped mode
- [x] Manual testing: gn/gp navigation scrolls to show selected group header