### PR TITLE
Add keyboard navigation shortcuts for input mode and task prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Enhanced Keyboard Navigation** - Added support for macOS-style keyboard shortcuts in input mode and the task prompt writer. Input mode now properly forwards `Opt+Left/Right` (word navigation) and `Opt+Backspace` (word deletion) to Claude instances. The task prompt writer now supports both the `msg.Alt` flag and string-based key reporting for `Opt+Arrow/Backspace`, as well as `Cmd+Left/Right/Backspace` (line navigation and delete-to-line-start) for terminals that forward these keys.
+
 ### Changed
 
 - **Adversarial Mode UI Enhancement** - Current round instances in adversarial mode now appear directly in the main adversarial group header instead of being nested under a "[Round X]" sub-group. The group header displays round information inline (e.g., "Refactor auth (Round 3) [2/2]"), making it immediately visible which round is active. Previous rounds are still organized under the "Previous Rounds" container for historical reference. This flattens the UI for the current round while preserving full round history navigation.

--- a/internal/tui/input/tmux.go
+++ b/internal/tui/input/tmux.go
@@ -30,6 +30,12 @@ func SendKeyToTmux(sender KeySender, msg tea.KeyMsg) {
 	case tea.KeyEnter:
 		key = "Enter"
 	case tea.KeyBackspace:
+		// Check for Alt modifier (Opt+Backspace on macOS)
+		if msg.Alt {
+			sender.SendKey("Escape")
+			sender.SendKey("BSpace")
+			return
+		}
 		key = "BSpace"
 	case tea.KeyTab:
 		key = "Tab"
@@ -41,14 +47,34 @@ func SendKeyToTmux(sender KeySender, msg tea.KeyMsg) {
 	case tea.KeyEsc:
 		key = "Escape"
 
-	// Arrow keys
+	// Arrow keys - check for Alt modifier (Opt+Arrow on macOS)
 	case tea.KeyUp:
+		if msg.Alt {
+			sender.SendKey("Escape")
+			sender.SendKey("Up")
+			return
+		}
 		key = "Up"
 	case tea.KeyDown:
+		if msg.Alt {
+			sender.SendKey("Escape")
+			sender.SendKey("Down")
+			return
+		}
 		key = "Down"
 	case tea.KeyRight:
+		if msg.Alt {
+			sender.SendKey("Escape")
+			sender.SendKey("Right")
+			return
+		}
 		key = "Right"
 	case tea.KeyLeft:
+		if msg.Alt {
+			sender.SendKey("Escape")
+			sender.SendKey("Left")
+			return
+		}
 		key = "Left"
 
 	// Navigation keys


### PR DESCRIPTION
## Summary
- Input mode now properly forwards `Opt+Left/Right` (word navigation) and `Opt+Backspace` (word deletion) to Claude instances via tmux
- Task prompt writer now supports macOS-style shortcuts:
  - `Opt+Left/Right` for word navigation
  - `Opt+Up/Down` for start/end of input
  - `Opt+Backspace` for word deletion
  - `Cmd+Left/Right` for line start/end navigation
  - `Cmd+Backspace` for delete-to-line-start
- Both string-based and flag-based key reporting are handled for cross-terminal compatibility

## Test plan
- [x] All existing tests pass
- [x] Added comprehensive tests for Alt+Arrow key combinations (string and flag-based)
- [x] Added tests for Alt+Backspace word deletion
- [x] Added consistency tests verifying string vs flag handling produces identical results
- [x] `go vet` and `gofmt` pass