### PR TITLE
Optimize adversarial mode sentinel file polling for large repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Documentation Updates** - Refreshed documentation to cover v0.13.0 and v0.14.0 features: color themes, sidebar scroll navigation (J/K), macOS keyboard shortcuts, `validate` command, background cleanup options, tripleshot adversarial integration, and stuck instance recovery.
 
+### Performance
+
+- **Adversarial Mode Polling Optimization** - Fixed UI hitching/freezing when starting adversarial tasks in large repositories. The sentinel file polling (which checks for increment and review files every 100ms) now uses a fast-path optimization: expected file locations are cached after first discovery, and expensive full directory traversals are rate-limited to once every 5 seconds. This eliminates the overhead of `os.ReadDir()` calls on worktrees with many subdirectories.
+
 ## [0.14.1] - 2026-01-30
 
 ### Fixed


### PR DESCRIPTION
## Summary

Fixed UI freeze/hitch when starting adversarial tasks in large repositories by optimizing the sentinel file polling mechanism.

- **Caching**: Once a file is found in a non-standard location (subdirectory or parent), that directory is cached for O(1) lookups on subsequent polls
- **Rate-limiting**: Expensive full directory traversals via `os.ReadDir()` are rate-limited to once every 5 seconds
- **Error handling**: Properly distinguishes "file not found" from other errors (permissions, I/O) to avoid silent failures
- **Code deduplication**: Extracted common logic from `CheckIncrementReady()` and `CheckReviewReady()` into a shared `checkFileReady()` helper

The 5-second interval is a reasonable trade-off between responsiveness and performance - files written to non-standard locations will still be found within 5 seconds, while files at the expected location (worktree root) are always checked immediately with a fast `os.Stat()` call.

## Test plan

- [x] New tests for caching behavior (`TestCoordinator_CheckIncrementReady_CachesLocation`)
- [x] New tests for rate-limiting (`TestCoordinator_CheckIncrementReady_RateLimitsFullSearch`)
- [x] New tests for stale cache clearing (`TestCoordinator_CheckIncrementReady_ClearsStaleCache`)
- [x] New tests for review file caching (`TestCoordinator_CheckReviewReady_CachesLocation`)
- [x] All existing adversarial tests pass
- [x] Race detector finds no issues (`go test -race`)
- [x] Verified UI responsiveness when starting adversarial tasks in a large repo