### PR TITLE
Fix exit panic on conflict detector double-stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Exit Panic on Conflict Detector** - Fixed panic when exiting Claudio caused by the conflict detector's `Stop()` method being called multiple times (from both `StopSession` and `Shutdown`). The `Stop()` method is now idempotent using `sync.Once`.
 - **Session Backend Init** - Initialize AI backend in `NewWithSession` to avoid undefined backend build errors.
 - **Codex Detector Thread Safety** - Fixed potential race condition in Codex backend detector initialization using sync.Once for thread-safe lazy initialization.
 - **TUI Config AI Settings** - Added `ai.claude.command` and `ai.codex.command` settings to the TUI config editor for customizing CLI binary paths.

--- a/internal/conflict/detector_test.go
+++ b/internal/conflict/detector_test.go
@@ -19,6 +19,21 @@ func TestDetector_NewAndStop(t *testing.T) {
 	d.Stop()
 }
 
+func TestDetector_StopIsIdempotent(t *testing.T) {
+	d, err := New()
+	if err != nil {
+		t.Fatalf("Failed to create detector: %v", err)
+	}
+
+	d.Start()
+	time.Sleep(10 * time.Millisecond)
+
+	// Calling Stop() multiple times should not panic
+	d.Stop()
+	d.Stop()
+	d.Stop()
+}
+
 func TestDetector_AddInstance(t *testing.T) {
 	d, err := New()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fixed panic when exiting Claudio caused by the conflict detector's `Stop()` method being called multiple times
- Both `StopSession()` and `Shutdown()` could call `Stop()` on the same detector, causing `close(d.stopCh)` to panic with "close of closed channel"
- Made `Stop()` idempotent using `sync.Once` to ensure cleanup runs exactly once

## Test plan
- [x] Added `TestDetector_StopIsIdempotent` test that calls `Stop()` multiple times
- [x] All existing tests pass
- [x] Manual verification: exit Claudio without panic