### PR TITLE
Fix false positive stuck detection in adversarial mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Adversarial Mode False Positive Stuck Detection** - Fixed a race condition in adversarial mode where the implementer or reviewer would be incorrectly marked as "stuck" immediately after completion. The issue occurred because the TUI detected the instance as "completed" before Claude had finished writing the sentinel file (`.claudio-adversarial-incremental.json` or `.claudio-adversarial-review.json`). A 3-second grace period is now applied before declaring an instance stuck, allowing time for the file write to complete.
 
+- **Adversarial Mode False Positive Stuck Detection** - Removed automatic stuck detection from adversarial mode, which was causing false positives when Claude was actively thinking/processing. Claude Code shows UI elements like "(shift+Tab to cycle)" even while processing, which triggered incorrect `StateWaitingInput` detection. Adversarial mode now simply polls for completion files like tripleshot does. If an instance genuinely gets stuck, users can interact with it directly or use `:adversarial-retry` to restart.
+
+- **Improved Working State Detection** - Added comprehensive detection of Claude Code's spinner/thinking status words (Thinking, Frosting, Cogitating, Manifesting, Architecting, Razzmatazzing, etc. - the full ~60 word pool) to the working state patterns. This ensures Claude is correctly detected as "working" when these indicators appear in output, preventing false "waiting" state detection.
+
 ## [0.13.0] - 2026-01-29
 
 This release introduces **Adversarial Review Mode** and **Color Themes** - two major features that enhance workflow quality and user experience.

--- a/internal/instance/detect/state.go
+++ b/internal/instance/detect/state.go
@@ -166,6 +166,12 @@ var (
 		`(?i)(?:let me (?:check|look|see|analyze|examine|investigate|read|search|find)|i'?ll (?:check|look|start|begin)|going to (?:check|look|analyze|implement)|about to (?:start|begin|run))`,
 		`(?i)(?:working on|processing|loading|fetching)`,
 		`⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏`, // Spinner characters
+		// Claude Code spinner/thinking status words - these appear in the status line
+		// when Claude is actively processing (e.g., "* Thinking..." or "· thinking")
+		// Full list from Claude Code's spinner word pool
+		`(?i)(?:thinking|thought|accomplishing|actioning|actualizing|architecting|baking|brewing|calculating|cerebrating|churning|clauding|coalescing|cogitating|computing|conjuring|considering|contemplating|cooking|crafting|creating|crunching|deliberating|determining|doing|effecting|finagling|forging|forming|frosting|generating|hatching|herding|honking|hustling|ideating|inferring|manifesting|marinating|moseying|mulling|mustering|musing|noodling|percolating|pondering|processing|puttering|razzmatazzing|reticulating|ruminating|scampering|schlepping|shucking|simmering|smooshing|spinning|stewing|synthesizing|transmuting|vibing|working)`,
+		// Token count indicator (e.g., "12.6k tokens") - appears during active processing
+		`\d+(?:\.\d+)?k?\s*tokens`,
 	}
 
 	// PROpenedPatterns detect when a pull request URL appears in output.

--- a/internal/instance/detect/state_test.go
+++ b/internal/instance/detect/state_test.go
@@ -436,6 +436,63 @@ func TestDetector_Detect_Working(t *testing.T) {
 			name:   "spinner char braille 3",
 			output: "⠹ Compiling",
 		},
+		// Claude Code thinking/processing spinner words
+		{
+			name:   "thinking indicator",
+			output: "* Thinking...",
+		},
+		{
+			name:   "thinking in status line",
+			output: "· thinking",
+		},
+		{
+			name:   "thought indicator",
+			output: "thought for 5 seconds",
+		},
+		{
+			name:   "frosting indicator",
+			output: "* Frosting...",
+		},
+		{
+			name:   "cogitating indicator",
+			output: "Cogitating...",
+		},
+		{
+			name:   "manifesting indicator",
+			output: "Manifesting...",
+		},
+		{
+			name:   "pondering indicator",
+			output: "* Pondering...",
+		},
+		{
+			name:   "contemplating indicator",
+			output: "Contemplating the problem...",
+		},
+		{
+			name:   "token count indicator",
+			output: "12.6k tokens",
+		},
+		{
+			name:   "token count with context",
+			output: "esc to interrupt · 3m 36s · ↓ 12.6k tokens · thinking",
+		},
+		{
+			name:   "small token count",
+			output: "500 tokens",
+		},
+		{
+			name:   "architecting indicator",
+			output: "* Architecting...",
+		},
+		{
+			name:   "determining indicator",
+			output: "Determining approach...",
+		},
+		{
+			name:   "forging indicator",
+			output: "* Forging...",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

- Removes automatic stuck detection from adversarial mode which was causing false positives when Claude was actively thinking/processing
- Adds comprehensive detection of Claude Code's spinner/thinking status words to working state patterns
- Adversarial mode now polls for completion files like tripleshot does

## Problem

When starting a new adversarial session, the stuck detection would immediately trigger with "Error: Adversarial implementer stuck! Completed without writing required file." This happened because:

1. Claude Code shows UI elements like `(shift+Tab to cycle)` even while actively processing/thinking
2. This triggered `StateWaitingInput` detection
3. The stuck detection saw "waiting" state + no file written = stuck

## Solution

1. **Remove automatic stuck detection** - Adversarial mode now simply polls for completion files like tripleshot does. If an instance genuinely gets stuck, users can interact with it directly or use `:adversarial-retry` to restart.

2. **Add comprehensive working state patterns** - Added Claude Code's full spinner word pool (~60 words: Thinking, Frosting, Cogitating, Manifesting, Architecting, Razzmatazzing, etc.) plus token count indicators to ensure Claude is correctly detected as "working" when these appear in output.

## Test plan

- [x] All existing tests pass
- [x] New test cases for spinner word detection pass
- [x] `gofmt`, `go vet`, `go build` all pass
- [ ] Manual test: Start adversarial mode and verify no false positive stuck detection