### PR TITLE
Fix Alt/Option arrow keys being interpreted as Escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **TripleShot-Adversarial Feedback Loop** - Each implementer now properly iterates with reviewer feedback instead of failing on first rejection. When a reviewer rejects an attempt, the implementer is restarted with the reviewer's feedback, issues, and required changes. This continues until the reviewer approves or max rounds are exhausted (uses `adversarial.max_iterations`, default 10, 0 = unlimited). Also fixed the TUI not polling during the adversarial review phase, which prevented reviewer completions from being detected.
 
+- **Alt/Option Arrow Keys in Input Mode** - Fixed Opt+Left and Opt+Right being incorrectly interpreted as Escape key presses by underlying Claude sessions. The issue was caused by sending Alt+key combinations as two separate key events (Escape then arrow) instead of a single atomic Meta+key event. All Alt/Option modified keys now use tmux's `M-` prefix notation (e.g., `M-Left`, `M-Right`), which sends them as proper word-navigation commands.
+
 - **Tripleshot UI Responsiveness** - Fixed UI stalling when starting a tripleshot on large repositories. Worktree creation is now performed asynchronously in parallel, allowing the UI to remain responsive. Instances appear immediately with "Preparing" status while worktrees are created in the background.
 
 - **TUI Tripleshot Config Settings** - The `:tripleshot` command in the TUI now properly respects the `tripleshot.auto_approve` and `tripleshot.adversarial` settings from the config file. Previously, starting a tripleshot from the TUI always used hardcoded defaults, ignoring user configuration.

