### PR TITLE
Prevent UI stall when starting tripleshot on large repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Tripleshot UI Responsiveness** - Fixed UI stalling when starting a tripleshot on large repositories. Worktree creation is now performed asynchronously in parallel, allowing the UI to remain responsive. Instances appear immediately with "Preparing" status while worktrees are created in the background.
+
 - **TUI Tripleshot Config Settings** - The `:tripleshot` command in the TUI now properly respects the `tripleshot.auto_approve` and `tripleshot.adversarial` settings from the config file. Previously, starting a tripleshot from the TUI always used hardcoded defaults, ignoring user configuration.
 
 - **False Positive Stale Detection** - Fixed instances being incorrectly marked as "stuck" in two scenarios: (1) When Claude was actively working but the output wasn't changing (e.g., running explore agents with collapsed output, or showing a static spinner during thinking phase) - the stale counter now only increments when no working indicators (spinners, "Reading...", "Analyzing...", etc.) are present. (2) When Claude was waiting for user input but the patterns didn't match Claude Code's actual UI - the state detection patterns now correctly recognize Claude Code's input prompt (`❯`), plan/auto/focus mode indicators (`⏸`), and case variations in mode cycling hints.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2319,6 +2319,17 @@ func (o *Orchestrator) AddInstanceStub(session *Session, task string) (*Instance
 	return inst, nil
 }
 
+// CompleteInstanceSetupByID finds an instance by ID and completes its async setup.
+// This is a convenience wrapper around CompleteInstanceSetup for use by components
+// that only have the instance ID (e.g., tripleshot coordinator).
+func (o *Orchestrator) CompleteInstanceSetupByID(session *Session, instanceID string) error {
+	inst := session.GetInstance(instanceID)
+	if inst == nil {
+		return fmt.Errorf("instance %s not found", instanceID)
+	}
+	return o.CompleteInstanceSetup(session, inst)
+}
+
 // CompleteInstanceSetup finishes the async setup for a stub instance.
 // This is the slow second phase - it creates the worktree and registers
 // the instance with managers. Should be called from a goroutine.

--- a/internal/orchestrator/workflow_adapters.go
+++ b/internal/orchestrator/workflow_adapters.go
@@ -37,6 +37,16 @@ func (a *orchestratorAdapter) SaveSession() error {
 	return a.orch.SaveSession()
 }
 
+func (a *orchestratorAdapter) AddInstanceStub(session tripleshot.SessionInterface, task string) (tripleshot.InstanceInterface, error) {
+	s := session.(*sessionAdapter).session
+	return a.orch.AddInstanceStub(s, task)
+}
+
+func (a *orchestratorAdapter) CompleteInstanceSetupByID(session tripleshot.SessionInterface, instanceID string) error {
+	s := session.(*sessionAdapter).session
+	return a.orch.CompleteInstanceSetupByID(s, instanceID)
+}
+
 // sessionAdapter implements tripleshot.SessionInterface
 type sessionAdapter struct {
 	session *Session

--- a/internal/orchestrator/workflows/tripleshot/types.go
+++ b/internal/orchestrator/workflows/tripleshot/types.go
@@ -35,6 +35,8 @@ type AttemptStatus string
 const (
 	// AttemptStatusPending - attempt has not started yet
 	AttemptStatusPending AttemptStatus = ""
+	// AttemptStatusPreparing - attempt stub created, worktree being set up
+	AttemptStatusPreparing AttemptStatus = "preparing"
 	// AttemptStatusWorking - attempt is actively working on the problem
 	AttemptStatusWorking AttemptStatus = "working"
 	// AttemptStatusUnderReview - implementation complete, awaiting adversarial review approval

--- a/internal/tui/msg/commands.go
+++ b/internal/tui/msg/commands.go
@@ -193,6 +193,42 @@ func LoadDiffAsync(o *orchestrator.Orchestrator, worktreePath string, instanceID
 	}
 }
 
+// CreateTripleShotStubsAsync returns a command that creates stub instances for all three
+// tripleshot attempts. This is the fast first phase - it creates instance metadata
+// immediately so the UI can show "Preparing" status while worktrees are created.
+func CreateTripleShotStubsAsync(
+	coordinator *tripleshot.Coordinator,
+	groupID string,
+) tea.Cmd {
+	return func() tea.Msg {
+		instanceIDs, err := coordinator.CreateAttemptStubs()
+		return TripleShotStubsCreatedMsg{
+			GroupID:     groupID,
+			InstanceIDs: instanceIDs,
+			Err:         err,
+		}
+	}
+}
+
+// CompleteTripleShotAttemptSetupAsync returns a command that completes the setup for a
+// single tripleshot attempt. This is the slow second phase - it creates the worktree
+// and starts the instance. Should be called for each attempt after receiving
+// TripleShotStubsCreatedMsg.
+func CompleteTripleShotAttemptSetupAsync(
+	coordinator *tripleshot.Coordinator,
+	groupID string,
+	attemptIndex int,
+) tea.Cmd {
+	return func() tea.Msg {
+		err := coordinator.CompleteAttemptSetup(attemptIndex)
+		return TripleShotAttemptSetupCompleteMsg{
+			GroupID:      groupID,
+			AttemptIndex: attemptIndex,
+			Err:          err,
+		}
+	}
+}
+
 // CheckTripleShotCompletionAsync returns a command that checks tripleshot completion files
 // in a goroutine, avoiding blocking the UI event loop with file I/O.
 func CheckTripleShotCompletionAsync(

--- a/internal/tui/msg/types.go
+++ b/internal/tui/msg/types.go
@@ -93,6 +93,22 @@ type UltraPlanInitMsg struct{}
 // TripleShotStartedMsg indicates triple-shot attempts have started.
 type TripleShotStartedMsg struct{}
 
+// TripleShotStubsCreatedMsg indicates that stub instances for all three attempts
+// have been created (fast first phase). The UI can show these with "Preparing" status.
+type TripleShotStubsCreatedMsg struct {
+	GroupID     string
+	InstanceIDs [3]string
+	Err         error
+}
+
+// TripleShotAttemptSetupCompleteMsg indicates that a single attempt's worktree setup
+// has completed (slow second phase). The attempt is now ready to run.
+type TripleShotAttemptSetupCompleteMsg struct {
+	GroupID      string
+	AttemptIndex int
+	Err          error
+}
+
 // TripleShotJudgeStartedMsg indicates the judge has started evaluating.
 type TripleShotJudgeStartedMsg struct {
 	// ImplementersGroupID is the ID of the Implementers sub-group, used by TUI


### PR DESCRIPTION
## Summary
- Fixes UI stalling when starting a tripleshot on large repositories
- Worktree creation is now performed asynchronously in parallel
- Instances appear immediately with "Preparing" status while worktrees are created in the background

## Changes
- Add `AttemptStatusPreparing` for intermediate state during setup
- Add `CreateAttemptStubs()` for fast stub creation (phase 1)
- Add `CompleteAttemptSetup()` for parallel worktree setup (phase 2)
- Add `CompleteInstanceSetupByID()` orchestrator wrapper
- Update TUI to use two-phase async initialization
- Extract `findTripleGroup()` helper to reduce duplication
- Add comprehensive tests for new methods

## Test plan
- [x] All existing tests pass
- [x] New tests added for `CreateAttemptStubs`, `CompleteAttemptSetup`, `AllAttemptsReady`
- [ ] Manual test: Run tripleshot on a large repo, verify UI stays responsive
- [ ] Verify sidebar shows instances with "Preparing" → "Working" status transition