### PR TITLE
Optimize INPUT mode responsiveness with cache sharing and fast paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Input Mode Typing Responsiveness** - Fixed typing lag and stuttering in INPUT mode when interacting with Claude instances. The output filtering logic now caches filtered results per instance and only recomputes when the raw output or filter settings change. Previously, every keystroke triggered expensive string operations (line splitting, regex matching, case conversion) on the entire output buffer, even when nothing had changed.
 
+- **Scroll Calculation Cache Optimization** - Fixed remaining INPUT mode lag caused by scroll calculations bypassing the filter cache. Line counting and visible line calculations now use cached filtered output instead of recomputing filtering on every 100ms tick. Previously, these operations called the filter function directly, causing redundant O(n) filtering even when output hadn't changed.
+
+- **Input/Terminal Mode Keystroke Optimization** - Further improved INPUT mode and terminal mode responsiveness by adding fast paths that skip expensive state synchronization. Keystrokes in passthrough modes now bypass the full router state sync, which previously performed multiple state updates on every keystroke. Also removed a redundant write lock acquisition in the render path.
+
 ### Fixed
 
 - **TripleShot-Adversarial Feedback Loop** - Each implementer now properly iterates with reviewer feedback instead of failing on first rejection. When a reviewer rejects an attempt, the implementer is restarted with the reviewer's feedback, issues, and required changes. This continues until the reviewer approves or max rounds are exhausted (uses `adversarial.max_iterations`, default 10, 0 = unlimited). Also fixed the TUI not polling during the adversarial review phase, which prevented reviewer completions from being detected.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1390,8 +1390,10 @@ func (m Model) renderInstance(inst *orchestrator.Instance, width int) string {
 	isRunning := mgr != nil && mgr.Running()
 
 	// Get filtered output using cache (avoids expensive recomputation on every render)
-	// Ensure filter function is set for cached filtering to work
-	m.outputManager.SetFilterFunc(m.filterOutput)
+	// Note: filterFunc is set via updateOutputScroll() on each tick, not here.
+	// Setting it here would acquire a write lock on every render/keystroke.
+	// The filter settings (filterCategories map, filterRegex pointer) are reference
+	// types, so the same filterFunc closure works across Model copies.
 	output := m.outputManager.GetFilteredOutput(inst.ID)
 
 	renderState := view.RenderState{

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1098,12 +1098,14 @@ func (m *Model) scrollOutputToTop(instanceID string) {
 // scrollOutputToBottom scrolls to the bottom and re-enables auto-scroll
 func (m *Model) scrollOutputToBottom(instanceID string) {
 	m.outputManager.SetFilterFunc(m.filterOutput)
+	_ = m.outputManager.GetFilteredOutput(instanceID) // Prime cache for scroll calculation
 	m.outputManager.ScrollToBottom(instanceID, m.getOutputMaxLines())
 }
 
 // updateOutputScroll updates scroll position based on new output (if auto-scroll is enabled)
 func (m *Model) updateOutputScroll(instanceID string) {
 	m.outputManager.SetFilterFunc(m.filterOutput)
+	_ = m.outputManager.GetFilteredOutput(instanceID) // Prime cache for scroll calculation
 	m.outputManager.UpdateScroll(instanceID, m.getOutputMaxLines())
 }
 


### PR DESCRIPTION
## Summary

- **Scroll calculation cache optimization**: Line counting and visible line calculations now use cached filtered output instead of recomputing filtering on every 100ms tick
- **Keystroke fast paths**: INPUT mode and terminal mode now skip expensive `syncRouterState()` calls when just forwarding keys to tmux
- **Removed redundant write lock**: `SetFilterFunc()` was being called on every render, acquiring a write lock unnecessarily

## Problem

After PR #606 added caching to `GetFilteredOutput()`, internal scroll-related methods (`getLineCountLocked`, `GetVisibleLines`) were still calling `filterFunc(output)` directly, bypassing the cache. This caused redundant O(n) filtering operations on every 100ms tick update.

Additionally, every keystroke in INPUT mode was triggering the full `syncRouterState()` function even though passthrough modes just forward keys to tmux.

## Solution

1. **Cache sharing**: Added `getFilteredOutputLocked()` helper that checks the cache without requiring a write lock. On cache miss, it recomputes but doesn't cache (to avoid lock upgrade). The caller primes the cache via `GetFilteredOutput()` before scroll calculations.

2. **Fast paths**: INPUT mode and terminal mode checks are now performed before `syncRouterState()`, allowing keystrokes to bypass expensive state synchronization in passthrough modes.

3. **Removed redundant lock**: Removed `SetFilterFunc()` call from `renderInstance()` since the filter function is already set via `updateOutputScroll()` on each tick.

## Test plan

- [x] Existing tests pass
- [x] New test `TestGetLineCountUsesFilterCache` verifies filter is only called when cache is invalidated
- [x] Manual testing: INPUT mode typing should feel as responsive as a fresh instance