### PR TITLE
Fix adversarial mode false positive stuck detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Hash and Tilde Characters in Input** - Fixed an issue where hash (`#`) and tilde (`~`) characters were not being sent correctly to underlying Claude sessions when using tmux control mode. These characters are now properly quoted to prevent tmux from interpreting them as format specifiers or tilde expansion. Unicode characters like `£`, `€`, and emoji continue to work correctly.
 
+- **Adversarial Mode False Positive Stuck Detection** - Fixed a race condition in adversarial mode where the implementer or reviewer would be incorrectly marked as "stuck" immediately after completion. The issue occurred because the TUI detected the instance as "completed" before Claude had finished writing the sentinel file (`.claudio-adversarial-incremental.json` or `.claudio-adversarial-review.json`). A 3-second grace period is now applied before declaring an instance stuck, allowing time for the file write to complete.
+
 ## [0.13.0] - 2026-01-29
 
 This release introduces **Adversarial Review Mode** and **Color Themes** - two major features that enhance workflow quality and user experience.


### PR DESCRIPTION
## Summary

- Fix race condition in adversarial mode where implementer/reviewer would be incorrectly marked as "stuck" immediately after completion
- Add a 3-second grace period before declaring an instance stuck, allowing time for the sentinel file write to complete
- Refactor stuck detection logic into a helper method to reduce code duplication

## Problem

The adversarial mode stuck detection had a race condition:
1. Claude instance finishes responding → state becomes "completed"
2. TUI polls (every 100ms) and checks: file exists? NO, instance completed? YES
3. TUI immediately declares "stuck"
4. Claude finishes writing the sentinel file a moment later → too late

## Solution

Added a grace period mechanism that:
- Records when an instance is first detected as "completed without file"
- Only declares "stuck" after 3 seconds have elapsed
- Resets the timer if the file appears OR the instance resumes working

## Test plan

- [x] All existing tests pass
- [x] Added tests for grace period behavior
- [x] Added tests for grace period reset scenarios
- [x] Verified with `go vet` and `gofmt`