### PR TITLE
Ensure all exit paths reliably kill Claude backend processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Process Cleanup on Exit** - Closing Claudio now reliably kills all Claude backend processes across all code paths, including PR workflows. Previously, `tmux kill-session` could leave orphaned Claude CLI processes if they ignored SIGHUP. The shutdown now captures the full process tree before stopping, polls for graceful exit, kills the per-instance tmux server (not just the session), and force-kills any surviving processes via SIGKILL. The shutdown sequence is consolidated into a shared `tmux.GracefulShutdown()` helper used by all stop paths.
+
 - **Group Dismiss Freezing** - Fixed a bug where killing a group via `gq` would freeze the TUI and corrupt the display. The group dismiss operation now runs asynchronously to avoid blocking the main thread, and warning messages no longer write directly to stderr (which corrupts the Bubble Tea TUI). Users now see a "Dismissing N instance(s)..." message while the operation runs in the background.
 
 - **Tripleshot Adversarial UI Nesting** - Fixed a bug where tripleshot attempts in adversarial mode were not immediately nested under "Attempt N" sub-groups when using the async startup path. Previously, attempts were only nested when a new round started, causing a flat instance list during the initial "preparing" phase. Now attempts are properly nested immediately when created via `CreateAttemptStubs`.

--- a/internal/instance/prworkflow_test.go
+++ b/internal/instance/prworkflow_test.go
@@ -66,3 +66,35 @@ func TestPRWorkflow_Running_Initial(t *testing.T) {
 		t.Error("New PR workflow should not be running")
 	}
 }
+
+func TestPRWorkflow_Stop_NotRunning(t *testing.T) {
+	cfg := PRWorkflowConfig{
+		TmuxWidth:  100,
+		TmuxHeight: 50,
+	}
+	workflow := NewPRWorkflow("test-stop", "/tmp", "main", "task", cfg)
+
+	// Stop on a non-running workflow should be a no-op
+	if err := workflow.Stop(); err != nil {
+		t.Errorf("Stop() on non-running workflow returned error: %v", err)
+	}
+
+	if workflow.Running() {
+		t.Error("workflow should not be running after Stop()")
+	}
+}
+
+func TestPRWorkflow_Stop_Idempotent(t *testing.T) {
+	cfg := PRWorkflowConfig{
+		TmuxWidth:  100,
+		TmuxHeight: 50,
+	}
+	workflow := NewPRWorkflow("test-idem", "/tmp", "main", "task", cfg)
+
+	// Multiple stops should not panic
+	for i := 0; i < 3; i++ {
+		if err := workflow.Stop(); err != nil {
+			t.Errorf("Stop() call %d returned error: %v", i+1, err)
+		}
+	}
+}

