### PR TITLE
Stop Claude processes on normal exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Tripleshot Adversarial Mode Grouping** - In tripleshot with adversarial mode enabled, instances are now organized hierarchically by attempt. Each of the three attempts gets its own "Attempt N" sub-group in the sidebar, with current round instances at the top level and previous rounds collapsed under a "Previous Rounds" container. The judge instance remains at the main tripleshot group level. This makes it easy to track which attempt each implementer/reviewer pair belongs to and which round within that attempt.
 
+### Fixed
+
+- **Process Cleanup on Exit** - Claude processes (running in tmux sessions) are now properly terminated when Claudio exits. Previously, normal quit (`:quit`, Ctrl+C, SIGTERM) would leave Claude processes running indefinitely, causing resource accumulation over time. The new `Shutdown()` method stops all instances while preserving session state for potential resume. Force quit (`:quit!`) behavior remains unchanged.
+
 ### Changed
 
 - **Documentation Updates** - Refreshed documentation to cover v0.13.0 and v0.14.0 features: color themes, sidebar scroll navigation (J/K), macOS keyboard shortcuts, `validate` command, background cleanup options, tripleshot adversarial integration, and stuck instance recovery.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -228,8 +228,10 @@ func NewWithAdversarials(orch *orchestrator.Orchestrator, session *orchestrator.
 
 // Run starts the TUI application
 func (a *App) Run() error {
-	// Ensure session lock is released when TUI exits (both normal and signal-based)
-	defer func() { _ = a.orchestrator.ReleaseLock() }()
+	// Ensure Claude processes are stopped and session lock is released when TUI exits.
+	// This handles all exit paths: normal quit, Ctrl+C, SIGTERM, etc.
+	// Shutdown() stops instances but preserves session state for potential resume.
+	defer func() { _ = a.orchestrator.Shutdown() }()
 
 	a.program = tea.NewProgram(
 		a.model,


### PR DESCRIPTION
## Summary

- Fix process leak where Claude instances (running in tmux sessions) were not stopped on normal exit
- Add `Shutdown()` method to orchestrator that stops all instances while preserving session state
- Replace `ReleaseLock()` with `Shutdown()` in TUI's defer to ensure cleanup on all exit paths

Previously, only `:quit!` (force quit) properly cleaned up. Now `:quit`, Ctrl+C, SIGTERM, etc. all stop Claude processes.

## Test plan

- [x] Added `TestOrchestrator_Shutdown` - verifies instances stop but session file is preserved
- [x] Added `TestOrchestrator_Shutdown_NoSession` - verifies no panic with no session
- [x] Verified idempotency (calling Shutdown twice is safe)
- [x] All existing tests pass