### PR TITLE
Fix hash and tilde characters not being sent to Claude sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Adversarial Mode Sentinel File Search** - Improved file detection for adversarial mode's increment and review files. The system now searches multiple locations (worktree root, subdirectories, and parent directory) to handle cases where Claude writes the file to an unexpected location (e.g., monorepo root instead of worktree, or a subdirectory). When the worktree path is known (round > 1), the prompt now includes the absolute file path for clarity.
 
+- **Hash and Tilde Characters in Input** - Fixed an issue where hash (`#`) and tilde (`~`) characters were not being sent correctly to underlying Claude sessions when using tmux control mode. These characters are now properly quoted to prevent tmux from interpreting them as format specifiers or tilde expansion. Unicode characters like `£`, `€`, and emoji continue to work correctly.
+
 ## [0.13.0] - 2026-01-29
 
 This release introduces **Adversarial Review Mode** and **Color Themes** - two major features that enhance workflow quality and user experience.

--- a/internal/instance/input/persistent_sender.go
+++ b/internal/instance/input/persistent_sender.go
@@ -406,8 +406,14 @@ func escapeForControlMode(s string) string {
 	// if it contains special characters. We use single quotes and escape
 	// any existing single quotes by ending the quote, adding escaped quote,
 	// and restarting the quote: ' -> '\''
-	// Note: semicolon (;) is a tmux command separator and must be quoted.
-	if strings.ContainsAny(s, " \t\n\r'\"\\;") {
+	//
+	// Characters that must be quoted:
+	// - space, tab, newline, carriage return: whitespace separates arguments
+	// - ' " \: quote and escape characters
+	// - ; : tmux command separator
+	// - # : tmux format specifier prefix (e.g., #{window_name})
+	// - ~ : tilde expansion in some contexts
+	if strings.ContainsAny(s, " \t\n\r'\"\\;#~") {
 		escaped := strings.ReplaceAll(s, "'", "'\\''")
 		return "'" + escaped + "'"
 	}

--- a/internal/instance/input/persistent_sender_test.go
+++ b/internal/instance/input/persistent_sender_test.go
@@ -242,6 +242,75 @@ func TestEscapeForControlMode(t *testing.T) {
 			input:    ";",
 			expected: "';'",
 		},
+		// Hash/pound sign tests - critical for tmux format specifiers
+		{
+			name:     "string with hash",
+			input:    "#hello",
+			expected: "'#hello'",
+		},
+		{
+			name:     "hash only",
+			input:    "#",
+			expected: "'#'",
+		},
+		{
+			name:     "hashtag",
+			input:    "#golang",
+			expected: "'#golang'",
+		},
+		{
+			name:     "markdown header",
+			input:    "# Header",
+			expected: "'# Header'",
+		},
+		{
+			name:     "shell comment",
+			input:    "echo hello # comment",
+			expected: "'echo hello # comment'",
+		},
+		// Tilde tests
+		{
+			name:     "string with tilde",
+			input:    "~/Documents",
+			expected: "'~/Documents'",
+		},
+		{
+			name:     "tilde only",
+			input:    "~",
+			expected: "'~'",
+		},
+		// Unicode characters (should pass through unquoted if no special chars)
+		{
+			name:     "british pound",
+			input:    "£100",
+			expected: "£100",
+		},
+		{
+			name:     "euro symbol",
+			input:    "€50",
+			expected: "€50",
+		},
+		{
+			name:     "chinese characters",
+			input:    "你好",
+			expected: "你好",
+		},
+		{
+			name:     "emoji",
+			input:    "👍",
+			expected: "👍",
+		},
+		// Unicode with special characters (should be quoted)
+		{
+			name:     "british pound with space",
+			input:    "£100 total",
+			expected: "'£100 total'",
+		},
+		{
+			name:     "unicode with hash",
+			input:    "価格#1",
+			expected: "'価格#1'",
+		},
 	}
 
 	for _, tt := range tests {
@@ -337,6 +406,45 @@ func TestPersistentTmuxSender_BuildCommand(t *testing.T) {
 			keys:     "console.log('hello'); return;",
 			literal:  true,
 			expected: "send-keys -t my-session -l 'console.log('\\''hello'\\''); return;'\n",
+		},
+		// Hash/pound sign tests - must be quoted to avoid tmux format specifier interpretation
+		{
+			name:     "literal hash",
+			keys:     "#",
+			literal:  true,
+			expected: "send-keys -t my-session -l '#'\n",
+		},
+		{
+			name:     "literal hashtag",
+			keys:     "#hello",
+			literal:  true,
+			expected: "send-keys -t my-session -l '#hello'\n",
+		},
+		{
+			name:     "literal markdown header",
+			keys:     "# Title",
+			literal:  true,
+			expected: "send-keys -t my-session -l '# Title'\n",
+		},
+		// Tilde tests
+		{
+			name:     "literal tilde path",
+			keys:     "~/file",
+			literal:  true,
+			expected: "send-keys -t my-session -l '~/file'\n",
+		},
+		// Unicode tests - should not need quoting
+		{
+			name:     "literal unicode",
+			keys:     "£100",
+			literal:  true,
+			expected: "send-keys -t my-session -l £100\n",
+		},
+		{
+			name:     "literal emoji",
+			keys:     "👍",
+			literal:  true,
+			expected: "send-keys -t my-session -l 👍\n",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Fixed an issue where hash (`#`) and tilde (`~`) characters were not being sent correctly to underlying Claude sessions when using tmux control mode
- These characters are now properly quoted to prevent tmux from interpreting them as format specifiers (`#{...}`) or tilde expansion (`~/...`)
- Added comprehensive tests for special character escaping including unicode verification

## Test plan

- [x] All 509 existing tests pass
- [x] New test cases cover: hash alone, hash in text, markdown headers, shell comments, tilde paths, tilde alone
- [x] Unicode characters (£, €, Chinese, emoji) verified to pass through without unnecessary quoting
- [x] `gofmt` and `go vet` pass with no issues