### PR TITLE
Comprehensive documentation refresh for v0.13.0-v0.14.0 features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Documentation Updates** - Refreshed documentation to cover v0.13.0 and v0.14.0 features: color themes, sidebar scroll navigation (J/K), macOS keyboard shortcuts, `validate` command, background cleanup options, tripleshot adversarial integration, and stuck instance recovery.
+
 ## [0.14.1] - 2026-01-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -35,12 +35,15 @@ Claudio enables parallel AI-assisted development by orchestrating multiple Claud
 - **UltraPlan Mode** - Hierarchical 4-phase planning with automatic parallel execution
 - **Multi-Pass Planning** - Three competing strategies evaluate and select the best approach
 - **TripleShot Mode** - Spawn 3 parallel attempts per task, then judge selects the best
+- **Adversarial Review** - Iterative implementation with critical reviewer feedback loops
 
 ### Workflow Automation
 - **PR Automation** - AI-generated pull requests with smart reviewer assignment
 - **Cost Tracking** - Monitor token usage and API costs with configurable limits
 - **Session Recovery** - Resume sessions after disconnection
 - **Structured Logging** - JSON logs with filtering, rotation, and export capabilities
+- **Color Themes** - 14 built-in themes plus custom theme support
+- **Plan Validation** - Validate ultraplan JSON files before execution
 
 ## Requirements
 
@@ -124,6 +127,7 @@ claudio add "Update API documentation"
 |-----|--------|
 | `Tab` / `l` / `→` | Next instance |
 | `Shift+Tab` / `h` / `←` | Previous instance |
+| `J` / `K` | Scroll sidebar without changing selection |
 | `a` | Add new instance |
 | `s` | Start selected instance |
 | `p` | Pause/resume instance |
@@ -141,10 +145,12 @@ Press `:` to enter command mode for advanced operations:
 
 | Command | Description |
 |---------|-------------|
+| `:a "task"` | Add a new instance |
 | `:plan "objective"` | Start inline plan generation |
 | `:ultraplan "objective"` | Start inline ultraplan workflow |
 | `:multiplan "objective"` | Multi-pass planning (requires experimental flag) |
-| `:tripleshot "task"` | Start tripleshot execution |
+| `:tripleshot "task"` | Start tripleshot execution (aliases: `:triple`, `:3shot`) |
+| `:adversarial-retry` | Restart stuck adversarial role |
 | `:group create [name]` | Create a new instance group |
 | `:group add <instance> <group>` | Add instance to a group |
 | `:q!` or `:quit!` | Force quit with cleanup |
@@ -248,7 +254,12 @@ completion:
 tui:
   auto_focus_on_input: true
   max_output_lines: 1000
-  sidebar_width: 30
+  sidebar_width: 36
+  theme: default  # or: monokai, dracula, nord, claude-code, etc.
+
+# Session settings
+session:
+  auto_start_on_add: true  # Auto-start instances when added via TUI
 
 # Instance settings
 instance:
@@ -281,6 +292,16 @@ resources:
 # UltraPlan settings
 ultraplan:
   max_parallel: 3
+
+# TripleShot settings
+tripleshot:
+  auto_approve: false
+  adversarial: false  # Pair each implementer with a reviewer
+
+# Adversarial review settings
+adversarial:
+  max_iterations: 10
+  min_passing_score: 8
 
 # Experimental features
 experimental:

