### PR TITLE
Fix INPUT mode typing lag with filtered output caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`claudio tripleshot` CLI Command** - The standalone `claudio tripleshot` command has been removed. TripleShot mode is now exclusively accessed through the TUI via the `:tripleshot` command (or aliases `:triple`, `:3shot`). This consolidates all tripleshot functionality within the standard TUI, providing a more consistent user experience. To use tripleshot, run `claudio start` and then use `:tripleshot` in command mode.
 
+### Performance
+
+- **Input Mode Typing Responsiveness** - Fixed typing lag and stuttering in INPUT mode when interacting with Claude instances. The output filtering logic now caches filtered results per instance and only recomputes when the raw output or filter settings change. Previously, every keystroke triggered expensive string operations (line splitting, regex matching, case conversion) on the entire output buffer, even when nothing had changed.
+
 ### Fixed
 
 - **TripleShot-Adversarial Feedback Loop** - Each implementer now properly iterates with reviewer feedback instead of failing on first rejection. When a reviewer rejects an attempt, the implementer is restarted with the reviewer's feedback, issues, and required changes. This continues until the reviewer approves or max rounds are exhausted (uses `adversarial.max_iterations`, default 10, 0 = unlimited). Also fixed the TUI not polling during the adversarial review phase, which prevented reviewer completions from being detected.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1389,11 +1389,10 @@ func (m Model) renderInstance(inst *orchestrator.Instance, width int) string {
 	mgr := m.orchestrator.GetInstanceManager(inst.ID)
 	isRunning := mgr != nil && mgr.Running()
 
-	// Apply filters to output
-	output := m.outputManager.GetOutput(inst.ID)
-	if output != "" {
-		output = m.filterOutput(output)
-	}
+	// Get filtered output using cache (avoids expensive recomputation on every render)
+	// Ensure filter function is set for cached filtering to work
+	m.outputManager.SetFilterFunc(m.filterOutput)
+	output := m.outputManager.GetFilteredOutput(inst.ID)
 
 	renderState := view.RenderState{
 		Output:            output,

--- a/internal/tui/keyhandler.go
+++ b/internal/tui/keyhandler.go
@@ -1060,22 +1060,27 @@ func (m Model) handleFilterInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "e", "1":
 		m.filterCategories["errors"] = !m.filterCategories["errors"]
+		m.outputManager.InvalidateFilterCache()
 		return m, nil
 
 	case "w", "2":
 		m.filterCategories["warnings"] = !m.filterCategories["warnings"]
+		m.outputManager.InvalidateFilterCache()
 		return m, nil
 
 	case "t", "3":
 		m.filterCategories["tools"] = !m.filterCategories["tools"]
+		m.outputManager.InvalidateFilterCache()
 		return m, nil
 
 	case "h", "4":
 		m.filterCategories["thinking"] = !m.filterCategories["thinking"]
+		m.outputManager.InvalidateFilterCache()
 		return m, nil
 
 	case "p", "5":
 		m.filterCategories["progress"] = !m.filterCategories["progress"]
+		m.outputManager.InvalidateFilterCache()
 		return m, nil
 
 	case "a":
@@ -1090,12 +1095,14 @@ func (m Model) handleFilterInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		for k := range m.filterCategories {
 			m.filterCategories[k] = !allEnabled
 		}
+		m.outputManager.InvalidateFilterCache()
 		return m, nil
 
 	case "c":
 		// Clear custom filter
 		m.filterCustom = ""
 		m.filterRegex = nil
+		m.outputManager.InvalidateFilterCache()
 		return m, nil
 	}
 
@@ -1105,6 +1112,7 @@ func (m Model) handleFilterInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if len(m.filterCustom) > 0 {
 			m.filterCustom = m.filterCustom[:len(m.filterCustom)-1]
 			m.compileFilterRegex()
+			m.outputManager.InvalidateFilterCache()
 		}
 		return m, nil
 
@@ -1114,12 +1122,14 @@ func (m Model) handleFilterInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if char != "e" && char != "w" && char != "t" && char != "h" && char != "p" && char != "a" && char != "c" {
 			m.filterCustom += char
 			m.compileFilterRegex()
+			m.outputManager.InvalidateFilterCache()
 		}
 		return m, nil
 
 	case tea.KeySpace:
 		m.filterCustom += " "
 		m.compileFilterRegex()
+		m.outputManager.InvalidateFilterCache()
 		return m, nil
 	}
 


### PR DESCRIPTION
## Summary
- Add filtered output caching to the OutputManager to avoid expensive string operations on every keystroke
- Cache is invalidated only when raw output changes (`SetOutput`/`AddOutput`) or filter settings change (`InvalidateFilterCache()`)
- Use a `cacheEntry` struct to consolidate cache metadata for cleaner code organization

## Problem
Every keystroke in INPUT mode triggered `filterOutput()` which performed O(n) operations (split lines, regex match each line, join lines) on the entire output buffer. This caused noticeable typing lag, especially with large output buffers.

## Solution
Cache the filtered output per instance and only recompute when:
1. The raw output changes (tracked via `outputVersions`)
2. Filter settings change (tracked via `filterVersion`)

The cache uses double-checked locking for thread safety with minimal lock contention on cache hits.

## Test plan
- [x] All existing tests pass
- [x] New `TestGetFilteredOutputCaching` test validates caching behavior
- [x] Manual testing shows improved typing responsiveness in INPUT mode