### PR TITLE
Fix tripleshot adversarial mode UI nesting and round disambiguation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Tripleshot Adversarial UI Nesting** - Fixed a bug where tripleshot attempts in adversarial mode were not immediately nested under "Attempt N" sub-groups when using the async startup path. Previously, attempts were only nested when a new round started, causing a flat instance list during the initial "preparing" phase. Now attempts are properly nested immediately when created via `CreateAttemptStubs`.
+
+- **Tripleshot Adversarial Round Disambiguation** - Fixed a bug where completing a round in tripleshot adversarial mode could spawn multiple reviewers. When an implementer completed after a rejection (round 2+), `ProcessAttemptCompletion` was incorrectly resetting `ReviewRound` to 1 and spawning duplicate reviewers. Now the code: (1) skips processing if already under review, (2) preserves the current review round, and (3) validates review file round numbers to ignore stale files from prior rounds.
+
 ## [0.16.0] - 2026-02-02
 
 ### Added


### PR DESCRIPTION
## Summary

- **Fix UI Nesting**: `CreateAttemptStubs` now properly creates "Attempt N" sub-groups when adversarial mode is enabled, ensuring instances are hierarchically organized immediately rather than only when a new round starts
- **Fix Round Disambiguation**: Prevent duplicate reviewer spawning when an implementer completes after a rejection by (1) skipping if already under review, (2) preserving the current review round, and (3) validating review file round numbers to ignore stale files

## Test plan

- [x] All existing tripleshot tests pass (127+ tests)
- [x] New tests verify sub-group creation in adversarial mode (`TestCoordinator_CreateAttemptStubs_Adversarial_CreatesSubGroups`)
- [x] New tests verify non-adversarial mode unchanged (`TestCoordinator_CreateAttemptStubs_NonAdversarial_NoSubGroups`)
- [x] New tests verify skip when already under review (`TestCoordinator_ProcessAttemptCompletion_Adversarial_SkipsWhenUnderReview`)
- [x] New tests verify ReviewRound preservation (`TestCoordinator_ProcessAttemptCompletion_Adversarial_PreservesReviewRound`)
- [x] New tests verify round mismatch validation (`TestCoordinator_ProcessAdversarialReviewCompletion_RoundMismatch`)
- [x] `go vet ./...` passes
- [x] `gofmt -d .` shows no formatting issues
- [ ] Manual testing with tripleshot adversarial mode