### PR TITLE
Improve adversarial mode sentinel file detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Sidebar Auto-Scroll on Navigation** - Fixed sidebar not scrolling when navigating to instances or groups that are off-screen. When using h/l (tab/shift+tab) to switch instances or gn/gp to navigate between groups, the sidebar now automatically scrolls to ensure the selected item is visible. This also fixes a bug where `ensureActiveVisible()` used the wrong position in grouped mode due to not accounting for group headers.
 
+- **Adversarial Mode Sentinel File Search** - Improved file detection for adversarial mode's increment and review files. The system now searches multiple locations (worktree root, subdirectories, and parent directory) to handle cases where Claude writes the file to an unexpected location (e.g., monorepo root instead of worktree, or a subdirectory). When the worktree path is known (round > 1), the prompt now includes the absolute file path for clarity.
+
 ## [0.13.0] - 2026-01-29
 
 This release introduces **Adversarial Review Mode** and **Color Themes** - two major features that enhance workflow quality and user experience.

--- a/internal/orchestrator/workflows/adversarial/coordinator.go
+++ b/internal/orchestrator/workflows/adversarial/coordinator.go
@@ -399,7 +399,9 @@ func (c *Coordinator) StartImplementer() error {
 	c.manager.StartRound()
 
 	// Build the implementer prompt
-	prompt := FormatImplementerPrompt(task, round, previousReview)
+	// For round > 1, we know the worktree path from the previous round
+	// For round 1, worktreePath will be empty and get set after instance creation
+	prompt := FormatImplementerPrompt(task, round, previousReview, c.implementerWorktree)
 
 	// Find the adversarial group to add instances to
 	var advGroup GroupInterface
@@ -486,7 +488,8 @@ func (c *Coordinator) StartReviewer(increment *IncrementFile) error {
 	if minPassingScore < 1 || minPassingScore > 10 {
 		minPassingScore = 8 // Fallback to default if invalid
 	}
-	prompt := FormatReviewerPrompt(task, round, increment, minPassingScore)
+	// The reviewer always works in the same worktree as the implementer
+	prompt := FormatReviewerPrompt(task, round, increment, minPassingScore, c.reviewerWorktree)
 
 	// Find the adversarial group
 	var advGroup GroupInterface
@@ -542,14 +545,15 @@ func (c *Coordinator) StartReviewer(increment *IncrementFile) error {
 	return nil
 }
 
-// CheckIncrementReady checks if the implementer has written their increment file
+// CheckIncrementReady checks if the implementer has written their increment file.
+// It searches multiple locations to handle cases where Claude writes the file
+// to the wrong directory (e.g., subdirectory or parent in a monorepo).
 func (c *Coordinator) CheckIncrementReady() (bool, error) {
 	if c.implementerWorktree == "" {
 		return false, nil
 	}
 
-	incrementPath := IncrementFilePath(c.implementerWorktree)
-	_, err := os.Stat(incrementPath)
+	_, err := FindIncrementFile(c.implementerWorktree)
 	if err == nil {
 		return true, nil
 	}
@@ -559,14 +563,15 @@ func (c *Coordinator) CheckIncrementReady() (bool, error) {
 	return false, fmt.Errorf("failed to check increment file: %w", err)
 }
 
-// CheckReviewReady checks if the reviewer has written their review file
+// CheckReviewReady checks if the reviewer has written their review file.
+// It searches multiple locations to handle cases where Claude writes the file
+// to the wrong directory (e.g., subdirectory or parent in a monorepo).
 func (c *Coordinator) CheckReviewReady() (bool, error) {
 	if c.reviewerWorktree == "" {
 		return false, nil
 	}
 
-	reviewPath := ReviewFilePath(c.reviewerWorktree)
-	_, err := os.Stat(reviewPath)
+	_, err := FindReviewFile(c.reviewerWorktree)
 	if err == nil {
 		return true, nil
 	}
@@ -606,9 +611,13 @@ func (c *Coordinator) ProcessIncrementCompletion() error {
 
 	c.notifyIncrementReady(round, increment)
 
-	// Clear the increment file so it's fresh for next round
-	if err := os.Remove(IncrementFilePath(c.implementerWorktree)); err != nil && !os.IsNotExist(err) {
-		c.logger.Warn("failed to remove increment file", "error", err)
+	// Clear the increment file so it's fresh for next round.
+	// Use FindIncrementFile to get the actual path (which may be in a subdirectory
+	// or parent if Claude wrote it to the wrong location).
+	if incrementPath, err := FindIncrementFile(c.implementerWorktree); err == nil {
+		if err := os.Remove(incrementPath); err != nil && !os.IsNotExist(err) {
+			c.logger.Warn("failed to remove increment file", "error", err, "path", incrementPath)
+		}
 	}
 
 	// Start the reviewer
@@ -658,9 +667,13 @@ func (c *Coordinator) ProcessReviewCompletion() error {
 
 	c.notifyReviewReady(round, review)
 
-	// Clear the review file so it's fresh for next round
-	if err := os.Remove(ReviewFilePath(c.reviewerWorktree)); err != nil && !os.IsNotExist(err) {
-		c.logger.Warn("failed to remove review file", "error", err)
+	// Clear the review file so it's fresh for next round.
+	// Use FindReviewFile to get the actual path (which may be in a subdirectory
+	// or parent if Claude wrote it to the wrong location).
+	if reviewPath, err := FindReviewFile(c.reviewerWorktree); err == nil {
+		if err := os.Remove(reviewPath); err != nil && !os.IsNotExist(err) {
+			c.logger.Warn("failed to remove review file", "error", err, "path", reviewPath)
+		}
 	}
 
 	if review.Approved {
@@ -709,9 +722,12 @@ func (c *Coordinator) ProcessRejectionAfterApproval() error {
 		c.logger.Info("review file found after approval but it's still approved, ignoring",
 			"score", review.Score,
 		)
-		// Remove the file so we don't keep re-processing it
-		if err := os.Remove(ReviewFilePath(c.reviewerWorktree)); err != nil && !os.IsNotExist(err) {
-			c.logger.Warn("failed to remove review file", "error", err)
+		// Remove the file so we don't keep re-processing it.
+		// Use FindReviewFile to get the actual path.
+		if reviewPath, err := FindReviewFile(c.reviewerWorktree); err == nil {
+			if err := os.Remove(reviewPath); err != nil && !os.IsNotExist(err) {
+				c.logger.Warn("failed to remove review file", "error", err, "path", reviewPath)
+			}
 		}
 		return nil
 	}
@@ -729,9 +745,12 @@ func (c *Coordinator) ProcessRejectionAfterApproval() error {
 	// Record the rejection
 	c.notifyReviewReady(session.CurrentRound, review)
 
-	// Remove the review file so it's fresh for next round
-	if err := os.Remove(ReviewFilePath(c.reviewerWorktree)); err != nil && !os.IsNotExist(err) {
-		c.logger.Warn("failed to remove review file", "error", err)
+	// Remove the review file so it's fresh for next round.
+	// Use FindReviewFile to get the actual path.
+	if reviewPath, err := FindReviewFile(c.reviewerWorktree); err == nil {
+		if err := os.Remove(reviewPath); err != nil && !os.IsNotExist(err) {
+			c.logger.Warn("failed to remove review file", "error", err, "path", reviewPath)
+		}
 	}
 
 	// Check iteration limits


### PR DESCRIPTION
## Summary

- **Improved file detection** for adversarial mode's increment and review files by searching multiple locations (worktree root, subdirectories, and parent directory)
- **Added absolute paths** to prompts when worktree is known, reducing misplacement
- **Fixed file cleanup** to remove files from actual found locations, not hardcoded paths

## Changes

- Added `FindIncrementFile` and `FindReviewFile` functions that search multiple locations
- Updated `ParseIncrementFile` and `ParseReviewFile` to use the new search
- Modified `FormatImplementerPrompt` and `FormatReviewerPrompt` to accept worktree path parameter
- Updated `CheckIncrementReady` and `CheckReviewReady` to use new search functions
- Fixed file removal in `ProcessIncrementCompletion`, `ProcessReviewCompletion`, and `ProcessRejectionAfterApproval` to remove from actual found path
- Replaced custom `replaceFirst` function with `strings.Replace` (code simplification)

## Test plan

- [x] All existing tests pass
- [x] New tests for `FindIncrementFile` and `FindReviewFile` cover:
  - File in worktree root (expected location)
  - File in subdirectory (handles Claude cd into subdir)
  - File in parent directory (handles monorepo case)
  - File not found
  - Hidden directories are skipped
- [x] Tests for prompt formatting with worktree paths
- [x] `gofmt` and `go vet` pass