### PR TITLE
Remove progress counters from group headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Adversarial Mode UI Enhancement** - Current round instances in adversarial mode now appear directly in the main adversarial group header instead of being nested under a "[Round X]" sub-group. The group header displays round information inline (e.g., "Refactor auth (Round 3) [2/2]"), making it immediately visible which round is active. Previous rounds are still organized under the "Previous Rounds" container for historical reference. This flattens the UI for the current round while preserving full round history navigation.
+- **Adversarial Mode UI Enhancement** - Current round instances in adversarial mode now appear directly in the main adversarial group header instead of being nested under a "[Round X]" sub-group. The group header displays round information inline (e.g., "Refactor auth (Round 3)"), making it immediately visible which round is active. Previous rounds are still organized under the "Previous Rounds" container for historical reference. This flattens the UI for the current round while preserving full round history navigation.
+
+- **Simplified Group Headers** - Removed the `[x/y]` progress counters from group headers in the sidebar. The phase indicator (● for executing, ✓ for completed, ✗ for failed) already provides visual feedback on group status, making the numeric counters redundant visual noise.
 
 ### Removed
 
 - **`claudio tripleshot` CLI Command** - The standalone `claudio tripleshot` command has been removed. TripleShot mode is now exclusively accessed through the TUI via the `:tripleshot` command (or aliases `:triple`, `:3shot`). This consolidates all tripleshot functionality within the standard TUI, providing a more consistent user experience. To use tripleshot, run `claudio start` and then use `:tripleshot` in command mode.
 
 ### Fixed
-
-- **Group Progress Display** - Fixed group title progress indicators (e.g., `[0/4]`) always showing `[0/x]` for orchestrated workflows. Progress now accurately reflects work completion for tripleshot (including adversarial reviewers), adversarial, and ralph session types by using workflow-specific completion tracking rather than just instance process status. For example, a tripleshot with 3 completed attempts now shows `[3/4]` instead of `[0/4]`.
 
 - **TUI Tripleshot Config Settings** - The `:tripleshot` command in the TUI now properly respects the `tripleshot.auto_approve` and `tripleshot.adversarial` settings from the config file. Previously, starting a tripleshot from the TUI always used hardcoded defaults, ignoring user configuration.
 

