### PR TITLE
Fix group dismiss freezing TUI and corrupting display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Group Dismiss Freezing** - Fixed a bug where killing a group via `gq` would freeze the TUI and corrupt the display. The group dismiss operation now runs asynchronously to avoid blocking the main thread, and warning messages no longer write directly to stderr (which corrupts the Bubble Tea TUI). Users now see a "Dismissing N instance(s)..." message while the operation runs in the background.
+
 - **Tripleshot Adversarial UI Nesting** - Fixed a bug where tripleshot attempts in adversarial mode were not immediately nested under "Attempt N" sub-groups when using the async startup path. Previously, attempts were only nested when a new round started, causing a flat instance list during the initial "preparing" phase. Now attempts are properly nested immediately when created via `CreateAttemptStubs`.
 
 - **Tripleshot Adversarial Round Disambiguation** - Fixed a bug where completing a round in tripleshot adversarial mode could spawn multiple reviewers. When an implementer completed after a rejection (round 2+), `ProcessAttemptCompletion` was incorrectly resetting `ReviewRound` to 1 and spawning duplicate reviewers. Now the code: (1) skips processing if already under review, (2) preserves the current review round, and (3) validates review file round numbers to ignore stale files from prior rounds.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1104,13 +1104,25 @@ func (o *Orchestrator) RemoveInstance(session *Session, instanceID string, force
 	// Remove worktree
 	if err := o.wt.Remove(inst.WorktreePath); err != nil {
 		// Log but don't fail - the directory might already be gone
-		fmt.Fprintf(os.Stderr, "Warning: failed to remove worktree: %v\n", err)
+		if o.logger != nil {
+			o.logger.Warn("failed to remove worktree",
+				"instance_id", inst.ID,
+				"worktree_path", inst.WorktreePath,
+				"error", err,
+			)
+		}
 	}
 
 	// Delete branch
 	if err := o.wt.DeleteBranch(inst.Branch); err != nil {
 		// Log but don't fail - the branch might already be gone
-		fmt.Fprintf(os.Stderr, "Warning: failed to delete branch: %v\n", err)
+		if o.logger != nil {
+			o.logger.Warn("failed to delete branch",
+				"instance_id", inst.ID,
+				"branch", inst.Branch,
+				"error", err,
+			)
+		}
 	}
 
 	// Remove from session
@@ -1121,7 +1133,9 @@ func (o *Orchestrator) RemoveInstance(session *Session, instanceID string, force
 
 	// Update context
 	if err := o.updateContext(); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: failed to update context: %v\n", err)
+		if o.logger != nil {
+			o.logger.Warn("failed to update context", "error", err)
+		}
 	}
 
 	// Save session

--- a/internal/tui/msg/commands_test.go
+++ b/internal/tui/msg/commands_test.go
@@ -510,6 +510,47 @@ func TestRemoveInstanceAsync(t *testing.T) {
 	})
 }
 