--- a/docs/guide/adversarial.md
+++ b/docs/guide/adversarial.md
@@ -242,12 +242,23 @@ The header displays:
 └──────────────────────────────┘
 ```
 
+### Round Organization
+
+**Auto-Collapse:** Completed rounds automatically collapse into sub-groups, keeping the sidebar clean while preserving access to round history. The final approved round remains expanded.
+
+**Previous Rounds Container:** When round 2+ starts, previous rounds are condensed into a single "Previous Rounds" container group. This reduces sidebar clutter when tasks span many rounds. You'll see only two groups:
+- "Previous Rounds" (collapsed) - Contains all completed rounds
+- Current round (expanded) - Shows active implementer/reviewer
+
+You can expand "Previous Rounds" to access any historical round's details.
+
 ### Viewing History
 
 Review previous rounds to understand the evolution:
 - Each round's feedback is preserved
 - See how issues were addressed
 - Track score progression
+- Expand collapsed rounds using `gc` key
 
 ## When to Use Adversarial Mode
 
@@ -374,6 +385,29 @@ If iterations don't converge:
 - Check that required_changes are being addressed
 - Look for contradictory feedback
 - Consider breaking into smaller tasks
+
+### Stuck Instance Detection
+
+Claudio automatically detects when an adversarial instance (implementer or reviewer) completes without writing its required sentinel file. When this happens:
+
+1. The workflow transitions to a "stuck" phase
+2. The TUI sidebar shows which role (implementer/reviewer) got stuck
+3. You're notified with recovery options
+
+**Recovery:**
+
+Use the `:adversarial-retry` command in the TUI to restart the stuck role:
+
+```
+:adversarial-retry
+```
+
+This restarts the stuck implementer or reviewer with the appropriate context, allowing the workflow to continue.
+
+**Common causes:**
+- Claude finishes work but fails to write the completion file
+- Network interruptions during file write
+- Task ambiguity causing Claude to wait for clarification
 
 ## Example Workflow
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -33,10 +33,10 @@ Generate structured task plans from high-level objectives. Create execution plan
 Orchestrate complex tasks with intelligent planning. Let Claude analyze your codebase, create an execution plan, and coordinate parallel task execution automatically.
 
 ### [TripleShot Mode](tripleshot.md)
-Run three parallel implementations and let a judge select the best. Ideal for tasks with multiple valid approaches or when optimal solution is unclear. Access via `:tripleshot` command in the TUI.
+Run three parallel implementations and let a judge select the best. Ideal for tasks with multiple valid approaches or when optimal solution is unclear. Access via `:tripleshot` command in the TUI. Can be combined with adversarial review for higher quality results.
 
 ### [Adversarial Review](adversarial.md)
-Iterative implementation with critical reviewer feedback. The implementer and reviewer loop until the code meets quality thresholds.
+Iterative implementation with critical reviewer feedback. The implementer and reviewer loop until the code meets quality thresholds (score >= 8/10). Includes stuck instance detection and `:adversarial-retry` recovery command.
 
 ### [Inline Planning](inline-planning.md) (Experimental)
 Start Plan and UltraPlan workflows directly from the standard TUI. Create plans, organize tasks into visual groups, and execute them without leaving your session.

--- a/docs/guide/tripleshot.md
+++ b/docs/guide/tripleshot.md
@@ -353,6 +353,53 @@ If `tripleshot.auto_approve` is enabled in your config, the winner is applied au
 2. Create a PR from that branch
 3. Optionally incorporate suggested improvements
 
+## Configuration
+
+Configure TripleShot behavior in your config file:
+
+```yaml
+tripleshot:
+  # Automatically apply the winning solution
+  auto_approve: false
+
+  # Enable adversarial review for each implementer
+  adversarial: false
+```
+
+### Adversarial Mode Integration
+
+When `tripleshot.adversarial` is enabled, each of the three implementers is paired with a critical reviewer:
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                 TRIPLESHOT + ADVERSARIAL MODE                     │
+├──────────────────────────────────────────────────────────────────┤
+│  ┌─ Pair 1 ─────────┐  ┌─ Pair 2 ─────────┐  ┌─ Pair 3 ─────────┐ │
+│  │ Implementer 0    │  │ Implementer 1    │  │ Implementer 2    │ │
+│  │       ↓          │  │       ↓          │  │       ↓          │ │
+│  │ Reviewer 0       │  │ Reviewer 1       │  │ Reviewer 2       │ │
+│  │ (8/10 ✓)         │  │ (7/10 ✗)         │  │ (9/10 ✓)         │ │
+│  └──────────────────┘  └──────────────────┘  └──────────────────┘ │
+│                                                                   │
+│                      Only approved pairs                          │
+│                      proceed to judge                             │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+The workflow becomes:
+1. Three implementers work on the task in parallel
+2. Each implementer is paired with a reviewer
+3. The implementer and reviewer iterate until approval (score >= 8/10)
+4. Only approved implementations proceed to the judge phase
+5. The judge evaluates and selects the best approved solution
+
+This ensures higher quality implementations but requires more time and API calls.
+
+The sidebar shows clear implementer/reviewer pair status:
+- Phase indicator (Implementing, Under Review, Judging, Complete)
+- Reviewer approval status with scores
+- Count of active pairs during review phase
+
 ## See Also
 
 - [Adversarial Review](adversarial.md) - Iterative implementation with reviewer feedback

--- a/docs/guide/tui-navigation.md
+++ b/docs/guide/tui-navigation.md
@@ -36,8 +36,15 @@ Claudio's Terminal User Interface (TUI) provides a real-time dashboard for manag
 | `Shift+Tab` | Previous instance |
 | `l` or `→` | Next instance |
 | `h` or `←` | Previous instance |
-| `j` or `↓` | Scroll sidebar down (when many instances) |
-| `k` or `↑` | Scroll sidebar up |
+
+## Sidebar Navigation
+
+| Key | Action |
+|-----|--------|
+| `J` (Shift+j) | Scroll sidebar viewport down without changing selection |
+| `K` (Shift+k) | Scroll sidebar viewport up without changing selection |
+
+Use `J`/`K` to view instances that are off-screen (indicated by "▲ N more above" or "▼ N more below") without losing your current selection. This is useful when you want to see what other instances are doing without switching away from your focused instance.
 
 ## Instance Control
 
@@ -150,6 +157,15 @@ The input field supports editing:
 | `Ctrl+u` | Delete to beginning |
 | `Backspace` | Delete character |
 
+**macOS keyboard shortcuts (when terminal supports them):**
+
+| Key | Action |
+|-----|--------|
+| `Opt+←` / `Opt+→` | Move cursor by word |
+| `Opt+Backspace` | Delete word |
+| `Cmd+←` / `Cmd+→` | Move to line start/end |
+| `Cmd+Backspace` | Delete to line start |
+
 ## Command Mode
 
 Press `:` to enter command mode for advanced operations. Type a command and press `Enter` to execute.
@@ -158,10 +174,15 @@ Press `:` to enter command mode for advanced operations. Type a command and pres
 
 | Command | Description |
 |---------|-------------|
+| `:a "task"` | Add a new instance with the given task |
+| `:s` | Start the selected instance |
+| `:d` | Show diff for selected instance |
+| `:D` | Remove selected instance (with confirmation) |
 | `:plan "objective"` | Start inline plan generation |
 | `:ultraplan "objective"` | Start inline UltraPlan workflow |
 | `:multiplan "objective"` | Multi-pass planning (requires `experimental.inline_plan`) |
-| `:tripleshot "task"` | Start TripleShot execution (requires `experimental.triple_shot`) |
+| `:tripleshot "task"` | Start TripleShot execution (aliases: `:triple`, `:3shot`) |
+| `:adversarial-retry` | Restart a stuck adversarial implementer or reviewer |
 | `:group create [name]` | Create a new instance group |
 | `:group add <instance> <group>` | Add instance to a group |
 | `:group remove <instance>` | Remove instance from its group |
@@ -244,12 +265,12 @@ The sidebar uses colors to indicate state:
 When enabled, the sidebar shows:
 ```
 1. auth-api
