### PR TITLE
Add blank session creation and instance renaming commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Blank Session Command** - Added `:new` (alias `:n`) command to create a blank Claude session without requiring a prompt. This starts Claude in interactive mode, allowing users to work with the assistant directly. Sessions can be optionally named (`:new my-session`) or automatically numbered ("Session 1", "Session 2", etc.). Also added `:rename <name>` command to change the display name of any instance, which is useful for both blank sessions and task-based instances.
+
 - **Release Skill** - Added a Claude skill for cutting releases with professional release notes and GitHub Releases. The `/release` command handles the complete workflow: validating release readiness, parsing CHANGELOG.md, determining semantic version bumps, generating narrative release notes, updating the changelog, creating git tags, and publishing GitHub Releases. Includes `/release-preview` for dry-run previews, `/release-notes` for generating standalone release notes in multiple formats (markdown, Slack, Discord, Twitter, email), and `/release-notes-from-git` for auditing changelog completeness against git history.
 
 - **Enhanced Keyboard Navigation** - Added support for macOS-style keyboard shortcuts in input mode and the task prompt writer. Input mode now properly forwards `Opt+Left/Right` (word navigation) and `Opt+Backspace` (word deletion) to Claude instances. The task prompt writer now supports both the `msg.Alt` flag and string-based key reporting for `Opt+Arrow/Backspace`, as well as `Cmd+Left/Right/Backspace` (line navigation and delete-to-line-start) for terminals that forward these keys.

--- a/internal/orchestrator/session_test.go
+++ b/internal/orchestrator/session_test.go
@@ -743,6 +743,12 @@ func TestInstance_EffectiveName(t *testing.T) {
 			task:        "A very long task description",
 			expected:    "X",
 		},
+		{
+			name:        "blank session with DisplayName",
+			displayName: "Session 1",
+			task:        "", // Blank session has empty task
+			expected:    "Session 1",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/tui/msg/commands.go
+++ b/internal/tui/msg/commands.go
@@ -128,6 +128,22 @@ func CompleteInstanceSetupAsync(o *orchestrator.Orchestrator, session *orchestra
 	}
 }
 
+// AddBlankInstanceStubAsync returns a command that creates a blank instance stub asynchronously.
+// Blank instances have no task/prompt - they start Claude in interactive mode.
+// The displayName is optional; if empty, a generic "Session N" name is generated.
+func AddBlankInstanceStubAsync(o *orchestrator.Orchestrator, session *orchestrator.Session, displayName string) tea.Cmd {
+	return func() tea.Msg {
+		if o == nil {
+			return BlankInstanceStubCreatedMsg{Instance: nil, Err: fmt.Errorf("orchestrator is nil")}
+		}
+		if session == nil {
+			return BlankInstanceStubCreatedMsg{Instance: nil, Err: fmt.Errorf("session is nil")}
+		}
+		inst, err := o.AddBlankInstanceStub(session, displayName)
+		return BlankInstanceStubCreatedMsg{Instance: inst, Err: err}
+	}
+}
+
 // AddTaskFromBranchAsync returns a command that adds a task from a specific base branch asynchronously.
 // The baseBranch parameter specifies which branch the new worktree should be created from.
 func AddTaskFromBranchAsync(o *orchestrator.Orchestrator, session *orchestrator.Session, task string, baseBranch string) tea.Cmd {

--- a/internal/tui/msg/types.go
+++ b/internal/tui/msg/types.go
@@ -67,6 +67,13 @@ type InstanceSetupCompleteMsg struct {
 	Err        error
 }
 
+// BlankInstanceStubCreatedMsg is sent when a blank instance stub creation completes.
+// Blank instances have no task/prompt - they start Claude in interactive mode.
+type BlankInstanceStubCreatedMsg struct {
+	Instance *orchestrator.Instance
+	Err      error
+}
+
 // DependentTaskAddedMsg is sent when async dependent task addition completes.
 type DependentTaskAddedMsg struct {
 	Instance  *orchestrator.Instance

--- a/internal/tui/panel/help.go
+++ b/internal/tui/panel/help.go
@@ -166,6 +166,8 @@ func DefaultHelpSections() []HelpSection {
 			Title: "Instance Management",
 			Items: []HelpItem{
 				{Key: ":a  :add", Description: "Create and add new instance"},
+				{Key: ":n  :new [name]", Description: "Create blank session (no prompt)"},
+				{Key: ":rename <name>", Description: "Rename the selected instance"},
 				{Key: ":chain [N]  :dep  :depends", Description: "Add dependent task (N = sidebar #, or #N)"},
 				{Key: ":D  :remove", Description: "Remove instance (keeps branch)"},
 				{Key: ":kill", Description: "Force kill and remove instance"},


### PR DESCRIPTION
## Summary

- Added `:new` (alias `:n`) command to create blank Claude sessions without requiring a prompt, allowing users to start interactive sessions directly
- Sessions can be optionally named (`:new my-session`) or automatically numbered ("Session 1", "Session 2", etc.)
- Added `:rename <name>` command to change the display name of any instance
- `ManuallyNamed` flag prevents LLM auto-rename for user-named or auto-numbered sessions

## Test plan

- [x] Build passes: `go build ./...`
- [x] All tests pass: `go test ./...`
- [x] Linting passes: `go vet ./...`
- [x] Formatting clean: `gofmt -d .`
- [x] New orchestrator tests for `AddBlankInstanceStub` and `RenameInstance`
- [x] New command tests for `:new/:n` and `:rename`
- [x] Help panel updated and tests pass
- [x] CHANGELOG entry added