--- a/internal/tmux/process.go
+++ b/internal/tmux/process.go
@@ -1,0 +1,188 @@
+package tmux
+
+import (
+	"context"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// DefaultGracefulStopTimeout is the default time to wait after sending Ctrl+C
+// before force-killing processes during shutdown. This constant is shared across
+// all stop paths (instance.Manager, lifecycle.Manager, PRWorkflow) to ensure
+// consistent behavior.
+const DefaultGracefulStopTimeout = 500 * time.Millisecond
+
+// GetPanePID returns the PID of the process running in the tmux pane.
+// Returns 0 if the PID cannot be determined (e.g., session doesn't exist).
+func GetPanePID(socketName, sessionName string) int {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cmd := CommandContextWithSocket(ctx, socketName, "display-message", "-t", sessionName, "-p", "#{pane_pid}")
+	output, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(string(output)))
+	if err != nil {
+		return 0
+	}
+	return pid
+}
+
+// GetDescendantPIDs returns all descendant PIDs of the given PID (recursive).
+// Uses pgrep -P to find child processes.
+func GetDescendantPIDs(pid int) []int {
+	if pid <= 0 {
+		return nil
+	}
+	return getDescendantPIDs(pid)
+}
+
+func getDescendantPIDs(pid int) []int {
+	cmd := exec.Command("pgrep", "-P", strconv.Itoa(pid))
+	output, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+
+	var descendants []int
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		childPID, err := strconv.Atoi(line)
+		if err != nil {
+			continue
+		}
+		descendants = append(descendants, childPID)
+		// Recursively get grandchildren
+		descendants = append(descendants, getDescendantPIDs(childPID)...)
+	}
+	return descendants
+}
+
+// IsProcessAlive checks if a process with the given PID exists.
+// Uses kill(pid, 0) which checks for process existence without sending a signal.
+func IsProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	// On Unix, kill with signal 0 checks process existence without sending a signal.
+	err := syscall.Kill(pid, 0)
+	return err == nil
+}
+
+// KillProcessTree sends SIGKILL to a process and all its descendants.
+// Descendants are killed first (bottom-up) to prevent orphaning.
+func KillProcessTree(pid int) {
+	if pid <= 0 {
+		return
+	}
+
+	// Get all descendants first (before killing, so we can traverse the tree)
+	descendants := GetDescendantPIDs(pid)
+
+	// Kill descendants bottom-up (deepest children first)
+	for i := len(descendants) - 1; i >= 0; i-- {
+		if IsProcessAlive(descendants[i]) {
+			_ = syscall.Kill(descendants[i], syscall.SIGKILL)
+		}
+	}
+
+	// Kill the root process
+	if IsProcessAlive(pid) {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+	}
+}
+
+// KillServer kills the tmux server for the given socket name.
+// This is more thorough than kill-session: it terminates the server itself
+// and all sessions/windows/panes within it.
+func KillServer(socketName string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return CommandContextWithSocket(ctx, socketName, "kill-server").Run()
+}
+
+// CollectProcessTree returns the pane PID and all its descendants.
+// This should be called before initiating any shutdown to capture the full tree.
+func CollectProcessTree(socketName, sessionName string) []int {
+	panePID := GetPanePID(socketName, sessionName)
+	if panePID <= 0 {
+		return nil
+	}
+
+	pids := []int{panePID}
+	pids = append(pids, GetDescendantPIDs(panePID)...)
+	return pids
+}
+
+// EnsureProcessesKilled checks if any of the given PIDs are still alive
+// and force-kills them along with any new descendants they may have spawned.
+func EnsureProcessesKilled(pids []int) {
+	for _, pid := range pids {
+		if IsProcessAlive(pid) {
+			KillProcessTree(pid)
+		}
+	}
+}
+
+// GracefulShutdown performs a defense-in-depth shutdown of a tmux session.
+// It captures the process tree, sends Ctrl+C for graceful stop, polls for
+// process exit, kills the session and server, then force-kills any survivors.
+//
+// This is the canonical shutdown sequence shared by all stop paths
+// (instance.Manager, lifecycle.Manager, PRWorkflow).
+func GracefulShutdown(socketName, sessionName string, gracefulTimeout time.Duration) {
+	// Capture the process tree while the session is still alive so we can
+	// verify all processes are dead after tmux cleanup.
+	processPIDs := CollectProcessTree(socketName, sessionName)
+	panePID := 0
+	if len(processPIDs) > 0 {
+		panePID = processPIDs[0]
+	}
+
+	// Send Ctrl+C to gracefully stop the backend
+	_ = CommandWithSocket(socketName, "send-keys", "-t", sessionName, "C-c").Run()
+
+	// Poll for process exit instead of blind sleep
+	WaitForProcessExit(panePID, gracefulTimeout)
+
+	// Kill the tmux session
+	_ = CommandWithSocket(socketName, "kill-session", "-t", sessionName).Run()
+
+	// Kill the tmux server for this socket to prevent orphaned servers
+	_ = KillServer(socketName)
+
+	// Force-kill any processes that survived the tmux shutdown
+	EnsureProcessesKilled(processPIDs)
+}
+
+// WaitForProcessExit polls until the given PID exits or the timeout is reached.
+// Returns true if the process exited within the timeout, false if it's still alive.
+func WaitForProcessExit(pid int, timeout time.Duration) bool {
+	if pid <= 0 || !IsProcessAlive(pid) {
+		return true
+	}
+
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			return !IsProcessAlive(pid)
+		case <-ticker.C:
+			if !IsProcessAlive(pid) {
+				return true
+			}
+		}
+	}
+}