+func TestDismissGroupAsync(t *testing.T) {
+	t.Run("returns non-nil command", func(t *testing.T) {
+		cmd := DismissGroupAsync(nil, nil, "group-123", []string{"inst-1", "inst-2"})
+		if cmd == nil {
+			t.Fatal("DismissGroupAsync() returned nil command")
+		}
+	})
+
+	t.Run("returns error when orchestrator is nil", func(t *testing.T) {
+		cmd := DismissGroupAsync(nil, nil, "group-123", []string{"inst-1", "inst-2"})
+		msg := cmd()
+
+		dismissedMsg, ok := msg.(GroupDismissedMsg)
+		if !ok {
+			t.Fatalf("DismissGroupAsync()() returned %T, want GroupDismissedMsg", msg)
+		}
+
+		if len(dismissedMsg.Errors) == 0 {
+			t.Error("expected errors when orchestrator is nil")
+		}
+		if dismissedMsg.GroupID != "group-123" {
+			t.Errorf("GroupID = %q, want %q", dismissedMsg.GroupID, "group-123")
+		}
+	})
+
+	t.Run("returns error when session is nil", func(t *testing.T) {
+		// Create a minimal orchestrator mock for this test
+		cmd := DismissGroupAsync(nil, nil, "group-456", []string{"inst-1"})
+		msg := cmd()
+
+		dismissedMsg, ok := msg.(GroupDismissedMsg)
+		if !ok {
+			t.Fatalf("DismissGroupAsync()() returned %T, want GroupDismissedMsg", msg)
+		}
+
+		if len(dismissedMsg.Errors) == 0 {
+			t.Error("expected errors when session is nil")
+		}
+	})
+}
+
 func TestLoadDiffAsync(t *testing.T) {
 	t.Run("returns non-nil command", func(t *testing.T) {
 		cmd := LoadDiffAsync(nil, "/path/to/worktree", "test-instance-id")

--- a/internal/tui/msg/types.go
+++ b/internal/tui/msg/types.go
@@ -80,6 +80,13 @@ type InstanceRemovedMsg struct {
 	Err        error
 }
 
+// GroupDismissedMsg is sent when async group dismissal completes.
+type GroupDismissedMsg struct {
+	GroupID      string
+	RemovedCount int
+	Errors       []error
+}
+
 // DiffLoadedMsg is sent when async diff loading completes.
 type DiffLoadedMsg struct {
 	InstanceID  string

--- a/internal/tui/msg/types_test.go
+++ b/internal/tui/msg/types_test.go
@@ -792,6 +792,60 @@ func TestInstanceRemovedMsg(t *testing.T) {
 	}
 }
 
+func TestGroupDismissedMsg(t *testing.T) {
+	tests := []struct {
+		name         string
+		groupID      string
+		removedCount int
+		errors       []error
+	}{
+		{
+			name:         "successful removal of all instances",
+			groupID:      "group-123",
+			removedCount: 3,
+			errors:       nil,
+		},
+		{
+			name:         "partial removal with errors",
+			groupID:      "group-456",
+			removedCount: 2,
+			errors:       []error{errors.New("instance inst-1: worktree still in use")},
+		},
+		{
+			name:         "complete failure",
+			groupID:      "group-789",
+			removedCount: 0,
+			errors:       []error{errors.New("instance inst-1: failed"), errors.New("instance inst-2: failed")},
+		},
+		{
+			name:         "empty group",
+			groupID:      "group-empty",
+			removedCount: 0,
+			errors:       nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := GroupDismissedMsg{
+				GroupID:      tt.groupID,
+				RemovedCount: tt.removedCount,
+				Errors:       tt.errors,
+			}
+
+			if msg.GroupID != tt.groupID {
+				t.Errorf("GroupDismissedMsg.GroupID = %q, want %q", msg.GroupID, tt.groupID)
+			}
+			if msg.RemovedCount != tt.removedCount {
+				t.Errorf("GroupDismissedMsg.RemovedCount = %d, want %d", msg.RemovedCount, tt.removedCount)
+			}
+			if len(msg.Errors) != len(tt.errors) {
+				t.Errorf("GroupDismissedMsg.Errors length = %d, want %d", len(msg.Errors), len(tt.errors))
+			}
+		})
+	}
+}
+
 func TestDiffLoadedMsg(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary
- Fixed TUI freezing when killing a group via `gq` by making instance removal asynchronous
- Fixed display corruption caused by warning messages writing directly to stderr
- Added proper feedback showing "Dismissing N instance(s)..." during the operation

## Background
Killing a group via `gq` was causing three issues:
1. **TUI Freezing** - The synchronous loop was blocking the main thread while git operations (worktree removal, branch deletion) executed sequentially for each instance
2. **Duplicated/Corrupted UI** - The orchestrator was writing warnings directly to stderr via `fmt.Fprintf(os.Stderr, ...)`, which corrupts Bubble Tea's terminal state
3. **Occasional errors** - Errors from directory deletion were being silently printed to stderr rather than properly reported

## Changes
| File | Change |
|------|--------|
| `internal/tui/msg/types.go` | Added `GroupDismissedMsg` type |
| `internal/tui/msg/commands.go` | Added `DismissGroupAsync()` function |
| `internal/tui/keyhandler.go` | Changed to use async dismissal |
| `internal/tui/app.go` | Added `handleGroupDismissed()` handler |
| `internal/orchestrator/orchestrator.go` | Replaced stderr prints with logger calls |

## Test plan
- [ ] Create a group with multiple instances
- [ ] Use `gq` to dismiss the group
- [ ] Verify TUI remains responsive during dismissal
- [ ] Verify no display corruption occurs
- [ ] Verify success message appears when complete
- [ ] Run `go test ./...` - all tests pass