### PR TITLE
Fix duplicate Previous Rounds entries in adversarial mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Release Skill Changelog Link** - The `/release` skill now links to the changelog at the release tag (e.g., `blob/v0.14.0/CHANGELOG.md`) instead of `main`, ensuring stable references.
 
+- **Duplicate Previous Rounds in Adversarial Mode** - Fixed a bug where "Round N" entries would appear duplicated in the "Previous Rounds" section of the sidebar. The issue occurred because both `StartImplementer` and `StartReviewer` called `getCurrentRoundGroup`, which would move previous round instances to a sub-group. On the second call, the sub-group had already been moved into "Previous Rounds" and couldn't be found as a direct child, causing a duplicate to be created. Added an idempotency guard that checks if a round was already moved before performing the operation.
+
 ## [0.14.0] - 2026-01-30
 
 ### Added

--- a/internal/orchestrator/workflows/adversarial/coordinator.go
+++ b/internal/orchestrator/workflows/adversarial/coordinator.go
@@ -345,6 +345,15 @@ func (c *Coordinator) movePreviousRoundInstancesToSubGroup(advGroup GroupInterfa
 	}
 	prevRoundHistory := session.History[prevRound-1]
 
+	// Check if this round was already moved (idempotency guard).
+	// This prevents duplicate "Round N" sub-groups when both StartImplementer
+	// and StartReviewer call getCurrentRoundGroup for the same round.
+	// SubGroupID is set at the end of this function after the move completes,
+	// making it a reliable marker that the operation already succeeded.
+	if prevRoundHistory.SubGroupID != "" {
+		return // Already moved to a sub-group
+	}
+
 	// Collect instance IDs from the previous round
 	var prevInstanceIDs []string
 	if prevRoundHistory.ImplementerID != "" {


### PR DESCRIPTION
## Summary
- Fixed a bug where "Round N" entries would appear duplicated in the "Previous Rounds" section of the sidebar in adversarial mode
- Added an idempotency guard that checks if `SubGroupID` is already set before moving previous round instances to a sub-group
- Added integration test to verify the fix works through the full `StartImplementer` -> `StartReviewer` flow

## Root Cause
Both `StartImplementer` and `StartReviewer` call `getCurrentRoundGroup` for the same round. On the second call, `GetOrCreateSubGroup` only searches direct children of the parent group, but the original "Round N" sub-group had already been moved INTO "Previous Rounds". Unable to find it, `GetOrCreateSubGroup` created a duplicate.

## Fix
Added an early-return check in `movePreviousRoundInstancesToSubGroup` that uses `SubGroupID` as an idempotency marker. Since `SubGroupID` is set at the end of the function after the move completes, it reliably indicates the operation already succeeded.

## Test plan
- [x] Unit test `TestCoordinator_MovePreviousRoundInstancesToSubGroup_IdempotencyGuard` verifies idempotency of the internal function
- [x] Integration test `TestCoordinator_StartImplementerThenReviewer_NoDuplicatePreviousRounds` exercises the full public API flow
- [x] All existing tests pass
- [x] `go vet` passes
- [x] `gofmt` passes