### PR TITLE
Add fast path for INPUT/TERMINAL mode keystrokes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Adversarial Mode Polling Optimization** - Fixed UI hitching/freezing when starting adversarial tasks in large repositories. The sentinel file polling (which checks for increment and review files every 100ms) now uses a fast-path optimization: expected file locations are cached after first discovery, and expensive full directory traversals are rate-limited to once every 5 seconds. This eliminates the overhead of `os.ReadDir()` calls on worktrees with many subdirectories.
 
+- **INPUT Mode Fast Path** - Dramatically improved typing responsiveness in INPUT mode by eliminating per-keystroke overhead. Previously, every keystroke triggered: (1) `syncRouterState()` calls with multiple setter operations, (2) `GetInstanceManager()` with mutex lock + map lookup, and (3) `Running()` check with another mutex lock. The fast path now caches the instance manager when entering INPUT mode and reuses it for all keystrokes, completely bypassing these expensive operations. This reduces per-keystroke overhead from 3+ mutex acquisitions to zero.
+
 ## [0.14.1] - 2026-01-30
 
 ### Fixed

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Iron-Ham/claudio/internal/config"
 	"github.com/Iron-Ham/claudio/internal/conflict"
+	"github.com/Iron-Ham/claudio/internal/instance"
 	"github.com/Iron-Ham/claudio/internal/logging"
 	"github.com/Iron-Ham/claudio/internal/orchestrator"
 	"github.com/Iron-Ham/claudio/internal/orchestrator/workflows/ralph"
@@ -315,7 +316,8 @@ type Model struct {
 	infoMessage    string    // Non-error status message
 	messageSetAt   time.Time // When the current message was set (for auto-dismiss)
 	lastMessageKey string    // Used to detect message changes (concatenation of both messages)
-	inputMode      bool      // When true, all keys are forwarded to the active instance's tmux session
+	inputMode        bool              // When true, all keys are forwarded to the active instance's tmux session
+	inputModeManager *instance.Manager // Cached manager for INPUT mode - avoids per-keystroke lookups
 
 	// Command mode state (vim-style ex commands with ':' prefix)
 	commandMode   bool   // When true, we're typing a command after ':'


### PR DESCRIPTION
## Summary

- Add fast path optimization that bypasses `syncRouterState()` for INPUT mode and TERMINAL mode keystrokes
- Move INPUT/TERMINAL mode checks to the top of `handleKeypress()` before expensive state synchronization
- Significantly improves typing responsiveness when interacting with Claude instances via tmux

## Background

PR #609 attempted to improve input responsiveness but the optimization was incomplete - `syncRouterState()` was still called for every keystroke. This PR fixes that by checking for passthrough modes first, routing directly to key handling without the overhead of:
- Multiple setter calls on inputRouter
- Pointer dereferences through ultraPlan.Coordinator.Session()
- GroupDecision state checks
- Various boolean flag synchronizations

## Test plan

- [x] Added `TestHandleKeypress_FastPath_InputMode` - verifies INPUT mode bypasses syncRouterState
- [x] Added `TestHandleKeypress_FastPath_TerminalMode` - verifies TERMINAL mode bypasses syncRouterState  
- [x] Added `TestHandleKeypress_SlowPath_NormalMode` - verifies normal mode still works correctly
- [x] All existing tests pass
- [x] Manual testing: typing in INPUT mode should feel more responsive