--- a/internal/tui/view/group_test.go
+++ b/internal/tui/view/group_test.go
@@ -178,7 +178,6 @@ func TestRenderGroupHeaderWrapped(t *testing.T) {
 	tests := []struct {
 		name       string
 		group      *orchestrator.InstanceGroup
-		progress   GroupProgress
 		collapsed  bool
 		isSelected bool
 		width      int
@@ -192,7 +191,6 @@ func TestRenderGroupHeaderWrapped(t *testing.T) {
 				Phase:       orchestrator.GroupPhasePending,
 				SessionType: string(orchestrator.SessionTypeTripleShot),
 			},
-			progress:   GroupProgress{Completed: 1, Total: 3},
 			collapsed:  false,
 			isSelected: false,
 			width:      80,
@@ -206,7 +204,6 @@ func TestRenderGroupHeaderWrapped(t *testing.T) {
 				Phase:       orchestrator.GroupPhaseExecuting,
 				SessionType: string(orchestrator.SessionTypeTripleShot),
 			},
-			progress:   GroupProgress{Completed: 2, Total: 5},
 			collapsed:  false,
 			isSelected: false,
 			width:      40,
@@ -220,7 +217,6 @@ func TestRenderGroupHeaderWrapped(t *testing.T) {
 				Phase:       orchestrator.GroupPhaseCompleted,
 				SessionType: string(orchestrator.SessionTypePlan),
 			},
-			progress:   GroupProgress{Completed: 3, Total: 3},
 			collapsed:  true,
 			isSelected: true,
 			width:      60,
@@ -230,13 +226,13 @@ func TestRenderGroupHeaderWrapped(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := RenderGroupHeaderWrapped(tt.group, tt.progress, tt.collapsed, tt.isSelected, tt.width)
+			result := RenderGroupHeaderWrapped(tt.group, tt.collapsed, tt.isSelected, tt.width)
 			if len(result) < tt.checkLines {
 				t.Errorf("RenderGroupHeaderWrapped() returned %d lines, want at least %d", len(result), tt.checkLines)
 			}
-			// First line should contain progress indicator
-			if len(result) > 0 && !strings.Contains(result[0], "[") {
-				t.Errorf("First line should contain progress indicator, got: %s", result[0])
+			// First line should contain the group name
+			if len(result) > 0 && !strings.Contains(result[0], tt.group.Name[:5]) {
+				t.Errorf("First line should contain group name, got: %s", result[0])
 			}
 		})
 	}
@@ -249,9 +245,8 @@ func TestRenderGroupHeader_WrappedOutput(t *testing.T) {
 		Phase:       orchestrator.GroupPhasePending,
 		SessionType: string(orchestrator.SessionTypeTripleShot),
 	}
-	progress := GroupProgress{Completed: 1, Total: 3}
 
-	result := RenderGroupHeader(group, progress, false, false, 80)
+	result := RenderGroupHeader(group, false, false, 80)
 
 	// Should be a single string (possibly with newlines)
 	if result == "" {
@@ -261,11 +256,6 @@ func TestRenderGroupHeader_WrappedOutput(t *testing.T) {
 	// Should contain the group name
 	if !strings.Contains(result, "Test Group") {
 		t.Errorf("RenderGroupHeader() should contain group name, got: %s", result)
-	}
-
-	// Should contain progress
-	if !strings.Contains(result, "[1/3]") {
-		t.Errorf("RenderGroupHeader() should contain progress [1/3], got: %s", result)
 	}
 }
 
@@ -754,14 +744,8 @@ func TestRenderGroupHeaderItemWrapped_WithRoundInfo(t *testing.T) {
 		Phase:       orchestrator.GroupPhaseExecuting,
 	}
 
-	progress := GroupProgress{
-		Completed: 1,
-		Total:     2,
-	}
-
 	item := GroupHeaderItem{
 		Group:      group,
-		Progress:   progress,
 		Collapsed:  false,
 		IsSelected: false,
 		Depth:      0,
@@ -784,11 +768,6 @@ func TestRenderGroupHeaderItemWrapped_WithRoundInfo(t *testing.T) {
 	if !strings.Contains(fullOutput, "Refactor auth") {
 		t.Errorf("RenderGroupHeaderItemWrapped() should contain group name, got: %s", fullOutput)
 	}
-
-	// The rendered output should include progress
-	if !strings.Contains(fullOutput, "[1/2]") {
-		t.Errorf("RenderGroupHeaderItemWrapped() should contain progress, got: %s", fullOutput)
-	}
 }
 
 func TestRenderGroupHeaderItemWrapped_WithoutRoundInfo(t *testing.T) {
@@ -800,14 +779,8 @@ func TestRenderGroupHeaderItemWrapped_WithoutRoundInfo(t *testing.T) {
 		Phase:       orchestrator.GroupPhaseExecuting,
 	}
 
-	progress := GroupProgress{
-		Completed: 2,
-		Total:     3,
-	}
-
 	item := GroupHeaderItem{
 		Group:      group,
-		Progress:   progress,
 		Collapsed:  false,
 		IsSelected: false,
 		Depth:      0,
@@ -844,7 +817,6 @@ func TestRenderGroupHeaderItem(t *testing.T) {
 
 	item := GroupHeaderItem{
 		Group:      group,
-		Progress:   GroupProgress{Completed: 1, Total: 2},
 		Collapsed:  false,
 		IsSelected: false,
 		Depth:      0,

--- a/internal/tui/view/sidebar_test.go
+++ b/internal/tui/view/sidebar_test.go
@@ -148,11 +148,6 @@ func TestSidebarView_GroupedModeWithGroups(t *testing.T) {
 		t.Errorf("grouped mode should show group 2, got:\n%s", result)
 	}
 
-	// Should contain progress indicators
-	if !strings.Contains(result, "[2/2]") {
-		t.Errorf("should show progress [2/2] for completed group, got:\n%s", result)
-	}
-
 	// Should contain instance names
 	if !strings.Contains(result, "Setup auth") {
 		t.Errorf("should show instance task 'Setup auth', got:\n%s", result)
@@ -745,15 +740,11 @@ func TestRenderGroupHeader(t *testing.T) {
 		Name:  "Test Group",
 		Phase: orchestrator.GroupPhaseExecuting,
 	}
-	progress := GroupProgress{Completed: 2, Total: 5}
 
 	// Test expanded
-	result := RenderGroupHeader(group, progress, false, false, 40)
+	result := RenderGroupHeader(group, false, false, 40)
 	if !strings.Contains(result, "Test Group") {
 		t.Errorf("should contain group name, got: %s", result)
-	}
-	if !strings.Contains(result, "[2/5]") {
-		t.Errorf("should contain progress [2/5], got: %s", result)
 	}
 	// Should have expanded indicator (down triangle)
 	if !strings.Contains(result, styles.IconGroupExpand) {
@@ -761,7 +752,7 @@ func TestRenderGroupHeader(t *testing.T) {
 	}
 
 	// Test collapsed
-	result = RenderGroupHeader(group, progress, true, false, 40)
+	result = RenderGroupHeader(group, true, false, 40)
 	// Should have collapsed indicator (right triangle)
 	if !strings.Contains(result, styles.IconGroupCollapse) {
 		t.Errorf("collapsed group should have right triangle, got: %s", result)

--- a/internal/tui/view/tripleshot.go
+++ b/internal/tui/view/tripleshot.go
@@ -491,24 +491,18 @@ func renderTripleShotPlanGroups(ctx TripleShotRenderContext, width int) string {
 			continue
 		}
 
-		// Calculate group progress
-		progress := CalculateGroupProgress(group, ctx.Session)
-
 		// Render group header (simplified - not collapsible in tripleshot view)
 		phaseColor := PhaseColor(group.Phase)
 		phaseIndicator := PhaseIndicator(group.Phase)
-		progressStr := fmt.Sprintf("[%d/%d]", progress.Completed, progress.Total)
 
 		// Truncate name if needed (use rune-based truncation for Unicode safety)
-		maxNameLen := width - len(progressStr) - 6
+		maxNameLen := width - 4 // Leave room for space + indicator
 		displayName := truncateGroupName(group.Name, maxNameLen)
 
 		headerStyle := lipgloss.NewStyle().Bold(true).Foreground(phaseColor)
-		progressStyle := lipgloss.NewStyle().Foreground(styles.MutedColor)
 		indicatorStyle := lipgloss.NewStyle().Foreground(phaseColor)
 
 		lines = append(lines, headerStyle.Render(displayName)+" "+
-			progressStyle.Render(progressStr)+" "+
 			indicatorStyle.Render(phaseIndicator))
 
 		// Render instances in this group


### PR DESCRIPTION
## Summary
- Remove the `[x/y]` progress counters from standard group headers in the sidebar
- The phase indicator (● ✓ ✗) already provides visual feedback on group status
- Round metadata for adversarial groups (e.g., "(Round 3)") is preserved
- Clean up unused `progress` parameter from render functions and `Progress` field from `GroupHeaderItem`

## Test plan
- [x] All existing tests pass
- [x] Build succeeds
- [x] `go vet` passes
- [x] Code properly formatted