-   [working]
-   $0.12 | 5.2k tokens
+   [working] 5m | $0.12 | 3 files
+   30s ago
 ```
 
-- `$0.12` - Estimated cost
-- `5.2k` - Token count (input + output)
+- Elapsed time, estimated cost, and files modified count
+- Last activity time for running instances
 
 ## Quitting
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,8 @@ Claudio enables parallel AI-assisted development by running multiple Claude Code
 - **Cost Tracking** - Monitor token usage with configurable limits
 - **Session Recovery** - Resume sessions after disconnection
 - **Structured Logging** - JSON logs with filtering, rotation, and export
+- **Color Themes** - 14 built-in themes plus custom theme support
+- **Plan Validation** - Validate ultraplan JSON before execution
 
 ## Quick Start
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -259,6 +259,34 @@ Reset configuration to defaults.
 claudio config reset
 ```
 
+#### claudio config theme
+Manage color themes.
+
+```bash
+claudio config theme [command]
+```
+
+**Subcommands:**
+| Command | Description |
+|---------|-------------|
+| `list` | List all available themes (built-in and custom) |
+| `create <name>` | Generate a custom theme template |
+| `export <theme>` | Export a theme's YAML definition |
+
+**Examples:**
+```bash
+# List all themes
+claudio config theme list
+
+# Create a custom theme
+claudio config theme create my-theme
+
+# Export for customization
+claudio config theme export dracula > ~/.config/claudio/themes/my-dracula.yaml
+```
+
+Custom themes are stored in `~/.config/claudio/themes/` and automatically discovered.
+
 ---
 
 ### claudio cleanup