--- a/internal/tmux/process_test.go
+++ b/internal/tmux/process_test.go
@@ -1,0 +1,291 @@
+package tmux
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestGetPanePID_InvalidSession(t *testing.T) {
+	// Requesting PID from a non-existent session should return 0
+	pid := GetPanePID("nonexistent-socket-test", "nonexistent-session")
+	if pid != 0 {
+		t.Errorf("GetPanePID(nonexistent) = %d, want 0", pid)
+	}
+}
+
+func TestGetDescendantPIDs_InvalidPID(t *testing.T) {
+	tests := []struct {
+		name string
+		pid  int
+	}{
+		{"zero", 0},
+		{"negative", -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pids := GetDescendantPIDs(tt.pid)
+			if pids != nil {
+				t.Errorf("GetDescendantPIDs(%d) = %v, want nil", tt.pid, pids)
+			}
+		})
+	}
+}
+
+func TestGetDescendantPIDs_WithChildren(t *testing.T) {
+	// Start a process that has a child
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Failed to start sleep process: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	childPID := cmd.Process.Pid
+
+	// Our test process should have at least the sleep child
+	descendants := GetDescendantPIDs(os.Getpid())
+
+	found := false
+	for _, pid := range descendants {
+		if pid == childPID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("GetDescendantPIDs(%d) did not include child PID %d, got %v", os.Getpid(), childPID, descendants)
+	}
+}
+
+func TestGetDescendantPIDs_NoChildren(t *testing.T) {
+	// A process with no children should return nil/empty
+	// Use a PID that's unlikely to have children (our own sleep process)
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Failed to start sleep process: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	// sleep itself should have no children
+	descendants := GetDescendantPIDs(cmd.Process.Pid)
+	if len(descendants) != 0 {
+		t.Errorf("GetDescendantPIDs(sleep) = %v, want empty", descendants)
+	}
+}
+
+func TestIsProcessAlive(t *testing.T) {
+	tests := []struct {
+		name     string
+		pid      int
+		expected bool
+	}{
+		{"zero PID", 0, false},
+		{"negative PID", -1, false},
+		{"own process", os.Getpid(), true},
+		{"nonexistent PID", 99999999, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsProcessAlive(tt.pid)
+			if got != tt.expected {
+				t.Errorf("IsProcessAlive(%d) = %v, want %v", tt.pid, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestKillProcessTree_InvalidPID(t *testing.T) {
+	// Should not panic on invalid PIDs
+	KillProcessTree(0)
+	KillProcessTree(-1)
+}
+
+func TestKillProcessTree_KillsProcess(t *testing.T) {
+	// Start a process we can kill
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Failed to start sleep process: %v", err)
+	}
+
+	pid := cmd.Process.Pid
+
+	// Verify it's alive
+	if !IsProcessAlive(pid) {
+		t.Fatalf("Process %d should be alive after start", pid)
+	}
+
+	// Kill the tree
+	KillProcessTree(pid)
+
+	// Wait for the process to be reaped
+	_ = cmd.Wait()
+
+	// Verify it's dead
+	if IsProcessAlive(pid) {
+		t.Errorf("Process %d should be dead after KillProcessTree", pid)
+	}
+}
+
+func TestKillProcessTree_KillsDescendants(t *testing.T) {
+	// Start a shell that runs a sleep subprocess
+	cmd := exec.Command("sh", "-c", "sleep 60 & wait")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Failed to start process: %v", err)
+	}
+	shellPID := cmd.Process.Pid
+
+	// Give the shell time to start the sleep subprocess
+	time.Sleep(200 * time.Millisecond)
+
+	// Get descendants before killing
+	descendants := GetDescendantPIDs(shellPID)
+
+	// Kill the tree
+	KillProcessTree(shellPID)
+	_ = cmd.Wait()
+
+	// Verify descendants are also dead
+	time.Sleep(100 * time.Millisecond) // Brief wait for process cleanup
+	for _, pid := range descendants {
+		if IsProcessAlive(pid) {
+			// Clean up just in case
+			_ = syscall.Kill(pid, syscall.SIGKILL)
+			t.Errorf("Descendant process %d should be dead after KillProcessTree", pid)
+		}
+	}
+}
+
+func TestKillServer_NonexistentSocket(t *testing.T) {
+	// Killing a non-existent server should return an error (but not panic)
+	err := KillServer("nonexistent-socket-for-test-12345")
+	if err == nil {
+		t.Error("KillServer on non-existent socket should return error")
+	}
+}
+
+func TestCollectProcessTree_InvalidSession(t *testing.T) {
+	pids := CollectProcessTree("nonexistent-socket", "nonexistent-session")
+	if pids != nil {
+		t.Errorf("CollectProcessTree(nonexistent) = %v, want nil", pids)
+	}
+}
+
+func TestEnsureProcessesKilled_EmptyList(t *testing.T) {
+	// Should not panic on empty/nil list
+	EnsureProcessesKilled(nil)
+	EnsureProcessesKilled([]int{})
+}
+
+func TestEnsureProcessesKilled_KillsSurvivors(t *testing.T) {
+	// Start a process
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Failed to start process: %v", err)
+	}
+	pid := cmd.Process.Pid
+
+	// Ensure it's killed
+	EnsureProcessesKilled([]int{pid})
+	_ = cmd.Wait()
+
+	if IsProcessAlive(pid) {
+		t.Errorf("Process %d should be dead after EnsureProcessesKilled", pid)
+	}
+}
+
+func TestEnsureProcessesKilled_DeadProcesses(t *testing.T) {
+	// Should not panic when given already-dead PIDs
+	EnsureProcessesKilled([]int{99999999, 99999998})
+}
+
+func TestWaitForProcessExit_AlreadyDead(t *testing.T) {
+	result := WaitForProcessExit(99999999, 100*time.Millisecond)
+	if !result {
+		t.Error("WaitForProcessExit should return true for non-existent process")
+	}
+}
+
+func TestWaitForProcessExit_InvalidPID(t *testing.T) {
+	tests := []struct {
+		name string
+		pid  int
+	}{
+		{"zero", 0},
+		{"negative", -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := WaitForProcessExit(tt.pid, 100*time.Millisecond)
+			if !result {
+				t.Errorf("WaitForProcessExit(%d) should return true for invalid PID", tt.pid)
+			}
+		})
+	}
+}
+
+func TestWaitForProcessExit_ProcessExits(t *testing.T) {
+	// Start a process that will exit quickly
+	cmd := exec.Command("sleep", "0.1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Failed to start process: %v", err)
+	}
+	pid := cmd.Process.Pid
+
+	// Reap the process in a goroutine so it doesn't become a zombie.
+	// Zombie processes still appear alive to kill(pid, 0).
+	go func() { _ = cmd.Wait() }()
+
+	// Wait for it with a generous timeout
+	result := WaitForProcessExit(pid, 2*time.Second)
+
+	if !result {
+		t.Error("WaitForProcessExit should return true when process exits within timeout")
+	}
+}
+
+func TestGracefulShutdown_NonexistentSession(t *testing.T) {
+	// Should not panic when called with a non-existent session/socket
+	GracefulShutdown("nonexistent-socket-test", "nonexistent-session", 100*time.Millisecond)
+}
+
+func TestGracefulShutdown_Idempotent(t *testing.T) {
+	// Multiple calls should not panic
+	for i := 0; i < 3; i++ {
+		GracefulShutdown("nonexistent-socket-test", "nonexistent-session", 100*time.Millisecond)
+	}
+}
+
+func TestDefaultGracefulStopTimeout(t *testing.T) {
+	if DefaultGracefulStopTimeout != 500*time.Millisecond {
+		t.Errorf("DefaultGracefulStopTimeout = %v, want 500ms", DefaultGracefulStopTimeout)
+	}
+}
+
+func TestWaitForProcessExit_Timeout(t *testing.T) {
+	// Start a process that won't exit on its own
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Failed to start process: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	pid := cmd.Process.Pid
+
+	// Wait with a short timeout
+	result := WaitForProcessExit(pid, 150*time.Millisecond)
+	if result {
+		t.Error("WaitForProcessExit should return false when process doesn't exit within timeout")
+	}
+}