--- a/internal/tui/input/tmux.go
+++ b/internal/tui/input/tmux.go
@@ -32,8 +32,7 @@ func SendKeyToTmux(sender KeySender, msg tea.KeyMsg) {
 	case tea.KeyBackspace:
 		// Check for Alt modifier (Opt+Backspace on macOS)
 		if msg.Alt {
-			sender.SendKey("Escape")
-			sender.SendKey("BSpace")
+			sender.SendKey("M-BSpace")
 			return
 		}
 		key = "BSpace"
@@ -48,31 +47,28 @@ func SendKeyToTmux(sender KeySender, msg tea.KeyMsg) {
 		key = "Escape"
 
 	// Arrow keys - check for Alt modifier (Opt+Arrow on macOS)
+	// Use M- prefix (Meta) for Alt combinations - tmux sends this as a single key event
 	case tea.KeyUp:
 		if msg.Alt {
-			sender.SendKey("Escape")
-			sender.SendKey("Up")
+			sender.SendKey("M-Up")
 			return
 		}
 		key = "Up"
 	case tea.KeyDown:
 		if msg.Alt {
-			sender.SendKey("Escape")
-			sender.SendKey("Down")
+			sender.SendKey("M-Down")
 			return
 		}
 		key = "Down"
 	case tea.KeyRight:
 		if msg.Alt {
-			sender.SendKey("Escape")
-			sender.SendKey("Right")
+			sender.SendKey("M-Right")
 			return
 		}
 		key = "Right"
 	case tea.KeyLeft:
 		if msg.Alt {
-			sender.SendKey("Escape")
-			sender.SendKey("Left")
+			sender.SendKey("M-Left")
 			return
 		}
 		key = "Left"
@@ -173,10 +169,9 @@ func SendKeyToTmux(sender KeySender, msg tea.KeyMsg) {
 		// Send literal characters
 		// Handle Alt+key combinations
 		if msg.Alt {
-			// For alt combinations, tmux uses M- prefix or Escape followed by char
+			// For alt combinations, tmux uses M- prefix for Meta key
 			key = string(msg.Runes)
-			sender.SendKey("Escape") // Send escape first
-			sender.SendLiteral(key)  // Then send the character
+			sender.SendKey("M-" + key)
 			return
 		}
 		key = string(msg.Runes)
@@ -208,16 +203,11 @@ func SendKeyToTmux(sender KeySender, msg tea.KeyMsg) {
 				key = keyStr
 			}
 		case strings.HasPrefix(keyStr, "alt+"):
-			// Alt combinations: send Escape then the key
+			// Alt combinations: use M- prefix (Meta) for tmux
 			baseKey := strings.TrimPrefix(keyStr, "alt+")
-			sender.SendKey("Escape")
-			if len(baseKey) == 1 {
-				sender.SendLiteral(baseKey)
-			} else {
-				// Map Bubble Tea key names to tmux key names
-				tmuxKey := tmux.MapKeyToTmux(baseKey)
-				sender.SendKey(tmuxKey)
-			}
+			// Map Bubble Tea key names to tmux key names and add M- prefix
+			tmuxKey := tmux.MapKeyToTmux(baseKey)
+			sender.SendKey("M-" + tmuxKey)
 			return
 		case strings.HasPrefix(keyStr, "ctrl+"):
 			// Try to handle ctrl combinations not caught above

--- a/internal/tui/input/tmux_test.go
+++ b/internal/tui/input/tmux_test.go
@@ -223,25 +223,25 @@ func TestSendKeyToTmux_AltRunes(t *testing.T) {
 	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}, Alt: true}
 	SendKeyToTmux(sender, msg)
 
-	// Alt+key sends Escape first, then the character as literal
-	if len(sender.keys) != 1 || sender.keys[0] != "Escape" {
-		t.Errorf("SendKeyToTmux() sent keys = %v, want [Escape]", sender.keys)
+	// Alt+key sends M- prefixed key (Meta key in tmux)
+	if len(sender.keys) != 1 || sender.keys[0] != "M-x" {
+		t.Errorf("SendKeyToTmux() sent keys = %v, want [M-x]", sender.keys)
 	}
-	if len(sender.literals) != 1 || sender.literals[0] != "x" {
-		t.Errorf("SendKeyToTmux() sent literals = %v, want [x]", sender.literals)
+	if len(sender.literals) != 0 {
+		t.Errorf("SendKeyToTmux() unexpectedly sent literals = %v", sender.literals)
 	}
 }
 
 func TestSendKeyToTmux_AltArrowKeys(t *testing.T) {
 	tests := []struct {
-		name         string
-		keyType      tea.KeyType
-		expectedKeys []string
+		name        string
+		keyType     tea.KeyType
+		expectedKey string
 	}{
-		{"alt-up", tea.KeyUp, []string{"Escape", "Up"}},
-		{"alt-down", tea.KeyDown, []string{"Escape", "Down"}},
-		{"alt-left", tea.KeyLeft, []string{"Escape", "Left"}},
-		{"alt-right", tea.KeyRight, []string{"Escape", "Right"}},
+		{"alt-up", tea.KeyUp, "M-Up"},
+		{"alt-down", tea.KeyDown, "M-Down"},
+		{"alt-left", tea.KeyLeft, "M-Left"},
+		{"alt-right", tea.KeyRight, "M-Right"},
 	}
 
 	for _, tt := range tests {
@@ -250,15 +250,8 @@ func TestSendKeyToTmux_AltArrowKeys(t *testing.T) {
 			msg := tea.KeyMsg{Type: tt.keyType, Alt: true}
 			SendKeyToTmux(sender, msg)
 
-			if len(sender.keys) != len(tt.expectedKeys) {
-				t.Errorf("SendKeyToTmux() sent %d keys = %v, want %d keys %v",
-					len(sender.keys), sender.keys, len(tt.expectedKeys), tt.expectedKeys)
-				return
-			}
-			for i, expected := range tt.expectedKeys {
-				if sender.keys[i] != expected {
-					t.Errorf("SendKeyToTmux() key[%d] = %v, want %v", i, sender.keys[i], expected)
-				}
+			if len(sender.keys) != 1 || sender.keys[0] != tt.expectedKey {
+				t.Errorf("SendKeyToTmux() sent keys = %v, want [%v]", sender.keys, tt.expectedKey)
 			}
 			if len(sender.literals) != 0 {
 				t.Errorf("SendKeyToTmux() unexpectedly sent literals = %v", sender.literals)
@@ -272,17 +265,9 @@ func TestSendKeyToTmux_AltBackspace(t *testing.T) {
 	msg := tea.KeyMsg{Type: tea.KeyBackspace, Alt: true}
 	SendKeyToTmux(sender, msg)
 
-	// Alt+Backspace (Opt+Backspace on macOS) sends Escape then BSpace
-	expectedKeys := []string{"Escape", "BSpace"}
-	if len(sender.keys) != len(expectedKeys) {
-		t.Errorf("SendKeyToTmux() sent %d keys = %v, want %d keys %v",
-			len(sender.keys), sender.keys, len(expectedKeys), expectedKeys)
-		return
-	}
-	for i, expected := range expectedKeys {
-		if sender.keys[i] != expected {
-			t.Errorf("SendKeyToTmux() key[%d] = %v, want %v", i, sender.keys[i], expected)
-		}
+	// Alt+Backspace (Opt+Backspace on macOS) sends M-BSpace (Meta+Backspace in tmux)
+	if len(sender.keys) != 1 || sender.keys[0] != "M-BSpace" {
+		t.Errorf("SendKeyToTmux() sent keys = %v, want [M-BSpace]", sender.keys)
 	}
 	if len(sender.literals) != 0 {
 		t.Errorf("SendKeyToTmux() unexpectedly sent literals = %v", sender.literals)


### PR DESCRIPTION
## Summary

- Fixed Opt+Left and Opt+Right being incorrectly interpreted as Escape key presses by underlying Claude sessions
- The issue was caused by sending Alt+key combinations as two separate key events (Escape then arrow) instead of a single atomic Meta+key event
- All Alt/Option modified keys now use tmux's `M-` prefix notation (e.g., `M-Left`, `M-Right`), which sends them as proper word-navigation commands

## Test plan

- [x] Run `go test ./internal/tui/input/...` - all tests pass
- [x] Run `go vet ./...` - no issues
- [x] Run `gofmt -d .` - no formatting issues
- [ ] Manual test: Press Opt+Left/Right in input mode, verify word navigation works instead of triggering Escape behavior