### PR TITLE
Add release skill for cutting releases

### DIFF
--- a/.claude/skills/release-commands/.claude-plugin/plugin.json
+++ b/.claude/skills/release-commands/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "release-commands",
+  "description": "Cut releases with detailed release notes, GitHub Releases, and semantic versioning",
+  "author": {
+    "name": "Iron-Ham",
+    "email": "noreply@github.com"
+  }
+}

--- a/.claude/skills/release-commands/README.md
+++ b/.claude/skills/release-commands/README.md
@@ -1,0 +1,230 @@
+# Release Commands
+
+A comprehensive Claude Code skill for cutting releases with detailed release notes, CHANGELOG updates, git tags, and GitHub releases.
+
+## Overview
+
+This skill automates the release process, ensuring consistency and thoroughness. It follows the [Keep a Changelog](https://keepachangelog.com/) format and [Semantic Versioning](https://semver.org/) conventions.
+
+## Commands
+
+### `/release [major|minor|patch|vX.Y.Z]`
+
+The main release command. Cuts a complete release including:
+
+1. **Pre-flight validation** - Checks branch, working directory, remote sync, and gh auth
+2. **Version determination** - Analyzes unreleased changes and recommends semantic version
+3. **Release notes generation** - Creates compelling narrative from changelog entries
+4. **CHANGELOG update** - Converts `[Unreleased]` to versioned section with date
+5. **Git commit** - Creates a release commit with conventional format
+6. **Git tag** - Creates annotated tag for the release
+7. **Push to remote** - Pushes commit and tag
+8. **GitHub release** - Creates a GitHub release with detailed body
+
+**Usage:**
+```bash
+# Auto-detect version based on changes
+/release
+
+# Explicit version type
+/release minor
+
+# Explicit version number
+/release v1.5.0
+```
+
+**What happens:**
+1. Claude validates you're ready to release (clean directory, on main, etc.)
+2. Analyzes your unreleased changelog entries
+3. Recommends a version number (you can override)
+4. Generates compelling release notes (shown for approval)
+5. Updates CHANGELOG.md with proper formatting
+6. Creates commit: `chore: release vX.Y.Z`
+7. Creates git tag: `vX.Y.Z`
+8. Pushes to origin and creates GitHub release
+9. Shows you the release URL
+
+### `/release-preview [major|minor|patch|vX.Y.Z]`
+
+Preview what a release would look like without making any changes. Useful for:
+- Reviewing the release before committing
+- Checking if the version recommendation makes sense
+- Previewing the GitHub release body
+- Verifying all prerequisites are met
+
+**Usage:**
+```bash
+/release-preview
+/release-preview minor
+```
+
+**Output includes:**
+- Release readiness status (branch, working directory, remote sync)
+- Categorized summary of unreleased changes
+- Recommended version number with reasoning
+- Full release notes preview
+- Exact CHANGELOG.md edits that would be made
+- Summary of all actions that would be performed
+
+### `/release-notes [version] [--format FORMAT]`
+
+Generate release notes from CHANGELOG.md without making any changes. Useful for:
+- Drafting release announcements
+- Creating posts for Slack, Discord, Twitter, or email
+- Reviewing changelog content before release
+- Generating notes for an existing release retroactively
+
+**Arguments:**
+- `version` - Optional. Generate notes for a specific version (e.g., `v0.13.0`). Defaults to Unreleased.
+- `--format` - Output format: `markdown` (default), `slack`, `discord`, `twitter`, or `email`
+
+**Usage:**
+```bash
+# Generate notes for unreleased changes
+/release-notes
+
+# Generate notes for a specific version
+/release-notes v0.13.0
+
+# Generate Slack-formatted announcement
+/release-notes --format slack
+
+# Generate Twitter thread
+/release-notes --format twitter
+```
+
+### `/release-notes-from-git`
+
+Generate release notes by analyzing git history and pull requests. Useful when:
+- CHANGELOG.md has missing entries
+- Cross-referencing changelog with commits
+- Identifying contributors
+- Auditing changelog completeness
+
+**Usage:**
+```bash
+/release-notes-from-git
+```
+
+**Output includes:**
+- Categorized changes from conventional commits
+- PR information and authors
+- Contributors list
+- Commits missing from changelog
+- Orphaned changelog entries without commits
+
+## CHANGELOG Format
+
+This skill expects and generates changelogs following Keep a Changelog format:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- **Feature Name** - Description of the feature
+
+### Changed
+- **Component** - Description of change
+
+### Removed
+- **Deprecated Feature** - Why it was removed
+
+### Fixed
+- **Bug Area** - Description of fix
+
+## [0.13.0] - 2026-01-29
+
+This release introduces major features X and Y.
+
+### Added
+- **Feature X** - Description
+
+[0.13.0]: https://github.com/owner/repo/releases/tag/v0.13.0
+```
+
+## Semantic Versioning
+
+| Change Type | Version Bump |
+|------------|--------------|
+| Breaking changes (Removed/Changed) | MAJOR |
+| New features, deprecations | MINOR |
+| Bug fixes, performance, security | PATCH |
+
+## GitHub Release Body
+
+The generated GitHub release includes:
+
+1. **Opening paragraph** - Release theme and value to users
+2. **Highlights** - Top 2-3 most impactful changes with context
+3. **What's New** - New features list
+4. **Improvements** - Changes and enhancements
+5. **Bug Fixes** - Issues resolved
+6. **Breaking Changes** - Migration steps if applicable
+
+Example:
+```markdown
+This release introduces Adversarial Review Mode and Color Themes,
+significantly enhancing workflow quality and user experience.
+
+## Highlights
+
+### Adversarial Review Mode
+Each implementer is now paired with a critical reviewer, ensuring
+higher quality outputs through structured feedback loops.
+- Enable with `--adversarial` flag
+- Automatic retry on rejection
+
+### Color Themes
+14 built-in themes plus custom theme support for personalizing
+your terminal experience.
+
+## What's New
+- Adversarial Review Mode for Tripleshot
+- Color Themes with 14 built-in options
+- Custom Theme Support
+
+## Bug Fixes
+- Fixed session attachment output capture
+- Fixed input mode editor interaction
+
+---
+Full Changelog: https://github.com/owner/repo/blob/main/CHANGELOG.md
+```
+
+## Requirements
+
+- **Git** - For commits and tags
+- **GitHub CLI** - `brew install gh` then `gh auth login`
+
+## Best Practices
+
+**Before releasing:**
+- Document all changes in `[Unreleased]`
+- Run tests and ensure CI passes
+- Use `/release-preview` to verify the release
+- Use `/release-notes-from-git` to catch missing entries
+
+**During release:**
+- Review the recommended version number
+- Approve the release summary and CHANGELOG diff
+- Review the GitHub release body
+
+**After releasing:**
+- Verify the GitHub release page
+- Announce via `/release-notes --format slack`
+
+## Troubleshooting
+
+| Error | Solution |
+|-------|----------|
+| No unreleased changes found | Add entries to `[Unreleased]` section |
+| gh: command not found | `brew install gh` |
+| gh: not authenticated | `gh auth login` |
+| Working directory is dirty | Commit or stash changes first |
+| Branch protection | Create a PR instead of direct push |
+| Not on main branch | `git checkout main` or confirm current branch |
+| Push rejected | `git pull --rebase origin main` |

--- a/.claude/skills/release-commands/commands/release-notes-from-git.md
+++ b/.claude/skills/release-commands/commands/release-notes-from-git.md
@@ -1,0 +1,149 @@
+---
+description: "Generate release notes from git history and pull requests"
+allowed-tools: Read, Bash(git log:*), Bash(git describe:*), Bash(gh pr:*), Bash(gh api:*)
+---
+
+# Generate Release Notes from Git History
+
+Generate release notes by analyzing git history and pull requests. This is useful when:
+- The CHANGELOG.md is missing entries
+- You want to cross-reference changelog with actual commits
+- You need to identify contributors for acknowledgment
+- You want to verify the changelog is complete before releasing
+
+## Context
+
+- Latest git tag: !`git describe --tags --abbrev=0 2>/dev/null || echo "No tags yet"`
+- Commits since last tag: !`git log $(git describe --tags --abbrev=0 2>/dev/null)..HEAD --pretty=format:"%h %s (%an)" 2>/dev/null | head -50 || echo "No previous tags - showing recent commits" && git log --oneline -20`
+- Merged PRs info: !`gh pr list --state merged --limit 20 --json number,title,author,mergedAt --jq '.[] | "#\(.number) \(.title) (@\(.author.login))"' 2>/dev/null || echo "gh CLI not available or not authenticated"`
+
+## Your Task
+
+Generate comprehensive release notes by analyzing git history and pull requests. This complements the changelog-based `/release-notes` command by working directly from source control.
+
+### Analysis Steps
+
+1. **Gather commit history** since the last tag
+2. **Categorize commits** by conventional commit type (feat, fix, docs, refactor, etc.)
+3. **Fetch PR information** for commits that reference PRs
+4. **Identify contributors** from commit authors and PR authors
+5. **Cross-reference with CHANGELOG.md** to find any gaps
+
+### Output Format
+
+Present the generated release notes:
+
+```
+═══════════════════════════════════════════════════════════════════
+                    GENERATED RELEASE NOTES
+                    (from git history)
+═══════════════════════════════════════════════════════════════════
+
+Based on X commits since vY.Z.A
+
+### Features (feat:)
+- Description from commit/PR (#123) - @author
+
+### Bug Fixes (fix:)
+- Description from commit/PR (#124) - @author
+
+### Documentation (docs:)
+- Description from commit
+
+### Refactoring (refactor:)
+- Description from commit
+
+### Other Changes
+- Commits that don't follow conventional commits
+
+### Contributors
+Thanks to the following contributors:
+- @username1
+- @username2
+
+═══════════════════════════════════════════════════════════════════
+```
+
+### Categorization Rules
+
+Map conventional commit prefixes to changelog categories:
+
+| Commit Prefix | Changelog Category | Include? |
+|---------------|-------------------|----------|
+| `feat:` | Added | Yes |
+| `fix:` | Fixed | Yes |
+| `docs:` | Changed (Documentation) | Yes |
+| `refactor:` | Changed | Yes |
+| `perf:` | Performance | Yes |
+| `test:` | Changed (Testing) | Optional |
+| `chore:` | Changed | Depends on impact |
+| `ci:` | (skip) | Usually no |
+| `style:` | (skip) | Usually no |
+
+### Quality Checks
+
+After generating notes, identify potential issues:
+
+```
+═══════════════════════════════════════════════════════════════════
+                    QUALITY CHECKS
+═══════════════════════════════════════════════════════════════════
+
+⚠ Commits without conventional commit format:
+  - abc1234 "Update readme"
+  - def5678 "Fix thing"
+
+⚠ PRs merged without changelog entries:
+  - #142 "Add new feature" (@contributor)
+
+⚠ Breaking changes detected (look for ! or BREAKING CHANGE):
+  - feat!: Remove deprecated API endpoint
+
+✓ Large changes that may warrant detailed notes:
+  - #145 "Refactor authentication system" (12 files changed)
+
+═══════════════════════════════════════════════════════════════════
+```
+
+### Comparison with CHANGELOG
+
+If CHANGELOG.md exists, compare and report discrepancies:
+
+```
+═══════════════════════════════════════════════════════════════════
+                    CHANGELOG COMPARISON
+═══════════════════════════════════════════════════════════════════
+
+Commits WITHOUT corresponding changelog entry:
+  ✗ abc1234 feat: add user preferences (#142)
+  ✗ def5678 fix: memory leak in cache handler
+
+Changelog entries WITHOUT corresponding commit:
+  ? "Added dark mode support" - no matching commit found
+
+Entries that match:
+  ✓ feat: adversarial review mode (#140) → "Adversarial Review Mode"
+  ✓ fix: stale status detection (#141) → "False Positive Stale Detection"
+
+Summary: 2 missing from changelog, 1 orphaned entry, 5 matched
+
+═══════════════════════════════════════════════════════════════════
+```
+
+### When to Use This vs /release-notes
+
+| Use Case | Command |
+|----------|---------|
+| Generate notes from well-maintained CHANGELOG | `/release-notes` |
+| Audit changelog completeness | `/release-notes-from-git` |
+| CHANGELOG is incomplete or missing | `/release-notes-from-git` |
+| Need contributor acknowledgments | `/release-notes-from-git` |
+| Want PR links and numbers | `/release-notes-from-git` |
+| Need specific output format (Slack, Discord) | `/release-notes` |
+
+## Key Points
+
+- **Read-only** - No changes are made to any files
+- **Works best with conventional commits** - Uses commit prefixes for categorization
+- **Requires gh CLI** - PR information needs `gh` to be authenticated
+- **Use before releasing** - Catches missing changelog entries

--- a/.claude/skills/release-commands/commands/release-notes.md
+++ b/.claude/skills/release-commands/commands/release-notes.md
@@ -1,0 +1,293 @@
+---
+description: "Generate release notes from CHANGELOG.md without cutting a release"
+argument-hint: "[version] [--format markdown|slack|discord|twitter]"
+allowed-tools: Bash(git tag:*), Bash(git log:*), Bash(date:*), Bash(gh repo view:*), Read
+---
+
+# Generate Release Notes
+
+Generate polished release notes from the CHANGELOG.md without making any changes. Useful for:
+- Drafting release announcements before cutting a release
+- Creating posts for Slack, Discord, Twitter, or other platforms
+- Reviewing changelog content quality before release
+- Generating notes for an existing release retroactively
+
+## Context
+
+- Repository: !`gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || git remote get-url origin 2>/dev/null | sed 's/.*github.com[:/]\([^/]*\/[^.]*\).*/\1/'`
+- Latest tags: !`git tag --sort=-v:refname | head -3`
+
+## Arguments
+
+The user may provide: "$ARGUMENTS"
+
+**Version (optional):**
+- `vX.Y.Z` or `X.Y.Z` - Generate notes for a specific released version
+- `unreleased` or empty - Generate notes for the Unreleased section (default)
+
+**Format (optional):**
+- `--format markdown` - Full GitHub/documentation format (default)
+- `--format slack` - Slack-optimized announcement
+- `--format discord` - Discord-optimized announcement
+- `--format twitter` - Twitter/X thread format (280 char limit per tweet)
+- `--format email` - Email announcement format
+
+## Workflow
+
+### Step 1: Identify Target Content
+
+Read CHANGELOG.md and locate the section to generate notes for:
+
+**If no version specified or `unreleased`:**
+- Use the `## [Unreleased]` section
+- Warn if empty
+
+**If version specified:**
+- Find the `## [X.Y.Z]` section
+- Error if version not found
+
+Report which section you're using:
+```
+Generating release notes for: [Unreleased]
+```
+or
+```
+Generating release notes for: v0.13.0 (released 2026-01-29)
+```
+
+### Step 2: Extract and Analyze Changes
+
+Parse the changelog section into categories and identify highlights:
+
+**Categories:** Added, Changed, Deprecated, Removed, Fixed, Security, Performance
+
+**Identify highlights** - Pick 2-3 most significant items (priority: Security > Features > Breaking changes > Bug fixes)
+
+Report the analysis:
+```
+Changes Summary:
+├─ Security: 0
+├─ Added: 3 entries (highlights: Color Themes, Adversarial Mode)
+├─ Changed: 2 entries
+├─ Fixed: 4 entries (highlight: Stale status fix)
+└─ Total: 9 entries
+```
+
+### Step 3: Generate Release Notes
+
+Based on the format argument (default: markdown), generate appropriate release notes.
+
+---
+
+#### Format: Markdown (default)
+
+Full-featured release notes for GitHub Releases or documentation.
+
+```markdown
+# [Compelling Title Summarizing Release]
+
+[Opening paragraph: 1-2 sentences describing the release theme and primary value]
+
+## Highlights
+
+### [Most Significant Feature]
+[2-3 sentences explaining what it does and why users should care]
+- Key capability 1
+- Key capability 2
+
+### [Second Significant Item]
+[Similar structure]
+
+## What's New
+- **Feature Name** - Brief description of the new capability
+- **Another Feature** - Brief description
+
+## Improvements
+- **Changed Item** - What changed and why
+
+## Bug Fixes
+- **Issue Fixed** - What was broken and how it's now resolved
+- **Another Fix** - Description
+
+## Breaking Changes
+<!-- Only if applicable -->
+⚠️ **Breaking**: [What changed]
+- Migration: [How to update]
+
+---
+📋 Full changelog: [CHANGELOG.md](link)
+📦 Release: [vX.Y.Z](link)
+```
+
+---
+
+#### Format: Slack
+
+Optimized for Slack announcements. Uses Slack markdown (mrkdwn).
+
+```
+:rocket: *[Project Name] vX.Y.Z Released!*
+
+[One compelling sentence about the release]
+
+*Highlights:*
+• *[Feature 1]* - Brief description
+• *[Feature 2]* - Brief description
+• *[Key Fix]* - What was fixed
+
+*Other changes:*
+• [Minor item 1]
+• [Minor item 2]
+
+:link: <https://github.com/owner/repo/releases/tag/vX.Y.Z|View Release Notes>
+:book: <https://github.com/owner/repo/blob/main/CHANGELOG.md|Full Changelog>
+```
+
+---
+
+#### Format: Discord
+
+Optimized for Discord announcements. Uses Discord markdown.
+
+```
+## :rocket: [Project Name] vX.Y.Z Released!
+
+[One compelling sentence about what's new]
+
+### Highlights
+- **[Feature 1]** - Brief description
+- **[Feature 2]** - Brief description
+- **[Key Fix]** - What was fixed
+
+### Other Changes
+- [Minor item 1]
+- [Minor item 2]
+
+:link: **Release:** <https://github.com/owner/repo/releases/tag/vX.Y.Z>
+```
+
+---
+
+#### Format: Twitter
+
+Thread format optimized for Twitter/X (280 char limit per tweet).
+
+```
+🧵 Thread: [Project] vX.Y.Z Release
+
+1/N
+🚀 [Project] vX.Y.Z is out!
+
+[Compelling one-liner about the release]
+
+Here's what's new: 👇
+
+2/N
+✨ [Feature 1]
+
+[2 sentences max describing the feature and its benefit]
+
+3/N
+✨ [Feature 2]
+
+[2 sentences max]
+
+4/N
+🐛 Bug Fixes:
+• [Fix 1]
+• [Fix 2]
+• [Fix 3]
+
+5/N
+📦 Get it now:
+github.com/owner/repo/releases/tag/vX.Y.Z
+
+Full changelog in thread or link in bio.
+
+#opensource #[relevant hashtag]
+```
+
+**Important for Twitter:**
+- Each tweet must be ≤280 characters
+- Number tweets as 1/N, 2/N, etc.
+- Use emoji for visual appeal
+- End with relevant hashtags
+
+---
+
+#### Format: Email
+
+Formatted for email newsletters or announcements.
+
+```
+Subject: [Project Name] vX.Y.Z Released - [Key Feature Highlight]
+
+Hi [community/team],
+
+We're excited to announce the release of [Project Name] vX.Y.Z!
+
+WHAT'S NEW
+==========
+
+[Feature 1]
+[2-3 sentences explaining the feature and its benefits]
+
+[Feature 2]
+[2-3 sentences]
+
+BUG FIXES
+=========
+• [Fix 1 description]
+• [Fix 2 description]
+
+BREAKING CHANGES
+================
+[Only if applicable]
+• [What changed and how to migrate]
+
+GET THE UPDATE
+==============
+Release: https://github.com/owner/repo/releases/tag/vX.Y.Z
+Changelog: https://github.com/owner/repo/blob/main/CHANGELOG.md
+
+Thanks for using [Project Name]!
+
+The [Project/Team] Team
+```
+
+---
+
+### Step 4: Output
+
+Present the generated notes in a clearly marked code block:
+
+```
+╔════════════════════════════════════════════════════════════════════╗
+║                    GENERATED RELEASE NOTES                         ║
+║                    Format: [selected format]                       ║
+╚════════════════════════════════════════════════════════════════════╝
+
+[Generated notes in code block for easy copying]
+```
+
+**If generating for Unreleased section:**
+```
+NOTE: These notes are for unreleased changes.
+When ready to release, run: /release [version-type]
+```
+
+**If generating for a past release:**
+```
+NOTE: These notes were generated for an already-released version.
+The GitHub Release may already have notes that differ from these.
+```
+
+## Writing Guidelines
+
+- **Lead with value** - What does this release give users?
+- **Be specific** - "Fixed memory leak in cache handler" not "Fixed bug"
+- **Group related changes** - Summarize multiple small fixes together
+- **Highlight breaking changes** - Make them impossible to miss
+- **Use active voice** - "Added support for..." not "Support has been added..."
+- **Match the platform** - Slack uses mrkdwn, Discord uses different markdown
+- **Respect character limits** - Twitter tweets must be ≤280 chars

--- a/.claude/skills/release-commands/commands/release-preview.md
+++ b/.claude/skills/release-commands/commands/release-preview.md
@@ -1,0 +1,268 @@
+---
+description: "Preview a release without making changes (dry-run)"
+argument-hint: "[major|minor|patch|vX.Y.Z]"
+allowed-tools: Bash(git tag:*), Bash(git log:*), Bash(git status:*), Bash(git branch:*), Bash(git rev-parse:*), Bash(gh release view:*), Bash(gh auth status:*), Bash(date:*), Read
+---
+
+# Preview a Release (Dry Run)
+
+Preview what a release would look like without making any changes. This is a read-only operation useful for:
+- Verifying the changelog is complete before cutting a release
+- Reviewing the generated release notes
+- Confirming the version number is correct
+- Checking that all prerequisites are met
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Latest tags: !`git tag --sort=-v:refname | head -5`
+- Git status: !`git status --short`
+
+## Arguments
+
+The user may provide: "$ARGUMENTS"
+
+Valid arguments:
+- `major` - Preview major version bump (X.0.0)
+- `minor` - Preview minor version bump (x.Y.0)
+- `patch` - Preview patch version bump (x.y.Z)
+- Explicit version like `v1.2.3` or `1.2.3`
+- Empty/none - Auto-detect from CHANGELOG.md content
+
+## Preview Workflow
+
+### Step 1: Check Release Readiness
+
+Evaluate current state and report status:
+
+**Branch Status:**
+- Current branch name
+- Is it `main`? (yellow warning if not)
+
+**Working Directory:**
+- Clean or dirty?
+- If dirty, list affected files
+
+**Remote Sync:**
+- Is local up-to-date with `origin/main`?
+- How many commits ahead/behind?
+
+**GitHub CLI:**
+- Is `gh` authenticated?
+
+Report in a clear status block:
+```
+╔════════════════════════════════════════════════════════════════════╗
+║                     RELEASE READINESS CHECK                        ║
+╚════════════════════════════════════════════════════════════════════╝
+
+Branch:            main                     ✓ Ready
+Working Directory: clean                    ✓ Ready
+Remote Sync:       up-to-date               ✓ Ready
+GitHub CLI:        authenticated            ✓ Ready
+
+Overall Status: READY TO RELEASE
+```
+
+Or with issues:
+```
+Branch:            feature/fix-bug          ⚠ Warning (not main)
+Working Directory: 2 uncommitted files      ✗ Blocking
+```
+
+### Step 2: Analyze Unreleased Changes
+
+Read CHANGELOG.md and extract the `## [Unreleased]` section.
+
+**Count and categorize changes:**
+
+```
+╔════════════════════════════════════════════════════════════════════╗
+║                    UNRELEASED CHANGES SUMMARY                      ║
+╚════════════════════════════════════════════════════════════════════╝
+
+│ Category      │ Count │ Entries                                    │
+├───────────────┼───────┼────────────────────────────────────────────┤
+│ Added         │   3   │ • Color Themes                             │
+│               │       │ • Adversarial Review Mode                  │
+│               │       │ • Background Cleanup Jobs                  │
+├───────────────┼───────┼────────────────────────────────────────────┤
+│ Changed       │   1   │ • Instance Manager Callbacks               │
+├───────────────┼───────┼────────────────────────────────────────────┤
+│ Fixed         │   4   │ • Stale RUNNING status                     │
+│               │       │ • Input mode exit on plan open             │
+│               │       │ • Theme persistence                        │
+│               │       │ • Adversarial sub-group ID                 │
+├───────────────┼───────┼────────────────────────────────────────────┤
+│ Removed       │   0   │                                            │
+├───────────────┼───────┼────────────────────────────────────────────┤
+│ Security      │   0   │                                            │
+├───────────────┼───────┼────────────────────────────────────────────┤
+│ Performance   │   0   │                                            │
+└───────────────┴───────┴────────────────────────────────────────────┘
+
+Total: 8 entries ready to release
+```
+
+If the Unreleased section is empty:
+```
+⚠ UNRELEASED SECTION IS EMPTY
+
+No changes to release. Add entries to the [Unreleased] section before
+cutting a release.
+
+Preview cannot continue.
+```
+
+### Step 3: Determine Version Number
+
+Based on changes (or user argument), calculate the next version:
+
+```
+╔════════════════════════════════════════════════════════════════════╗
+║                      VERSION DETERMINATION                         ║
+╚════════════════════════════════════════════════════════════════════╝
+
+Current Version:  v0.13.0 (released 2026-01-29)
+Last 3 Releases:
+  • v0.13.0 - 2026-01-29 (7 days ago)
+  • v0.12.7 - 2026-01-23 (13 days ago)
+  • v0.12.6 - 2026-01-22 (14 days ago)
+
+Change Analysis:
+  └─ Added section contains 3 new features
+  └─ No breaking changes detected in Changed/Removed
+
+Recommendation: MINOR bump (new features, backwards compatible)
+
+  ╭─────────────────────────────────────╮
+  │  Next Version:  v0.14.0            │
+  ╰─────────────────────────────────────╯
+```
+
+### Step 4: Generate Release Notes Preview
+
+Create the full release notes exactly as they would appear:
+
+```
+╔════════════════════════════════════════════════════════════════════╗
+║                     RELEASE NOTES PREVIEW                          ║
+╚════════════════════════════════════════════════════════════════════╝
+
+Title: "Color Themes and Adversarial Review Mode"
+
+────────────────────────────────────────────────────────────────────
+
+This release introduces user-selectable color themes and an adversarial
+review mode for tripleshot that pairs each implementer with a critical
+reviewer.
+
+## Highlights
+
+### Color Themes
+Choose from 14 carefully designed color themes to personalize your
+terminal experience. Themes include Monokai, Dracula, Nord, and more.
+- Configure via `tui.theme` in config or select interactively
+- Create custom themes in `~/.config/claudio/themes/`
+- Theme changes apply immediately with live preview
+
+### Adversarial Review Mode
+Each tripleshot implementer is now paired with a reviewer who must
+approve the work (score >= 8/10) before it's considered complete.
+- Enable with `--adversarial` flag or `tripleshot.adversarial` config
+- Automatic retry on reviewer rejection
+- Clear stuck detection and recovery
+
+## Other Improvements
+- Background cleanup jobs run async for better performance
+- Enhanced sidebar status with elapsed time, cost, and file counts
+
+## Bug Fixes
+- Fixed stale RUNNING status after tmux server death
+- Fixed input mode not exiting when plan editor opens
+- Fixed theme persistence across restarts
+
+────────────────────────────────────────────────────────────────────
+```
+
+### Step 5: Show CHANGELOG.md Changes
+
+Display the exact edits that would be made:
+
+```
+╔════════════════════════════════════════════════════════════════════╗
+║                    CHANGELOG.MD CHANGES PREVIEW                    ║
+╚════════════════════════════════════════════════════════════════════╝
+
+The following changes would be made to CHANGELOG.md:
+
+1. REPLACE: "## [Unreleased]"
+   WITH:    "## [0.14.0] - 2026-01-30"
+
+2. INSERT after header (line ~7):
+   ────────────────────────────────────────────────────────
+   ## [Unreleased]
+
+   ────────────────────────────────────────────────────────
+
+3. APPEND to version links at EOF:
+   ────────────────────────────────────────────────────────
+   [0.14.0]: https://github.com/Iron-Ham/claudio/releases/tag/v0.14.0
+   ────────────────────────────────────────────────────────
+```
+
+### Step 6: Summary
+
+Provide the final preview summary:
+
+```
+╔════════════════════════════════════════════════════════════════════╗
+║                     RELEASE PREVIEW SUMMARY                        ║
+╠════════════════════════════════════════════════════════════════════╣
+║                                                                    ║
+║  Version:      v0.14.0                                             ║
+║  Title:        "Color Themes and Adversarial Review Mode"          ║
+║  Date:         2026-01-30                                          ║
+║  Changes:      3 Added, 1 Changed, 4 Fixed                         ║
+║                                                                    ║
+╠════════════════════════════════════════════════════════════════════╣
+║                                                                    ║
+║  Actions that would be performed:                                  ║
+║                                                                    ║
+║    1. ✎ Edit CHANGELOG.md                                          ║
+║       • Change [Unreleased] to [0.14.0] - 2026-01-30              ║
+║       • Add new empty [Unreleased] section                        ║
+║       • Add version link at end of file                           ║
+║                                                                    ║
+║    2. ⊕ Create commit                                              ║
+║       • Message: "chore: release v0.14.0"                         ║
+║                                                                    ║
+║    3. ⊗ Create git tag                                             ║
+║       • Tag: v0.14.0 (annotated)                                  ║
+║                                                                    ║
+║    4. ↑ Push to origin                                             ║
+║       • Push commit to main                                       ║
+║       • Push tag v0.14.0                                          ║
+║                                                                    ║
+║    5. ◉ Create GitHub Release                                      ║
+║       • Title: "Color Themes and Adversarial Review Mode"         ║
+║       • Body: [release notes shown above]                         ║
+║                                                                    ║
+╠════════════════════════════════════════════════════════════════════╣
+║                                                                    ║
+║  To proceed with the actual release, run:                          ║
+║                                                                    ║
+║      /release minor                                                ║
+║                                                                    ║
+║  Or to specify version explicitly:                                 ║
+║                                                                    ║
+║      /release v0.14.0                                              ║
+║                                                                    ║
+╚════════════════════════════════════════════════════════════════════╝
+```
+
+## Key Points
+
+- **Read-only** - This command makes no changes
+- **Use before /release** - Verify everything looks correct first
+- **Review blocking issues** - Resolve any items before releasing

--- a/.claude/skills/release-commands/commands/release.md
+++ b/.claude/skills/release-commands/commands/release.md
@@ -1,0 +1,281 @@
+---
+description: "Cut a new release with changelog updates and GitHub Release"
+argument-hint: "[major|minor|patch|vX.Y.Z]"
+allowed-tools: Bash(git tag:*), Bash(git log:*), Bash(git diff:*), Bash(git status:*), Bash(git branch:*), Bash(git push:*), Bash(git add:*), Bash(git commit:*), Bash(gh release create:*), Bash(gh release view:*), Bash(gh auth status:*), Bash(date:*), Bash(head:*), Bash(tail:*), Read, Edit
+---
+
+# Cut a Release
+
+You are a release manager responsible for cutting new versions of this project. Your job is to create professional, well-documented releases with semantic versioning, meaningful GitHub Release notes, and proper changelog updates.
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Latest tags: !`git tag --sort=-v:refname | head -5`
+- Git status: !`git status --short`
+- Remote tracking: !`git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || echo "No upstream configured"`
+
+## Arguments
+
+The user may provide: "$ARGUMENTS"
+
+Valid arguments:
+- `major` - Bump major version (X.0.0) for breaking changes
+- `minor` - Bump minor version (x.Y.0) for new features (backwards compatible)
+- `patch` - Bump patch version (x.y.Z) for bug fixes only
+- Explicit version like `v1.2.3` or `1.2.3`
+- Empty/none - You will analyze CHANGELOG.md to auto-detect the appropriate version bump
+
+## Release Workflow
+
+Execute each step in order. Report progress clearly at each step.
+
+### Step 1: Pre-Flight Validation
+
+Check that we're ready to release. **All checks must pass before proceeding.**
+
+1. **Branch check**: Must be on `main` branch
+   - If not on main, ask user to confirm before proceeding
+
+2. **Clean working directory**: No uncommitted changes
+   - If dirty, list the files and ask user to commit/stash first
+
+3. **Remote sync**: Local main should be up-to-date with remote
+   - Run `git fetch origin main` then compare `git rev-parse HEAD` with `git rev-parse origin/main`
+   - If behind, warn user and suggest `git pull --rebase`
+
+4. **GitHub CLI**: Verify `gh` is authenticated
+   - Run `gh auth status` to verify
+
+5. **Unreleased content**: Read CHANGELOG.md and verify `## [Unreleased]` has actual content
+   - If empty, abort: "No changes to release. Add entries to the [Unreleased] section first."
+
+Report validation status:
+```
+[Pre-Flight Check]
+✓ Branch: main
+✓ Working directory: clean
+✓ Remote sync: up-to-date (or X commits ahead)
+✓ GitHub CLI: authenticated as <username>
+✓ Unreleased section: 5 entries found
+```
+
+### Step 2: Analyze Changelog & Determine Version
+
+Read CHANGELOG.md completely and extract the `## [Unreleased]` section content.
+
+**Parse and categorize changes:**
+- Count entries in each category (Added, Changed, Deprecated, Removed, Fixed, Security, Performance)
+- Identify the most significant changes for the release highlights
+
+**Find current version:**
+- Parse existing version headers to find the highest semantic version
+- Validate it matches the latest git tag
+
+**Determine next version:**
+
+If user provided explicit version/type, use that.
+
+Otherwise, apply semantic versioning rules:
+| Changelog Category | Version Bump | Reasoning |
+|-------------------|--------------|-----------|
+| `### Removed` with breaking changes | **major** | Breaking change - removed functionality |
+| `### Changed` with API breaking changes | **major** | Breaking change - behavior modification |
+| `### Added` with any entries | **minor** | New functionality, backwards compatible |
+| `### Security` only | **patch** | Security fix, no new features |
+| `### Fixed` only | **patch** | Bug fixes only |
+| `### Performance` only | **patch** | Internal improvements |
+| `### Deprecated` only | **minor** | Deprecation signals future breaking change |
+
+Report your analysis:
+```
+[Version Analysis]
+Current version: v0.13.0
+Changes detected:
+  ├─ Added: 3 entries
+  ├─ Changed: 1 entry
+  ├─ Fixed: 4 entries
+  └─ Total: 8 entries
+
+Recommended bump: minor (Added section has new features)
+Next version: v0.14.0
+```
+
+### Step 3: Generate Release Notes
+
+Create compelling, human-readable release notes from the changelog entries. This is NOT a copy-paste of the changelog—it's a **narrative transformation**.
+
+**Release Title Guidelines:**
+| Release Type | Title Style | Examples |
+|--------------|-------------|----------|
+| Major | Focus on breaking changes or new capabilities | "v2.0: New Plugin Architecture" |
+| Minor | Highlight key new features | "Enhanced Sidebar with Status Metrics" |
+| Patch | Summarize fixes briefly | "Critical tmux stability fixes" |
+
+**Release Body Structure:**
+
+```markdown
+[1-2 sentence opening paragraph describing the release theme and value to users]
+
+## Highlights
+
+### [Most Important Feature/Fix Name]
+[2-3 sentences explaining what it does, why it matters, and user benefit]
+- Key capability 1
+- Key capability 2
+
+### [Second Feature/Fix if applicable]
+[Similar structure for other major items]
+
+## Other Improvements
+- Brief list of smaller additions or changes
+- Keep these concise but meaningful
+
+## Bug Fixes
+- [Description of fix and what was broken]
+- Group related fixes when possible
+
+## Breaking Changes
+<!-- Only if applicable -->
+- What changed and migration steps required
+
+---
+Full changelog: [CHANGELOG.md](https://github.com/<owner>/<repo>/blob/main/CHANGELOG.md)
+```
+
+**Writing Guidelines:**
+- Lead with user value, not implementation details
+- Use active voice and be specific
+- Group related small items together
+- Include migration instructions for breaking changes
+
+Show the draft release notes for user approval before proceeding.
+
+### Step 4: Update CHANGELOG.md
+
+Using the Edit tool, make these precise changes to CHANGELOG.md:
+
+1. **Replace the `## [Unreleased]` header** with the new version:
+   ```markdown
+   ## [X.Y.Z] - YYYY-MM-DD
+   ```
+   Use today's date in ISO format.
+
+2. **Insert a new `## [Unreleased]` section** immediately after the file header (after the intro paragraph, before the new version header):
+   ```markdown
+   ## [Unreleased]
+
+   ```
+   Leave it empty with a single blank line.
+
+3. **Add the release comparison link** at the bottom of the file:
+   ```markdown
+   [X.Y.Z]: https://github.com/<owner>/<repo>/releases/tag/vX.Y.Z
+   ```
+   Add it after the existing version links, maintaining alphabetical/version order.
+
+**CRITICAL**: Use the Edit tool with exact string matching. Read the file first to get exact content.
+
+### Step 5: Create Release Commit
+
+Stage and commit the changelog update:
+
+```bash
+git add CHANGELOG.md
+git commit -m "chore: release vX.Y.Z"
+```
+
+The commit message follows the project's conventional commit format.
+
+### Step 6: Create Git Tag
+
+Create an annotated tag with a meaningful message:
+
+```bash
+git tag -a vX.Y.Z -m "Release vX.Y.Z
+
+[Brief 1-line summary of release highlights]"
+```
+
+The tag message should summarize the release in one line.
+
+### Step 7: Push to Remote
+
+Push the release commit and tag:
+
+```bash
+git push origin main
+git push origin vX.Y.Z
+```
+
+If push fails, diagnose the error:
+- **Permission denied**: Check repository write access
+- **Rejected (non-fast-forward)**: Remote has new commits; abort and inform user
+- **Tag already exists**: Version may have been partially released; suggest manual resolution
+
+### Step 8: Create GitHub Release
+
+Create the GitHub Release with the rich release notes:
+
+```bash
+gh release create vX.Y.Z \
+  --title "Release Title Here" \
+  --notes "$(cat <<'EOF'
+[Your rich release notes from Step 3]
+EOF
+)"
+```
+
+**Important:**
+- The `--title` should be the compelling title you crafted (NOT just "vX.Y.Z")
+- The `--notes` must be the narrative release notes, not raw changelog
+- Use HEREDOC to preserve formatting
+
+### Step 9: Verify & Report
+
+Verify the release was created successfully:
+
+```bash
+gh release view vX.Y.Z
+```
+
+Report the completion summary:
+
+```
+════════════════════════════════════════════════════════════════════
+                    RELEASE COMPLETE: vX.Y.Z
+════════════════════════════════════════════════════════════════════
+
+✓ CHANGELOG.md updated with version and date
+✓ Release commit created: <short-sha>
+✓ Git tag vX.Y.Z created and pushed
+✓ GitHub Release published
+
+Release URL: https://github.com/<owner>/<repo>/releases/tag/vX.Y.Z
+
+Summary:
+  • X new features, Y bug fixes
+  • Highlight: [Brief mention of most important change]
+
+════════════════════════════════════════════════════════════════════
+```
+
+## Error Recovery
+
+| Error | Action |
+|-------|--------|
+| Not on main branch | Ask user to confirm or switch |
+| Dirty working directory | List files; ask to commit/stash |
+| Empty Unreleased section | Abort - nothing to release |
+| Push rejected | Check for new remote commits |
+| gh CLI not authenticated | Show `gh auth login` instructions |
+| Tag already exists | Check for partial release |
+
+## Key Principles
+
+- **Changelog is canonical** - Never skip the changelog update
+- **No empty releases** - Verify Unreleased section has content first
+- **Semantic versioning** - Breaking = major, features = minor, fixes = patch
+- **Meaningful titles** - They're the first thing users see
+- **Narrative notes** - Transform changelog into readable prose, don't just copy
+- **User approval required** - Always show the draft before creating the GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Release Skill** - Added a Claude skill for cutting releases with professional release notes and GitHub Releases. The `/release` command handles the complete workflow: validating release readiness, parsing CHANGELOG.md, determining semantic version bumps, generating narrative release notes, updating the changelog, creating git tags, and publishing GitHub Releases. Includes `/release-preview` for dry-run previews, `/release-notes` for generating standalone release notes in multiple formats (markdown, Slack, Discord, Twitter, email), and `/release-notes-from-git` for auditing changelog completeness against git history.
+
 - **Enhanced Keyboard Navigation** - Added support for macOS-style keyboard shortcuts in input mode and the task prompt writer. Input mode now properly forwards `Opt+Left/Right` (word navigation) and `Opt+Backspace` (word deletion) to Claude instances. The task prompt writer now supports both the `msg.Alt` flag and string-based key reporting for `Opt+Arrow/Backspace`, as well as `Cmd+Left/Right/Backspace` (line navigation and delete-to-line-start) for terminals that forward these keys.
 
 ### Changed


### PR DESCRIPTION
## Summary

- Adds a Claude skill for managing releases with four commands:
  - `/release` - Full release workflow including validation, version determination, changelog update, git tag, push, and GitHub Release creation
  - `/release-preview` - Dry-run preview showing exactly what would happen without making changes
  - `/release-notes` - Generate release notes in multiple formats (markdown, slack, discord, twitter, email)
  - `/release-notes-from-git` - Audit changelog completeness against git history and identify missing entries

## Features

- **Pre-flight validation** - Checks branch, working directory, remote sync, and gh authentication before proceeding
- **Semantic versioning** - Auto-detects version bump based on changelog categories (Added=minor, Fixed=patch, etc.)
- **Narrative release notes** - Transforms changelog entries into compelling prose, not just bullet lists
- **Multiple output formats** - Generate announcements optimized for Slack, Discord, Twitter threads, or email
- **Changelog auditing** - Cross-reference CHANGELOG.md with git history to find missing entries

## Test plan

- [ ] Run `/release-preview` to verify dry-run works correctly
- [ ] Run `/release-notes` to generate release notes in different formats
- [ ] Run `/release-notes-from-git` to audit changelog against git history
- [ ] Verify skill appears in Claude Code's skill list