### PR TITLE
Fix adversarial round disambiguation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Adversarial Round Disambiguation** - Ignore stale increment/review files from prior rounds so new rounds don't start early
+
 ## [0.15.0] - 2026-02-02
 
 ### Added


### PR DESCRIPTION
## Summary
- ignore stale increment/review files from prior rounds in adversarial workflow to avoid premature starts
- clean up stale files via shared helpers
- add round mismatch coverage for increment/review processing

## Testing
- go test ./... (fails: internal/instance/input TestPersistentTmuxSender_ConcurrentAccess)
- go test ./internal/instance/input -run TestPersistentTmuxSender_ConcurrentAccess