### PR TITLE
Add adversarial reviewer backend configuration for mixed-backend sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Codex Backend Support** - Added configurable Codex CLI support alongside Claude, including backend selection, backend-aware state detection, and AI-assisted workflows using the selected backend.
+- **Adversarial Mixed-Backend Configuration** - Added `adversarial.reviewer_backend` configuration option to specify a different AI backend for the reviewer role in adversarial sessions. This enables workflows like "Claude as implementer + Codex as reviewer" for cross-model code review. When not set, both roles use the global `ai.backend` setting.
 
 ### Changed
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -238,6 +238,11 @@ type AdversarialConfig struct {
 	// MinPassingScore is the minimum score required for approval (1-10, default: 8)
 	// The reviewer must give a score >= this value for the implementation to be approved
 	MinPassingScore int `mapstructure:"min_passing_score"`
+	// ReviewerBackend specifies which AI backend to use for the reviewer role.
+	// If empty (default), uses the global ai.backend setting.
+	// Options: "claude", "codex"
+	// This allows configurations like Claude as implementer with Codex as reviewer.
+	ReviewerBackend string `mapstructure:"reviewer_backend"`
 }
 
 // LoggingConfig controls debug logging behavior
@@ -470,6 +475,7 @@ func Default() *Config {
 		Adversarial: AdversarialConfig{
 			MaxIterations:   10, // Reasonable default to prevent infinite loops
 			MinPassingScore: 8,  // Score >= 8 required for approval
+			ReviewerBackend: "", // Empty means use global ai.backend
 		},
 		Logging: LoggingConfig{
 			Enabled:    true,
@@ -596,6 +602,7 @@ func SetDefaults() {
 	// Adversarial defaults
 	viper.SetDefault("adversarial.max_iterations", defaults.Adversarial.MaxIterations)
 	viper.SetDefault("adversarial.min_passing_score", defaults.Adversarial.MinPassingScore)
+	viper.SetDefault("adversarial.reviewer_backend", defaults.Adversarial.ReviewerBackend)
 
 	// Logging defaults
 	viper.SetDefault("logging.enabled", defaults.Logging.Enabled)

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -483,6 +483,15 @@ func (c *Config) validateAdversarial() []ValidationError {
 		})
 	}
 
+	// ReviewerBackend must be a valid backend if specified
+	if c.Adversarial.ReviewerBackend != "" && !slices.Contains(ValidAIBackends(), c.Adversarial.ReviewerBackend) {
+		errors = append(errors, ValidationError{
+			Field:   "adversarial.reviewer_backend",
+			Value:   c.Adversarial.ReviewerBackend,
+			Message: fmt.Sprintf("must be one of: %s", strings.Join(ValidAIBackends(), ", ")),
+		})
+	}
+
 	return errors
 }
 

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -836,6 +836,37 @@ func TestConfig_Validate_Adversarial(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("valid reviewer backend options", func(t *testing.T) {
+		for _, backend := range []string{"", "claude", "codex"} {
+			cfg := Default()
+			cfg.Adversarial.ReviewerBackend = backend
+			errs := cfg.Validate()
+
+			for _, err := range errs {
+				if err.Field == "adversarial.reviewer_backend" {
+					t.Errorf("reviewer_backend %q should be valid, got error: %v", backend, err)
+				}
+			}
+		}
+	})
+
+	t.Run("invalid reviewer backend", func(t *testing.T) {
+		cfg := Default()
+		cfg.Adversarial.ReviewerBackend = "invalid-backend"
+		errs := cfg.Validate()
+
+		found := false
+		for _, err := range errs {
+			if err.Field == "adversarial.reviewer_backend" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("expected error for invalid reviewer_backend")
+		}
+	})
 }
 
 func TestConfig_Validate_Plan(t *testing.T) {

--- a/internal/orchestrator/workflow_adapters.go
+++ b/internal/orchestrator/workflow_adapters.go
@@ -248,6 +248,11 @@ func (a *adversarialOrchestratorAdapter) AddInstanceToWorktree(session adversari
 	return a.orch.AddInstanceToWorktree(s, task, worktreePath, branch)
 }
 
+func (a *adversarialOrchestratorAdapter) AddInstanceToWorktreeWithBackend(session adversarial.SessionInterface, task, worktreePath, branch, backendName string) (adversarial.InstanceInterface, error) {
+	s := session.(*adversarialSessionAdapter).session
+	return a.orch.AddInstanceToWorktreeWithBackend(s, task, worktreePath, branch, backendName)
+}
+
 func (a *adversarialOrchestratorAdapter) StartInstance(inst adversarial.InstanceInterface) error {
 	i := inst.(*Instance)
 	return a.orch.StartInstance(i)
@@ -389,11 +394,12 @@ func NewAdversarialSession(task string, config adversarial.Config) *adversarial.
 // NewAdversarialCoordinator creates a new adversarial coordinator
 func NewAdversarialCoordinator(orch *Orchestrator, session *Session, advSession *adversarial.Session, logger *logging.Logger) *adversarial.Coordinator {
 	cfg := adversarial.CoordinatorConfig{
-		Orchestrator: &adversarialOrchestratorAdapter{orch: orch},
-		BaseSession:  &adversarialSessionAdapter{session: session},
-		AdvSession:   advSession,
-		Logger:       logger,
-		SessionType:  string(SessionTypeAdversarial),
+		Orchestrator:    &adversarialOrchestratorAdapter{orch: orch},
+		BaseSession:     &adversarialSessionAdapter{session: session},
+		AdvSession:      advSession,
+		Logger:          logger,
+		SessionType:     string(SessionTypeAdversarial),
+		ReviewerBackend: advSession.Config.ReviewerBackend,
 	}
 	return adversarial.NewCoordinator(cfg)
 }

--- a/internal/orchestrator/workflows/adversarial/types.go
+++ b/internal/orchestrator/workflows/adversarial/types.go
@@ -50,6 +50,10 @@ type Config struct {
 	MaxIterations int `json:"max_iterations"`
 	// MinPassingScore is the minimum score required for approval (1-10, default: 8)
 	MinPassingScore int `json:"min_passing_score"`
+	// ReviewerBackend specifies which AI backend to use for the reviewer role.
+	// If empty, uses the global ai.backend setting (same as implementer).
+	// Options: "claude", "codex"
+	ReviewerBackend string `json:"reviewer_backend,omitempty"`
 }
 
 // DefaultConfig returns the default configuration
@@ -57,6 +61,7 @@ func DefaultConfig() Config {
 	return Config{
 		MaxIterations:   10, // Reasonable default to prevent infinite loops
 		MinPassingScore: 8,  // Score >= 8 required for approval
+		ReviewerBackend: "", // Empty means use global ai.backend
 	}
 }
 

--- a/internal/tui/config/config.go
+++ b/internal/tui/config/config.go
@@ -506,6 +506,14 @@ func New() Model {
 					Type:        "int",
 					Category:    "adversarial",
 				},
+				{
+					Key:         "adversarial.reviewer_backend",
+					Label:       "Reviewer Backend",
+					Description: "AI backend for reviewer (empty = use global ai.backend)",
+					Type:        "select",
+					Options:     []string{"", "claude", "codex"},
+					Category:    "adversarial",
+				},
 			},
 		},
 		{
@@ -1273,6 +1281,7 @@ func (m *Model) resetCurrentToDefault() {
 		// Adversarial
 		"adversarial.max_iterations":    defaults.Adversarial.MaxIterations,
 		"adversarial.min_passing_score": defaults.Adversarial.MinPassingScore,
+		"adversarial.reviewer_backend":  defaults.Adversarial.ReviewerBackend,
 		// Paths
 		"paths.worktree_dir":                   defaults.Paths.WorktreeDir,
 		"paths.sparse_checkout.enabled":        defaults.Paths.SparseCheckout.Enabled,


### PR DESCRIPTION
## Summary

- Adds `adversarial.reviewer_backend` configuration option to specify a different AI backend for the reviewer role in adversarial sessions
- Enables cross-model code review workflows (e.g., Claude as implementer + Codex as reviewer)
- When not set, both roles use the global `ai.backend` setting (backward compatible)

## Changes

- **Config layer**: Added `ReviewerBackend` field to both `config.AdversarialConfig` (file persistence) and `adversarial.Config` (runtime)
- **Validation**: Added validation ensuring `reviewer_backend` is either empty or a valid backend ("claude", "codex")
- **Orchestrator**: Added `AddInstanceToWorktreeWithBackend` method for per-instance backend selection with graceful fallback
- **Coordinator**: Modified `StartReviewer()` to use custom backend when configured
- **TUI Config**: Added new option to config editor with dropdown for backend selection
- **Tests**: Comprehensive coverage for validation and coordinator behavior

## Test plan

- [x] Config validation tests pass for valid/invalid reviewer backends
- [x] Coordinator tests verify correct backend method is called
- [x] JSON persistence tests confirm config survives marshal/unmarshal
- [x] Build succeeds (`go build ./...`)
- [x] Linting passes (`go vet ./...`)
- [x] All tests pass (`go test ./...`)