### PR TITLE
Fix tripleshot adversarial feedback loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **TripleShot-Adversarial Feedback Loop** - Each implementer now properly iterates with reviewer feedback instead of failing on first rejection. When a reviewer rejects an attempt, the implementer is restarted with the reviewer's feedback, issues, and required changes. This continues until the reviewer approves or max rounds are exhausted (uses `adversarial.max_iterations`, default 10, 0 = unlimited). Also fixed the TUI not polling during the adversarial review phase, which prevented reviewer completions from being detected.
+
 - **Tripleshot UI Responsiveness** - Fixed UI stalling when starting a tripleshot on large repositories. Worktree creation is now performed asynchronously in parallel, allowing the UI to remain responsive. Instances appear immediately with "Preparing" status while worktrees are created in the background.
 
 - **TUI Tripleshot Config Settings** - The `:tripleshot` command in the TUI now properly respects the `tripleshot.auto_approve` and `tripleshot.adversarial` settings from the config file. Previously, starting a tripleshot from the TUI always used hardcoded defaults, ignoring user configuration.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -670,6 +670,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Handle async judge completion processing result
 		return m.handleTripleShotJudgeProcessed(msg)
 
+	case tuimsg.TripleShotReviewProcessedMsg:
+		// Handle async adversarial review processing result
+		return m.handleTripleShotReviewProcessed(msg)
+
 	case tuimsg.PlanFileCheckResultMsg:
 		// Handle async plan file check result (single-pass mode)
 		return m.handlePlanFileCheckResult(msg)
@@ -1707,6 +1711,7 @@ func (m Model) initiateTripleShotMode(task string) (Model, tea.Cmd) {
 	cfg := config.Get()
 	tripleConfig.AutoApprove = cfg.Tripleshot.AutoApprove
 	tripleConfig.Adversarial = cfg.Tripleshot.Adversarial
+	tripleConfig.MaxAdversarialRounds = cfg.Adversarial.MaxIterations
 	tripleSession := orchestrator.NewTripleShotSession(task, tripleConfig)
 
 	// Link group ID to session for multi-tripleshot support

--- a/internal/tui/msg/types.go
+++ b/internal/tui/msg/types.go
@@ -134,6 +134,13 @@ type TripleShotCheckResultMsg struct {
 	// AttemptErrors maps attempt index to any errors encountered during check
 	AttemptErrors map[int]error
 
+	// ReviewResults maps attempt index to review completion status (true = file exists)
+	// Only populated during PhaseAdversarialReview
+	ReviewResults map[int]bool
+
+	// ReviewErrors maps attempt index to any errors encountered checking review files
+	ReviewErrors map[int]error
+
 	// JudgeComplete indicates whether the judge completion file exists
 	JudgeComplete bool
 
@@ -158,6 +165,14 @@ type TripleShotJudgeProcessedMsg struct {
 	GroupID     string
 	Err         error
 	TaskPreview string
+}
+
+// TripleShotReviewProcessedMsg contains the result of processing an adversarial review file.
+// This is returned by ProcessAdversarialReviewCompletionAsync after reading and parsing the file.
+type TripleShotReviewProcessedMsg struct {
+	GroupID      string
+	AttemptIndex int
+	Err          error
 }
 
 // PlanFileCheckResultMsg contains the result of async plan file checking.


### PR DESCRIPTION
## Summary

- Implements proper adversarial feedback loops in TripleShot mode
- When a reviewer rejects an implementation, the implementer is now restarted with feedback instead of being permanently marked as failed
- Each implementer can iterate up to `MaxAdversarialRounds` (default: 3) before exhausting attempts
- Fixes TUI polling during `PhaseAdversarialReview` to detect reviewer completions

## Test plan

- [x] Unit tests pass: `go test ./...`
- [x] Build succeeds: `go build ./...`
- [x] Lint passes: `golangci-lint run`
- [x] New tests added for:
  - `TestCoordinator_ProcessAdversarialReviewCompletion_Rejected_RestartsImplementer`
  - `TestCoordinator_ProcessAdversarialReviewCompletion_Rejected_MaxRoundsExhausted`
  - `TestCoordinator_RestartImplementerWithFeedback`
  - `TestFormatImplementerPromptWithFeedback`
- [ ] Manual test: Run tripleshot-adversarial mode, have reviewer reject, verify implementer restarts with feedback