@@ -277,14 +305,31 @@ claudio cleanup [flags]
 | `--worktrees` | | Clean up only worktrees |
 | `--branches` | | Clean up only branches |
 | `--tmux` | | Clean up only tmux sessions |
+| `--all-sessions` | | Clean resources from all sessions, not just current |
+| `--deep-clean` | | Perform thorough cleanup including orphaned resources |
+| `--foreground` | | Run synchronously instead of in background |
+| `--job-status` | | Check status of a background cleanup job |
+
+**Background Execution:**
+
+By default, cleanup runs in the background. Resources are snapshotted at invocation time, so new worktrees created during cleanup are not affected.
 
 **Examples:**
 ```bash
 # Preview cleanup
 claudio cleanup --dry-run
 
-# Clean everything
+# Clean everything (runs in background)
 claudio cleanup --force
+
+# Run synchronously
+claudio cleanup --force --foreground
+
+# Check background job status
+claudio cleanup --job-status abc123
+
+# Deep clean all sessions
+claudio cleanup --all-sessions --force --deep-clean
 
 # Clean only worktrees
 claudio cleanup --worktrees
@@ -294,6 +339,7 @@ claudio cleanup --worktrees
 - Worktrees in `.claudio/worktrees/` with no active session
 - Branches matching `<prefix>/*` not associated with active work
 - Orphaned `claudio-*` tmux sessions
+- Background job files older than 24 hours (auto-cleaned)
 
 ---
 
@@ -404,6 +450,14 @@ List recoverable sessions and orphaned tmux sessions.
 ```bash
 claudio sessions list
 ```
+
+#### claudio sessions attach
+Attach to an existing session by ID.
+```bash
+claudio sessions attach <session-id>
+```
+
+Reconnects to an existing session and launches the TUI.
 
 #### claudio sessions recover
 Recover a previous session.
@@ -564,6 +618,45 @@ claudio adversarial --max-iterations 5 --min-passing-score 9 "Implement auth tok
 4. Loop continues until approved with passing score, or max iterations reached
 
 See [Adversarial Review Guide](../guide/adversarial.md) for detailed documentation.
+
+---
+
+### claudio validate
+
+Validate ultraplan JSON files before execution.
+
+```bash
+claudio validate <plan-file> [flags]
+```
+
+**Arguments:**
+| Argument | Description |
+|----------|-------------|
+| `plan-file` | Path to the ultraplan JSON file to validate |
+
+**Flags:**
+| Flag | Description |
+|------|-------------|
+| `--json` | Output results as JSON for CI/CD integration |
+
+**Validation checks:**
+- Valid JSON syntax
+- Required fields present
+- Task dependency validity (no cycles, no missing references)
+- File conflict detection between parallel tasks
+- Warnings for high complexity tasks
+
+**Examples:**
+```bash
+# Validate a plan file
+claudio validate .claudio-plan.json
+
+# JSON output for CI/CD
+claudio validate --json my-plan.json
+
+# Validate before executing
+claudio validate plan.json && claudio ultraplan --plan plan.json
+```
 
 ---
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -49,12 +49,61 @@ Controls the Terminal UI behavior.
 |-----|------|---------|-------------|
 | `tui.auto_focus_on_input` | bool | `true` | Auto-focus new instances for input |
 | `tui.max_output_lines` | int | `1000` | Maximum output lines to display |
+| `tui.sidebar_width` | int | `30` | Width of the sidebar in characters |
+| `tui.theme` | string | `"default"` | Color theme for the TUI |
 
 ```yaml
 tui:
   auto_focus_on_input: true
   max_output_lines: 1000
+  sidebar_width: 36
+  theme: default
 ```
+
+#### Color Themes
+
+Claudio includes 14 built-in color themes. Set your theme via config:
+
+```yaml
+tui:
+  theme: dracula  # or: monokai, nord, claude-code, etc.
+```
+
+**Built-in themes:**
+
+| Theme | Description |
+|-------|-------------|
+| `default` | Original purple/green |
+| `monokai` | Classic Monokai editor colors |
+| `dracula` | Dracula theme |
+| `nord` | Cool blue-gray Nord theme |
+| `claude-code` | Claude Code inspired orange/coral |
+| `solarized-dark` | Solarized Dark |
+| `solarized-light` | Solarized Light |
+| `one-dark` | Atom One Dark |
+| `github-dark` | GitHub Dark mode |
+| `gruvbox` | Retro groove |
+| `tokyo-night` | Modern Tokyo nights |
+| `catppuccin` | Catppuccin Mocha pastel |
+| `synthwave` | Synthwave '84 retro neon |
+| `ayu` | Ayu Dark |
+
+**Custom themes:**
+
+Create custom themes in `~/.config/claudio/themes/`:
+
+```bash
+# Generate a template
+claudio config theme create my-theme
+
+# Export an existing theme for customization
+claudio config theme export dracula > ~/.config/claudio/themes/my-dracula.yaml
+
+# List all available themes
+claudio config theme list
+```
+
+Custom theme files are automatically discovered and available when running `claudio config`.
 
 ---
 
@@ -326,6 +375,23 @@ resources:
 
 ---
 
+### session
+
+Controls session behavior.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `session.auto_start_on_add` | bool | `true` | Automatically start instances when added via TUI |
+
+```yaml
+session:
+  auto_start_on_add: true
+```
+
+When enabled, instances added via `:a` in the TUI will automatically start instead of remaining in pending state. Disable this if you prefer to manually start instances with `:s`.
+
+---
+
 ### ultraplan
 
 Controls ultra-plan mode behavior.
@@ -350,6 +416,66 @@ ultraplan:
     enabled: true
     use_sound: false
     sound_path: ""
+```
+
+---
+
+### tripleshot
+
+Controls TripleShot mode behavior.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `tripleshot.auto_approve` | bool | `false` | Automatically apply the winning solution |
+| `tripleshot.adversarial` | bool | `false` | Enable adversarial review for each implementer |
+
+```yaml
+tripleshot:
+  auto_approve: false
+  adversarial: false
+```
+
+**adversarial mode:**
+
+When `tripleshot.adversarial` is enabled, each of the three implementers is paired with a critical reviewer. An implementation isn't considered complete until its reviewer approves the work (score >= 8/10). This creates higher-quality solutions but takes longer and uses more API calls.
+
+---
+
+### adversarial
+
+Controls adversarial review mode behavior.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `adversarial.max_iterations` | int | `10` | Maximum implement-review cycles (0 = unlimited) |
+| `adversarial.min_passing_score` | int | `8` | Minimum score (1-10) required for approval |
+
+```yaml
+adversarial:
+  max_iterations: 10
+  min_passing_score: 8
+```
+
+---
+
+### plan
+
+Controls Plan mode behavior.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `plan.output_format` | string | `"issues"` | Output format: `json`, `issues`, or `both` |
+| `plan.multi_pass` | bool | `false` | Enable multi-pass planning by default |
+| `plan.labels` | []string | `[]` | Default labels for GitHub Issues |
+| `plan.output_file` | string | `".claudio-plan.json"` | Default output filename |
+
+```yaml
+plan:
+  output_format: issues
+  multi_pass: false
+  labels:
+    - claudio-generated
+  output_file: .claudio-plan.json
 ```
 
 ---

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -11,6 +11,15 @@ Quick reference for TUI keyboard shortcuts.
 | `l` / `→` | Next instance |
 | `h` / `←` | Previous instance |
 
+## Sidebar Navigation
+
+| Key | Action |
+|-----|--------|
+| `J` (Shift+j) | Scroll sidebar down without changing selection |
+| `K` (Shift+k) | Scroll sidebar up without changing selection |
+
+Use `J`/`K` to view instances "above the fold" (indicated by "▲ N more above" or "▼ N more below") without losing your current selection. Regular `j`/`k` scrolls the output panel.
+
 ## Instance Control
 
 | Key | Action |
@@ -79,6 +88,19 @@ These shortcuts use a vim-style `g` prefix. Press `g` first, then the action key
 | `Enter` | Send input |
 | `Esc` | Cancel input |
 
+### macOS Navigation (Input Mode)
+
+| Key | Action |
+|-----|--------|
+| `Opt+←` | Move cursor one word left |
+| `Opt+→` | Move cursor one word right |
+| `Opt+Backspace` | Delete word before cursor |
+| `Cmd+←` | Move to beginning of line |
+| `Cmd+→` | Move to end of line |
+| `Cmd+Backspace` | Delete to beginning of line |
+
+> **Note:** macOS shortcuts require terminal support for forwarding these key combinations.
+
 ## Global
 
 | Key | Action |
@@ -94,13 +116,18 @@ Press `:` to enter command mode, then type a command:
 
 | Command | Action |
 |---------|--------|
+| `:a "task"` | Add new instance |
+| `:s` | Start selected instance |
 | `:plan "..."` | Inline plan generation |
 | `:ultraplan "..."` | Inline UltraPlan workflow |
 | `:multiplan "..."` | Multi-pass planning |
-| `:tripleshot "..."` | TripleShot execution |
+| `:tripleshot "..."` | TripleShot execution (aliases: `:triple`, `:3shot`) |
+| `:adversarial-retry` | Restart stuck adversarial role |
 | `:group create` | Create new group |
 | `:group add` | Add instance to group |
 | `:group show` | Toggle grouped view |
+| `:d` | Show diff for selected instance |
+| `:D` | Remove selected instance |
 | `:q!` | Force quit with cleanup |
 
 ## Status Indicators


### PR DESCRIPTION
## Summary

Comprehensive documentation update to reflect the current featureset introduced in v0.13.0 and v0.14.0:

- **Color Themes**: 14 built-in themes plus custom theme support via `claudio config theme` commands
- **Sidebar Navigation**: J/K keys for scroll-only viewport control without changing selection
- **macOS Keyboard Shortcuts**: Opt+Arrow, Cmd+Arrow for word/line navigation in input mode
- **New CLI Commands**: `claudio validate` for plan validation, `claudio sessions attach`
- **Background Cleanup**: New flags (--foreground, --job-status, --deep-clean, --all-sessions)
- **TripleShot Adversarial Mode**: Integration with reviewer pairs for each implementer
- **Adversarial Recovery**: Stuck instance detection and `:adversarial-retry` command
- **Round Organization**: Auto-collapse and Previous Rounds container in adversarial mode
- **New Config Sections**: session, tripleshot, adversarial, and plan configurations

### Files Updated

- README.md - Features list, TUI shortcuts, configuration examples
- docs/index.md - Landing page feature highlights
- docs/guide/index.md - Guide navigation links
- docs/guide/adversarial.md - Stuck instance detection, round organization
- docs/guide/tripleshot.md - Adversarial mode integration, configuration
- docs/guide/tui-navigation.md - J/K navigation, macOS shortcuts, metrics display
- docs/reference/cli.md - validate command, sessions attach, cleanup flags, theme subcommands
- docs/reference/configuration.md - Theme selection, session/tripleshot/adversarial/plan sections
- docs/reference/keyboard-shortcuts.md - Sidebar navigation, macOS shortcuts

## Test plan

- [ ] Documentation renders correctly on GitHub
- [ ] All documented commands exist in the codebase
- [ ] Configuration defaults match actual codebase values
- [ ] No broken internal links