### PR TITLE
Display current round in adversarial group header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Adversarial Mode UI Enhancement** - Current round instances in adversarial mode now appear directly in the main adversarial group header instead of being nested under a "[Round X]" sub-group. The group header displays round information inline (e.g., "Refactor auth (Round 3) [2/2]"), making it immediately visible which round is active. Previous rounds are still organized under the "Previous Rounds" container for historical reference. This flattens the UI for the current round while preserving full round history navigation.
+
 ### Removed
 
 - **`claudio tripleshot` CLI Command** - The standalone `claudio tripleshot` command has been removed. TripleShot mode is now exclusively accessed through the TUI via the `:tripleshot` command (or aliases `:triple`, `:3shot`). This consolidates all tripleshot functionality within the standard TUI, providing a more consistent user experience. To use tripleshot, run `claudio start` and then use `:tripleshot` in command mode.

--- a/internal/orchestrator/workflow_adapters.go
+++ b/internal/orchestrator/workflow_adapters.go
@@ -184,6 +184,26 @@ func (a *adversarialGroupAdapter) AddInstance(instanceID string) {
 	a.group.AddInstance(instanceID)
 }
 
+func (a *adversarialGroupAdapter) GetInstances() []string {
+	if a.group == nil {
+		return nil
+	}
+	return a.group.Instances
+}
+
+func (a *adversarialGroupAdapter) RemoveInstance(instanceID string) {
+	if a.group == nil {
+		return
+	}
+	filtered := make([]string, 0, len(a.group.Instances))
+	for _, id := range a.group.Instances {
+		if id != instanceID {
+			filtered = append(filtered, id)
+		}
+	}
+	a.group.Instances = filtered
+}
+
 // GetOrCreateSubGroup finds or creates a sub-group with the given ID and name.
 // This implements adversarial.GroupWithSubGroupsInterface.
 func (a *adversarialGroupAdapter) GetOrCreateSubGroup(id, name string) adversarial.GroupInterface {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -446,6 +446,12 @@ func (m Model) PlanStateData() *view.PlanState {
 	return m.planSessions
 }
 
+// AdversarialStateData returns the adversarial state for tracking concurrent adversarial sessions.
+// Implements view.SidebarState interface.
+func (m Model) AdversarialStateData() *view.AdversarialState {
+	return m.adversarial
+}
+
 // Orchestrator returns the orchestrator for instance lookups.
 // Implements view.SidebarState interface.
 func (m Model) Orchestrator() *orchestrator.Orchestrator {

--- a/internal/tui/view/group.go
+++ b/internal/tui/view/group.go
@@ -188,6 +188,36 @@ func RenderGroupHeader(group *orchestrator.InstanceGroup, progress GroupProgress
 	return strings.Join(lines, "\n")
 }
 
+// RenderGroupHeaderItem renders a group header from a GroupHeaderItem.
+// This version supports RoundInfo display for adversarial groups.
+// Example for adversarial: "▾ ⚔️ Refactor auth (Round 3) [2/2] ●"
+func RenderGroupHeaderItem(item GroupHeaderItem, width int) string {
+	lines := RenderGroupHeaderItemWrapped(item, width)
+	return strings.Join(lines, "\n")
+}
+
+// RenderGroupHeaderItemWrapped renders a group header with round info support.
+// For adversarial groups, appends " (Round N)" to the group name.
+func RenderGroupHeaderItemWrapped(item GroupHeaderItem, width int) []string {
+	group := item.Group
+	if group == nil {
+		return []string{}
+	}
+
+	// Build display name with optional round info
+	displayName := group.Name
+	if item.RoundInfo != "" {
+		displayName = fmt.Sprintf("%s (%s)", group.Name, item.RoundInfo)
+	}
+
+	// Create a temporary copy of the group with modified name for rendering
+	// (we don't want to modify the original group)
+	tempGroup := *group
+	tempGroup.Name = displayName
+
+	return RenderGroupHeaderWrapped(&tempGroup, item.Progress, item.Collapsed, item.IsSelected, width)
+}
+
 // RenderGroupHeaderWrapped renders a group header with word-wrapped name support.
 // Returns a slice of lines where the first line contains the collapse indicator,
 // icon, and start of name, and subsequent lines contain wrapped name continuation.
@@ -421,6 +451,7 @@ type GroupHeaderItem struct {
 	Collapsed  bool
 	IsSelected bool
 	Depth      int
+	RoundInfo  string // Optional round info for adversarial groups, e.g., "Round 3"
 }
 
 func flattenGroupRecursive(group *orchestrator.InstanceGroup, session *orchestrator.Session, state *GroupViewState, depth int, globalIdx *int) []any {

--- a/internal/tui/view/group_test.go
+++ b/internal/tui/view/group_test.go
@@ -744,3 +744,121 @@ func TestFindGroupContainingInstance(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderGroupHeaderItemWrapped_WithRoundInfo(t *testing.T) {
+	// Test that RoundInfo is included in the group header for adversarial groups
+	group := &orchestrator.InstanceGroup{
+		ID:          "adv-group-1",
+		Name:        "Refactor auth",
+		SessionType: "adversarial",
+		Phase:       orchestrator.GroupPhaseExecuting,
+	}
+
+	progress := GroupProgress{
+		Completed: 1,
+		Total:     2,
+	}
+
+	item := GroupHeaderItem{
+		Group:      group,
+		Progress:   progress,
+		Collapsed:  false,
+		IsSelected: false,
+		Depth:      0,
+		RoundInfo:  "Round 3",
+	}
+
+	result := RenderGroupHeaderItemWrapped(item, 80)
+
+	if len(result) == 0 {
+		t.Fatal("RenderGroupHeaderItemWrapped() returned empty result")
+	}
+
+	// The rendered output should include the round info
+	fullOutput := strings.Join(result, "\n")
+	if !strings.Contains(fullOutput, "Round 3") {
+		t.Errorf("RenderGroupHeaderItemWrapped() should contain round info, got: %s", fullOutput)
+	}
+
+	// The rendered output should include the group name
+	if !strings.Contains(fullOutput, "Refactor auth") {
+		t.Errorf("RenderGroupHeaderItemWrapped() should contain group name, got: %s", fullOutput)
+	}
+
+	// The rendered output should include progress
+	if !strings.Contains(fullOutput, "[1/2]") {
+		t.Errorf("RenderGroupHeaderItemWrapped() should contain progress, got: %s", fullOutput)
+	}
+}
+
+func TestRenderGroupHeaderItemWrapped_WithoutRoundInfo(t *testing.T) {
+	// Test that group header works without RoundInfo (non-adversarial groups)
+	group := &orchestrator.InstanceGroup{
+		ID:          "plan-group-1",
+		Name:        "Build feature",
+		SessionType: "plan",
+		Phase:       orchestrator.GroupPhaseExecuting,
+	}
+
+	progress := GroupProgress{
+		Completed: 2,
+		Total:     3,
+	}
+
+	item := GroupHeaderItem{
+		Group:      group,
+		Progress:   progress,
+		Collapsed:  false,
+		IsSelected: false,
+		Depth:      0,
+		RoundInfo:  "", // No round info for non-adversarial
+	}
+
+	result := RenderGroupHeaderItemWrapped(item, 80)
+
+	if len(result) == 0 {
+		t.Fatal("RenderGroupHeaderItemWrapped() returned empty result")
+	}
+
+	fullOutput := strings.Join(result, "\n")
+
+	// Should NOT contain "()" since RoundInfo is empty
+	if strings.Contains(fullOutput, "()") {
+		t.Errorf("RenderGroupHeaderItemWrapped() should not show empty parens, got: %s", fullOutput)
+	}
+
+	// Should contain the group name
+	if !strings.Contains(fullOutput, "Build feature") {
+		t.Errorf("RenderGroupHeaderItemWrapped() should contain group name, got: %s", fullOutput)
+	}
+}
+
+func TestRenderGroupHeaderItem(t *testing.T) {
+	// Test the single-line version
+	group := &orchestrator.InstanceGroup{
+		ID:          "adv-group-1",
+		Name:        "Test Task",
+		SessionType: "adversarial",
+		Phase:       orchestrator.GroupPhaseExecuting,
+	}
+
+	item := GroupHeaderItem{
+		Group:      group,
+		Progress:   GroupProgress{Completed: 1, Total: 2},
+		Collapsed:  false,
+		IsSelected: false,
+		Depth:      0,
+		RoundInfo:  "Round 1",
+	}
+
+	result := RenderGroupHeaderItem(item, 80)
+
+	if result == "" {
+		t.Fatal("RenderGroupHeaderItem() returned empty string")
+	}
+
+	// Should contain round info
+	if !strings.Contains(result, "Round 1") {
+		t.Errorf("RenderGroupHeaderItem() should contain round info, got: %s", result)
+	}
+}


### PR DESCRIPTION
## Summary

- Move current round metadata to top-line group header instead of nesting under [Round X] sub-group
- Group header now displays round information inline (e.g., "Refactor auth (Round 3) [2/2]")
- Previous rounds are still organized under the "Previous Rounds" container for historical reference

## Changes

- Add `RoundInfo` field to `GroupHeaderItem` for adversarial groups
- Implement `enrichAdversarialRoundInfo` to populate round info from adversarial coordinators
- Update `RenderGroupHeaderItemWrapped` to display round info inline
- Add `getCurrentRoundGroup` and `movePreviousRoundInstancesToSubGroup` to manage round transitions
- Remove deprecated `getOrCreateRoundSubGroup` wrapper function
- Add comprehensive test coverage for all new functionality
- Enhance `mockGroupWithSubGroups` to track `MoveSubGroupUnder` calls for better test verification

## Test plan

- [x] All existing tests pass
- [x] New tests for `enrichAdversarialRoundInfo` covering nil state, empty coordinators, valid round info, non-adversarial groups, and nil groups
- [x] New tests for `getCurrentRoundGroup` covering round 1 and round 2+ behavior
- [x] New tests for `movePreviousRoundInstancesToSubGroup` covering edge cases (no sub-group support, empty history, invalid rounds, no instances, session ID fallback)
- [x] Tests for `RenderGroupHeaderItem` with and without round info
- [x] Integration test `TestSidebarView_GroupedModeWithAdversarialState` verifies round info appears in sidebar