### PR TITLE
Fix typing 'k' and 'j' in interactive config text fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Interactive Config Text Input** - Fixed inability to type lowercase 'k' and 'j' when editing text fields in the interactive config UI (`:config`). The vim-style navigation keys were incorrectly intercepted even when editing string values, preventing users from typing these characters. Navigation with 'k' and 'j' still works for select-type dropdowns and in normal navigation mode.
+
 - **Release Skill Changelog Link** - The `/release` skill now links to the changelog at the release tag (e.g., `blob/v0.14.0/CHANGELOG.md`) instead of `main`, ensuring stable references.
 
 ## [0.14.0] - 2026-01-30


### PR DESCRIPTION
## Summary
- Fixed inability to type lowercase 'k' and 'j' when editing text fields in the interactive config UI (`:config`)
- The vim-style navigation keys were incorrectly intercepted even when editing string/int/float values
- Navigation with 'k' and 'j' still works correctly for select-type dropdowns

## Changes
- Separated handling of arrow keys and vim keys in `handleEditingKeypress()`
- 'k'/'j' now only trigger navigation for select-type fields; for text inputs they pass through to the textinput handler
- Added two regression tests to verify both the fix and preserved behavior
- Modernized code with Go 1.22+ idioms (range over int, min/max builtins, slices.Contains)

## Test plan
- [x] `go test ./internal/tui/config/...` passes
- [x] `go vet ./...` clean
- [x] `gofmt -d .` clean
- [ ] Manual test: run `claudio start`, then `:config`, navigate to a string field (e.g., Branch Prefix), press Enter, and verify typing 'k' and 'j' adds those characters to the input
- [ ] Manual test: verify 'k' and 'j' still navigate up/down in select dropdowns (e.g., Color Theme)