### PR DESCRIPTION
## Summary

- **Process cleanup on exit** — All three shutdown paths (`Manager.Stop()`, `lifecycle.Manager.Stop()`, `PRWorkflow.Stop()`) now reliably kill Claude backend processes using a defense-in-depth strategy: capture process tree → Ctrl+C → poll for graceful exit → kill tmux session → kill tmux server → SIGKILL survivors
- **Shared shutdown helper** — Extracted the ~50-line duplicated shutdown sequence into `tmux.GracefulShutdown()`, eliminating ~100 lines of copy-pasted code and ensuring consistent behavior across all stop paths
- **New process management utilities** — Added `internal/tmux/process.go` with `CollectProcessTree`, `WaitForProcessExit`, `KillProcessTree`, `EnsureProcessesKilled`, and `IsProcessAlive` functions

## Context

Previously, `tmux kill-session` could leave orphaned Claude CLI processes if they ignored SIGHUP. Users running multiple instances could end up with hundreds of active Claude processes causing severe performance issues. The new shutdown sequence captures the full process tree before stopping, polls for graceful exit, kills the per-instance tmux server (not just the session), and force-kills any surviving processes via SIGKILL.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `gofmt -d .` shows no formatting issues
- [x] All existing tests pass (`go test ./internal/tmux/... ./internal/instance/...`)
- [x] New tests for process utilities (edge cases, idempotent stop, process tree traversal)
- [x] New tests for `GracefulShutdown` (non-existent session, idempotent calls)
- [x] CHANGELOG.md updated