### PR TITLE
Add inter-instance mailbox and dynamic task queue for Orchestration 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Inter-Instance Mailbox** - File-based messaging system (`internal/mailbox/`) enabling cross-instance communication during orchestration. Supports broadcast and targeted messages with types including discovery, claim, release, warning, question, answer, and status. Includes prompt injection formatting and event bus integration. (#629)
+- **Dynamic Task Queue** - Dependency-aware task queue (`internal/taskqueue/`) with self-claiming and work-stealing, replacing static execution batch ordering. Instances claim tasks as dependencies are satisfied, eliminating idle time between execution groups. Includes failed task redistribution with retry, stale claim cleanup, state persistence, and event bus integration. (#630)
+
 ## [0.16.1] - 2026-02-05
 
 ### Fixed

--- a/internal/event/types.go
+++ b/internal/event/types.go
@@ -361,3 +361,88 @@ func NewGroupCompletionEvent(groupID, groupName string, success bool, failedCoun
 		SuccessCount: successCount,
 	}
 }
+
+// -----------------------------------------------------------------------------
+// Mailbox Events (Inter-Instance Communication)
+// -----------------------------------------------------------------------------
+
+// MailboxMessageEvent is emitted when an inter-instance mailbox message is sent.
+type MailboxMessageEvent struct {
+	baseEvent
+	From        string // Sender instance ID or "coordinator"
+	To          string // Recipient instance ID or "broadcast"
+	MessageType string // Message type (discovery, claim, warning, etc.)
+	Body        string // Message content
+}
+
+// NewMailboxMessageEvent creates a MailboxMessageEvent.
+func NewMailboxMessageEvent(from, to, messageType, body string) MailboxMessageEvent {
+	return MailboxMessageEvent{
+		baseEvent:   newBaseEvent("mailbox.message"),
+		From:        from,
+		To:          to,
+		MessageType: messageType,
+		Body:        body,
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Task Queue Events (Dynamic Task Claiming)
+// -----------------------------------------------------------------------------
+
+// TaskClaimedEvent is emitted when an instance claims a task from the queue.
+type TaskClaimedEvent struct {
+	baseEvent
+	TaskID     string // Task that was claimed
+	InstanceID string // Instance that claimed it
+}
+
+// NewTaskClaimedEvent creates a TaskClaimedEvent.
+func NewTaskClaimedEvent(taskID, instanceID string) TaskClaimedEvent {
+	return TaskClaimedEvent{
+		baseEvent:  newBaseEvent("queue.task_claimed"),
+		TaskID:     taskID,
+		InstanceID: instanceID,
+	}
+}
+
+// TaskReleasedEvent is emitted when a task is returned to the queue.
+type TaskReleasedEvent struct {
+	baseEvent
+	TaskID string // Task that was released
+	Reason string // Why it was released (e.g., "stale_claim", "instance_died")
+}
+
+// NewTaskReleasedEvent creates a TaskReleasedEvent.
+func NewTaskReleasedEvent(taskID, reason string) TaskReleasedEvent {
+	return TaskReleasedEvent{
+		baseEvent: newBaseEvent("queue.task_released"),
+		TaskID:    taskID,
+		Reason:    reason,
+	}
+}
+
+// QueueDepthChangedEvent is emitted when the queue depth changes.
+// Used by the TUI to display queue progress.
+type QueueDepthChangedEvent struct {
+	baseEvent
+	Pending   int // Number of pending tasks
+	Claimed   int // Number of claimed tasks
+	Running   int // Number of running tasks
+	Completed int // Number of completed tasks
+	Failed    int // Number of permanently failed tasks
+	Total     int // Total number of tasks
+}
+
+// NewQueueDepthChangedEvent creates a QueueDepthChangedEvent.
+func NewQueueDepthChangedEvent(pending, claimed, running, completed, failed, total int) QueueDepthChangedEvent {
+	return QueueDepthChangedEvent{
+		baseEvent: newBaseEvent("queue.depth_changed"),
+		Pending:   pending,
+		Claimed:   claimed,
+		Running:   running,
+		Completed: completed,
+		Failed:    failed,
+		Total:     total,
+	}
+}

--- a/internal/mailbox/doc.go
+++ b/internal/mailbox/doc.go
@@ -1,0 +1,63 @@
+// Package mailbox provides inter-instance communication for Claudio sessions.
+//
+// When Claudio runs multiple Claude Code instances in parallel (via git worktrees),
+// those instances are currently isolated. The mailbox package enables instances to
+// exchange messages during execution, allowing coordination like sharing discoveries,
+// claiming file ownership, asking questions, and broadcasting status updates.
+//
+// # Architecture
+//
+// Messages are persisted to the filesystem under the session directory using an
+// append-only JSONL (JSON Lines) format. Each instance has a dedicated inbox
+// directory, and a shared broadcast directory enables messages intended for all
+// instances.
+//
+//	.claudio/mailbox/{sessionID}/
+//	    broadcast/index.jsonl    -- messages to all instances
+//	    {instanceID}/index.jsonl -- messages to a specific instance
+//
+// # Main Types
+//
+//   - [Message]: A single message with sender, recipient, type, body, and metadata
+//   - [MessageType]: Enumeration of supported message kinds (discovery, claim, etc.)
+//   - [Store]: Low-level file-based storage with atomic writes
+//   - [Mailbox]: High-level facade combining broadcast and targeted delivery
+//
+// # Message Types
+//
+//   - [MessageDiscovery]: Share findings with other instances
+//   - [MessageClaim]: Claim ownership of a file or module
+//   - [MessageRelease]: Relinquish previously claimed ownership
+//   - [MessageWarning]: Alert others about potential issues
+//   - [MessageQuestion]: Request help from other instances
+//   - [MessageAnswer]: Respond to a question
+//   - [MessageStatus]: Provide a progress update
+//
+// # Basic Usage
+//
+//	mb := mailbox.NewMailbox(sessionDir)
+//
+//	// Send a broadcast message
+//	msg := mailbox.Message{
+//	    From: "instance-1",
+//	    To:   "broadcast",
+//	    Type: mailbox.MessageDiscovery,
+//	    Body: "Found a shared utility in pkg/utils",
+//	}
+//	mb.Send(msg)
+//
+//	// Receive messages (broadcast + targeted)
+//	messages, err := mb.Receive("instance-2")
+//
+//	// Watch for new messages
+//	cancel := mb.Watch("instance-2", func(msg mailbox.Message) {
+//	    log.Printf("New message from %s: %s", msg.From, msg.Body)
+//	})
+//	defer cancel()
+//
+// # Thread Safety
+//
+// The [Store] and [Mailbox] types are safe for concurrent use within a single
+// process via an internal mutex. File writes use O_APPEND for POSIX atomicity
+// on small JSONL lines.
+package mailbox

--- a/internal/mailbox/events.go
+++ b/internal/mailbox/events.go
@@ -1,0 +1,8 @@
+package mailbox
+
+import "github.com/Iron-Ham/claudio/internal/event"
+
+// NewMailboxMessageEvent creates an event.MailboxMessageEvent from a Message.
+func NewMailboxMessageEvent(msg Message) event.MailboxMessageEvent {
+	return event.NewMailboxMessageEvent(msg.From, msg.To, string(msg.Type), msg.Body)
+}

--- a/internal/mailbox/events_test.go
+++ b/internal/mailbox/events_test.go
@@ -1,0 +1,76 @@
+package mailbox
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewMailboxMessageEvent(t *testing.T) {
+	msg := Message{
+		From:      "inst-1",
+		To:        "inst-2",
+		Type:      MessageDiscovery,
+		Body:      "found a helper function",
+		Timestamp: time.Now(),
+	}
+
+	evt := NewMailboxMessageEvent(msg)
+
+	if evt.EventType() != "mailbox.message" {
+		t.Errorf("EventType() = %q, want %q", evt.EventType(), "mailbox.message")
+	}
+	if evt.From != "inst-1" {
+		t.Errorf("From = %q, want %q", evt.From, "inst-1")
+	}
+	if evt.To != "inst-2" {
+		t.Errorf("To = %q, want %q", evt.To, "inst-2")
+	}
+	if evt.MessageType != "discovery" {
+		t.Errorf("MessageType = %q, want %q", evt.MessageType, "discovery")
+	}
+	if evt.Body != "found a helper function" {
+		t.Errorf("Body = %q, want %q", evt.Body, "found a helper function")
+	}
+	if evt.Timestamp().IsZero() {
+		t.Error("Timestamp() should not be zero")
+	}
+}
+
+func TestNewMailboxMessageEvent_Broadcast(t *testing.T) {
+	msg := Message{
+		From: "coordinator",
+		To:   BroadcastRecipient,
+		Type: MessageWarning,
+		Body: "watch out",
+	}
+
+	evt := NewMailboxMessageEvent(msg)
+
+	if evt.To != BroadcastRecipient {
+		t.Errorf("To = %q, want %q", evt.To, BroadcastRecipient)
+	}
+	if evt.MessageType != "warning" {
+		t.Errorf("MessageType = %q, want %q", evt.MessageType, "warning")
+	}
+}
+
+func TestNewMailboxMessageEvent_AllTypes(t *testing.T) {
+	types := []MessageType{
+		MessageDiscovery, MessageClaim, MessageRelease,
+		MessageWarning, MessageQuestion, MessageAnswer, MessageStatus,
+	}
+	for _, mt := range types {
+		t.Run(string(mt), func(t *testing.T) {
+			msg := Message{
+				From: "inst-1",
+				To:   "inst-2",
+				Type: mt,
+				Body: "test",
+			}
+			evt := NewMailboxMessageEvent(msg)
+			if evt.MessageType != string(mt) {
+				t.Errorf("MessageType = %q, want %q", evt.MessageType, string(mt))
+			}
+		})
+	}
+}

--- a/internal/mailbox/inject.go
+++ b/internal/mailbox/inject.go
@@ -1,0 +1,68 @@
+package mailbox
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// FormatForPrompt formats a slice of messages into a human-readable block
+// suitable for injection into a Claude prompt. Messages are grouped by type
+// for readability.
+//
+// Returns an empty string if there are no messages.
+func FormatForPrompt(messages []Message) string {
+	if len(messages) == 0 {
+		return ""
+	}
+
+	// Group messages by type, preserving order within each group.
+	groups := make(map[MessageType][]Message)
+	var typeOrder []MessageType
+	for _, msg := range messages {
+		if _, exists := groups[msg.Type]; !exists {
+			typeOrder = append(typeOrder, msg.Type)
+		}
+		groups[msg.Type] = append(groups[msg.Type], msg)
+	}
+
+	var b strings.Builder
+	b.WriteString("<mailbox-messages>\n")
+
+	for i, mt := range typeOrder {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(fmt.Sprintf("[%s]\n", strings.ToUpper(string(mt))))
+		for _, msg := range groups[mt] {
+			b.WriteString(fmt.Sprintf("  From: %s\n", msg.From))
+			b.WriteString(fmt.Sprintf("  %s\n", msg.Body))
+			if len(msg.Metadata) > 0 {
+				b.WriteString(fmt.Sprintf("  Metadata: %s\n", formatMetadata(msg.Metadata)))
+			}
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString("</mailbox-messages>")
+	return b.String()
+}
+
+// formatMetadata formats a metadata map as a compact key=value string.
+// Keys are sorted for deterministic output.
+func formatMetadata(m map[string]any) string {
+	if len(m) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%v", k, m[k]))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/mailbox/inject_test.go
+++ b/internal/mailbox/inject_test.go
@@ -1,0 +1,190 @@
+package mailbox
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFormatForPrompt_Empty(t *testing.T) {
+	result := FormatForPrompt(nil)
+	if result != "" {
+		t.Errorf("FormatForPrompt(nil) = %q, want empty string", result)
+	}
+
+	result = FormatForPrompt([]Message{})
+	if result != "" {
+		t.Errorf("FormatForPrompt([]) = %q, want empty string", result)
+	}
+}
+
+func TestFormatForPrompt_SingleMessage(t *testing.T) {
+	messages := []Message{
+		{
+			From: "inst-1",
+			To:   "inst-2",
+			Type: MessageDiscovery,
+			Body: "Found shared utility in pkg/utils",
+		},
+	}
+
+	result := FormatForPrompt(messages)
+
+	if !strings.Contains(result, "<mailbox-messages>") {
+		t.Error("expected <mailbox-messages> opening tag")
+	}
+	if !strings.Contains(result, "</mailbox-messages>") {
+		t.Error("expected </mailbox-messages> closing tag")
+	}
+	if !strings.Contains(result, "[DISCOVERY]") {
+		t.Error("expected [DISCOVERY] header")
+	}
+	if !strings.Contains(result, "From: inst-1") {
+		t.Error("expected From: inst-1")
+	}
+	if !strings.Contains(result, "Found shared utility in pkg/utils") {
+		t.Error("expected message body")
+	}
+}
+
+func TestFormatForPrompt_GroupsByType(t *testing.T) {
+	base := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	messages := []Message{
+		{From: "inst-1", To: "broadcast", Type: MessageDiscovery, Body: "disc-1", Timestamp: base},
+		{From: "inst-2", To: "broadcast", Type: MessageWarning, Body: "warn-1", Timestamp: base.Add(time.Second)},
+		{From: "inst-3", To: "broadcast", Type: MessageDiscovery, Body: "disc-2", Timestamp: base.Add(2 * time.Second)},
+	}
+
+	result := FormatForPrompt(messages)
+
+	// DISCOVERY should appear before WARNING (order of first appearance)
+	discIdx := strings.Index(result, "[DISCOVERY]")
+	warnIdx := strings.Index(result, "[WARNING]")
+	if discIdx < 0 {
+		t.Fatal("expected [DISCOVERY] header")
+	}
+	if warnIdx < 0 {
+		t.Fatal("expected [WARNING] header")
+	}
+	if discIdx >= warnIdx {
+		t.Error("expected [DISCOVERY] before [WARNING] based on first-appearance order")
+	}
+
+	// Both discovery messages should be under the DISCOVERY header
+	discSection := result[discIdx:warnIdx]
+	if !strings.Contains(discSection, "disc-1") {
+		t.Error("expected disc-1 under DISCOVERY")
+	}
+	if !strings.Contains(discSection, "disc-2") {
+		t.Error("expected disc-2 under DISCOVERY")
+	}
+}
+
+func TestFormatForPrompt_WithMetadata(t *testing.T) {
+	messages := []Message{
+		{
+			From:     "inst-1",
+			To:       "inst-2",
+			Type:     MessageClaim,
+			Body:     "claiming main.go",
+			Metadata: map[string]any{"file": "main.go"},
+		},
+	}
+
+	result := FormatForPrompt(messages)
+
+	if !strings.Contains(result, "Metadata:") {
+		t.Error("expected Metadata line for message with metadata")
+	}
+	if !strings.Contains(result, "file=main.go") {
+		t.Error("expected file=main.go in metadata")
+	}
+}
+
+func TestFormatForPrompt_WithoutMetadata(t *testing.T) {
+	messages := []Message{
+		{
+			From: "inst-1",
+			To:   "inst-2",
+			Type: MessageStatus,
+			Body: "50% complete",
+		},
+	}
+
+	result := FormatForPrompt(messages)
+
+	if strings.Contains(result, "Metadata:") {
+		t.Error("expected no Metadata line for message without metadata")
+	}
+}
+
+func TestFormatForPrompt_AllTypes(t *testing.T) {
+	types := []MessageType{
+		MessageDiscovery, MessageClaim, MessageRelease,
+		MessageWarning, MessageQuestion, MessageAnswer, MessageStatus,
+	}
+
+	var messages []Message
+	for _, mt := range types {
+		messages = append(messages, Message{
+			From: "inst-1",
+			To:   "broadcast",
+			Type: mt,
+			Body: "test " + string(mt),
+		})
+	}
+
+	result := FormatForPrompt(messages)
+
+	expectedHeaders := []string{
+		"[DISCOVERY]", "[CLAIM]", "[RELEASE]",
+		"[WARNING]", "[QUESTION]", "[ANSWER]", "[STATUS]",
+	}
+	for _, header := range expectedHeaders {
+		if !strings.Contains(result, header) {
+			t.Errorf("expected header %s in output", header)
+		}
+	}
+}
+
+func TestFormatForPrompt_MultipleMessagesPerType(t *testing.T) {
+	messages := []Message{
+		{From: "inst-1", To: "broadcast", Type: MessageStatus, Body: "starting"},
+		{From: "inst-2", To: "broadcast", Type: MessageStatus, Body: "halfway"},
+		{From: "inst-3", To: "broadcast", Type: MessageStatus, Body: "done"},
+	}
+
+	result := FormatForPrompt(messages)
+
+	// Should only have one [STATUS] header
+	if strings.Count(result, "[STATUS]") != 1 {
+		t.Errorf("expected exactly one [STATUS] header, got %d", strings.Count(result, "[STATUS]"))
+	}
+
+	// All bodies should appear
+	for _, body := range []string{"starting", "halfway", "done"} {
+		if !strings.Contains(result, body) {
+			t.Errorf("expected body %q in output", body)
+		}
+	}
+}
+
+func TestFormatMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]any
+		want     string
+	}{
+		{"nil map", nil, ""},
+		{"empty map", map[string]any{}, ""},
+		{"single entry", map[string]any{"file": "main.go"}, "file=main.go"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatMetadata(tt.metadata)
+			if got != tt.want {
+				t.Errorf("formatMetadata() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/mailbox/mailbox.go
+++ b/internal/mailbox/mailbox.go
@@ -1,0 +1,101 @@
+package mailbox
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// defaultPollInterval is the default interval for the Watch poller.
+	defaultPollInterval = 500 * time.Millisecond
+)
+
+// Mailbox provides a high-level interface for inter-instance messaging.
+// It wraps a Store and adds convenience methods for receiving messages
+// from both broadcast and targeted mailboxes, plus a poll-based watcher.
+type Mailbox struct {
+	store        *Store
+	pollInterval time.Duration
+}
+
+// NewMailbox creates a Mailbox backed by a file store in the given session directory.
+func NewMailbox(sessionDir string) *Mailbox {
+	return &Mailbox{
+		store:        NewStore(sessionDir),
+		pollInterval: defaultPollInterval,
+	}
+}
+
+// SetPollInterval configures the interval between Watch polls.
+// Must be called before Watch. Zero or negative values are ignored.
+func (m *Mailbox) SetPollInterval(d time.Duration) {
+	if d > 0 {
+		m.pollInterval = d
+	}
+}
+
+// Send delivers a message to the store. It populates the ID and Timestamp
+// fields if they are empty.
+func (m *Mailbox) Send(msg Message) error {
+	return m.store.Send(msg)
+}
+
+// Receive returns all messages for the given instance, including both
+// broadcast messages and messages addressed directly to the instance.
+// Messages are sorted chronologically by timestamp.
+func (m *Mailbox) Receive(instanceID string) ([]Message, error) {
+	return m.store.ReadAll(instanceID)
+}
+
+// Watch polls for new messages and invokes handler for each new message.
+// It returns a cancel function that stops the watcher. The watcher runs in a
+// separate goroutine. Messages are delivered in chronological order.
+//
+// The watcher tracks the count of previously seen messages and only delivers
+// messages that appear after the initial snapshot.
+func (m *Mailbox) Watch(instanceID string, handler func(Message)) (cancel func()) {
+	var stopped atomic.Bool
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		// Take an initial snapshot count to avoid delivering old messages.
+		seen := m.countMessages(instanceID)
+
+		for !stopped.Load() {
+			time.Sleep(m.pollInterval)
+			if stopped.Load() {
+				return
+			}
+
+			messages, err := m.Receive(instanceID)
+			if err != nil {
+				continue
+			}
+
+			if len(messages) > seen {
+				for _, msg := range messages[seen:] {
+					handler(msg)
+				}
+				seen = len(messages)
+			}
+		}
+	}()
+
+	return func() {
+		stopped.Store(true)
+		wg.Wait()
+	}
+}
+
+// countMessages returns the current message count for an instance (broadcast + targeted).
+func (m *Mailbox) countMessages(instanceID string) int {
+	messages, err := m.Receive(instanceID)
+	if err != nil {
+		return 0
+	}
+	return len(messages)
+}

--- a/internal/mailbox/mailbox_test.go
+++ b/internal/mailbox/mailbox_test.go
@@ -1,0 +1,349 @@
+package mailbox
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestMailbox_NewMailbox(t *testing.T) {
+	dir := t.TempDir()
+	mb := NewMailbox(dir)
+	if mb == nil {
+		t.Fatal("NewMailbox() returned nil")
+	}
+	if mb.store == nil {
+		t.Fatal("NewMailbox() store is nil")
+	}
+	if mb.pollInterval != defaultPollInterval {
+		t.Errorf("pollInterval = %v, want %v", mb.pollInterval, defaultPollInterval)
+	}
+}
+
+func TestMailbox_SetPollInterval(t *testing.T) {
+	dir := t.TempDir()
+	mb := NewMailbox(dir)
+
+	mb.SetPollInterval(100 * time.Millisecond)
+	if mb.pollInterval != 100*time.Millisecond {
+		t.Errorf("pollInterval = %v, want %v", mb.pollInterval, 100*time.Millisecond)
+	}
+
+	// Zero and negative values should be ignored
+	mb.SetPollInterval(0)
+	if mb.pollInterval != 100*time.Millisecond {
+		t.Errorf("pollInterval changed on zero, got %v", mb.pollInterval)
+	}
+
+	mb.SetPollInterval(-1 * time.Second)
+	if mb.pollInterval != 100*time.Millisecond {
+		t.Errorf("pollInterval changed on negative, got %v", mb.pollInterval)
+	}
+}
+
+func TestMailbox_SendAndReceive(t *testing.T) {
+	dir := t.TempDir()
+	mb := NewMailbox(dir)
+
+	// Send a targeted message
+	if err := mb.Send(Message{
+		From: "inst-1",
+		To:   "inst-2",
+		Type: MessageDiscovery,
+		Body: "found something",
+	}); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	// Send a broadcast
+	if err := mb.Send(Message{
+		From: "inst-1",
+		To:   BroadcastRecipient,
+		Type: MessageWarning,
+		Body: "heads up",
+	}); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	// inst-2 should see both
+	messages, err := mb.Receive("inst-2")
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(messages))
+	}
+
+	// inst-3 should see only the broadcast
+	messages, err = mb.Receive("inst-3")
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message for inst-3, got %d", len(messages))
+	}
+	if messages[0].Body != "heads up" {
+		t.Errorf("Body = %q, want %q", messages[0].Body, "heads up")
+	}
+}
+
+func TestMailbox_Receive_Empty(t *testing.T) {
+	dir := t.TempDir()
+	mb := NewMailbox(dir)
+
+	messages, err := mb.Receive("inst-1")
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+	if len(messages) != 0 {
+		t.Errorf("expected 0 messages, got %d", len(messages))
+	}
+}
+
+func TestMailbox_Receive_ChronologicalOrder(t *testing.T) {
+	dir := t.TempDir()
+	mb := NewMailbox(dir)
+
+	base := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	// Send messages out of order
+	if err := mb.Send(Message{
+		From:      "inst-1",
+		To:        "inst-2",
+		Type:      MessageStatus,
+		Body:      "third",
+		Timestamp: base.Add(3 * time.Second),
+	}); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	if err := mb.Send(Message{
+		From:      "inst-1",
+		To:        BroadcastRecipient,
+		Type:      MessageStatus,
+		Body:      "first",
+		Timestamp: base.Add(1 * time.Second),
+	}); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	if err := mb.Send(Message{
+		From:      "inst-3",
+		To:        "inst-2",
+		Type:      MessageStatus,
+		Body:      "second",
+		Timestamp: base.Add(2 * time.Second),
+	}); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	messages, err := mb.Receive("inst-2")
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+	if len(messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(messages))
+	}
+
+	expected := []string{"first", "second", "third"}
+	for i, want := range expected {
+		if messages[i].Body != want {
+			t.Errorf("messages[%d].Body = %q, want %q", i, messages[i].Body, want)
+		}
+	}
+}
+
+func TestMailbox_Watch(t *testing.T) {
+	dir := t.TempDir()
+	mb := NewMailbox(dir)
+	mb.SetPollInterval(20 * time.Millisecond)
+
+	var mu sync.Mutex
+	var received []Message
+
+	cancel := mb.Watch("inst-2", func(msg Message) {
+		mu.Lock()
+		received = append(received, msg)
+		mu.Unlock()
+	})
+	defer cancel()
+
+	// Allow the watcher to initialize
+	time.Sleep(30 * time.Millisecond)
+
+	// Send a message after the watch starts
+	if err := mb.Send(Message{
+		From: "inst-1",
+		To:   "inst-2",
+		Type: MessageDiscovery,
+		Body: "new finding",
+	}); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	// Wait for the watcher to pick it up
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	count := len(received)
+	mu.Unlock()
+
+	if count != 1 {
+		t.Errorf("expected 1 watched message, got %d", count)
+	}
+}
+
+func TestMailbox_Watch_SkipsExistingMessages(t *testing.T) {
+	dir := t.TempDir()
+	mb := NewMailbox(dir)
+	mb.SetPollInterval(20 * time.Millisecond)
+
+	// Send a message before the watch starts
+	if err := mb.Send(Message{
+		From: "inst-1",
+		To:   "inst-2",
+		Type: MessageDiscovery,
+		Body: "old message",
+	}); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	var mu sync.Mutex
+	var received []Message
+
+	cancel := mb.Watch("inst-2", func(msg Message) {
+		mu.Lock()
+		received = append(received, msg)
+		mu.Unlock()
+	})
+	defer cancel()
+
+	// Wait several poll cycles
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	count := len(received)
+	mu.Unlock()
+
+	if count != 0 {
+		t.Errorf("expected 0 watched messages (old messages should be skipped), got %d", count)
+	}
+}
+
+func TestMailbox_Watch_Cancel(t *testing.T) {
+	dir := t.TempDir()
+	mb := NewMailbox(dir)
+	mb.SetPollInterval(20 * time.Millisecond)
+
+	var mu sync.Mutex
+	var received []Message
+
+	cancel := mb.Watch("inst-2", func(msg Message) {
+		mu.Lock()
+		received = append(received, msg)
+		mu.Unlock()
+	})
+
+	// Cancel immediately
+	cancel()
+
+	// Send a message after cancellation
+	if err := mb.Send(Message{
+		From: "inst-1",
+		To:   "inst-2",
+		Type: MessageDiscovery,
+		Body: "after cancel",
+	}); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	count := len(received)
+	mu.Unlock()
+
+	if count != 0 {
+		t.Errorf("expected 0 watched messages after cancel, got %d", count)
+	}
+}
+
+func TestMailbox_Watch_BroadcastMessages(t *testing.T) {
+	dir := t.TempDir()
+	mb := NewMailbox(dir)
+	mb.SetPollInterval(20 * time.Millisecond)
+
+	var mu sync.Mutex
+	var received []Message
+
+	cancel := mb.Watch("inst-2", func(msg Message) {
+		mu.Lock()
+		received = append(received, msg)
+		mu.Unlock()
+	})
+	defer cancel()
+
+	// Allow the watcher to initialize
+	time.Sleep(30 * time.Millisecond)
+
+	// Send a broadcast message
+	if err := mb.Send(Message{
+		From: "inst-1",
+		To:   BroadcastRecipient,
+		Type: MessageWarning,
+		Body: "broadcast alert",
+	}); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	count := len(received)
+	mu.Unlock()
+
+	if count != 1 {
+		t.Errorf("expected 1 watched broadcast message, got %d", count)
+	}
+}
+
+func TestMailbox_Watch_MultipleMessages(t *testing.T) {
+	dir := t.TempDir()
+	mb := NewMailbox(dir)
+	mb.SetPollInterval(20 * time.Millisecond)
+
+	var mu sync.Mutex
+	var received []Message
+
+	cancel := mb.Watch("inst-2", func(msg Message) {
+		mu.Lock()
+		received = append(received, msg)
+		mu.Unlock()
+	})
+	defer cancel()
+
+	// Allow the watcher to initialize
+	time.Sleep(30 * time.Millisecond)
+
+	// Send multiple messages
+	for _, body := range []string{"one", "two", "three"} {
+		if err := mb.Send(Message{
+			From: "inst-1",
+			To:   "inst-2",
+			Type: MessageStatus,
+			Body: body,
+		}); err != nil {
+			t.Fatalf("Send() error = %v", err)
+		}
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	mu.Lock()
+	count := len(received)
+	mu.Unlock()
+
+	if count != 3 {
+		t.Errorf("expected 3 watched messages, got %d", count)
+	}
+}

--- a/internal/mailbox/sort.go
+++ b/internal/mailbox/sort.go
@@ -1,0 +1,10 @@
+package mailbox
+
+import "sort"
+
+// sortMessages sorts messages chronologically by timestamp.
+func sortMessages(msgs []Message) {
+	sort.Slice(msgs, func(i, j int) bool {
+		return msgs[i].Timestamp.Before(msgs[j].Timestamp)
+	})
+}

--- a/internal/mailbox/store.go
+++ b/internal/mailbox/store.go
@@ -1,0 +1,170 @@
+package mailbox
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// mailboxDir is the directory name within a session directory that holds mailboxes.
+	mailboxDir = "mailbox"
+
+	// indexFile is the append-only JSONL file within each mailbox directory.
+	indexFile = "index.jsonl"
+)
+
+// Store provides file-based mailbox storage with atomic writes.
+// Messages are persisted as JSONL (one JSON object per line) in an append-only log.
+type Store struct {
+	sessionDir string
+	mu         sync.Mutex
+}
+
+// NewStore creates a Store rooted at the given session directory.
+// The directory structure is created lazily on first write.
+func NewStore(sessionDir string) *Store {
+	return &Store{sessionDir: sessionDir}
+}
+
+// Send persists a message to the appropriate mailbox directory.
+// If msg.ID is empty, a unique ID is generated. If msg.Timestamp is zero, the
+// current time is used. Writes are serialized via a mutex and use O_APPEND.
+func (s *Store) Send(msg Message) error {
+	if msg.From == "" {
+		return fmt.Errorf("mailbox: message From field is required")
+	}
+	if msg.To == "" {
+		return fmt.Errorf("mailbox: message To field is required")
+	}
+	if msg.Type == "" {
+		return fmt.Errorf("mailbox: message Type field is required")
+	}
+
+	if msg.ID == "" {
+		msg.ID = generateID()
+	}
+	if msg.Timestamp.IsZero() {
+		msg.Timestamp = time.Now()
+	}
+
+	dir := s.dirForRecipient(msg.To)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mailbox: create directory: %w", err)
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("mailbox: marshal message: %w", err)
+	}
+	data = append(data, '\n')
+
+	return s.atomicAppend(filepath.Join(dir, indexFile), data)
+}
+
+// ReadBroadcast returns all messages from the broadcast mailbox.
+func (s *Store) ReadBroadcast() ([]Message, error) {
+	return s.readIndex(s.dirForRecipient(BroadcastRecipient))
+}
+
+// ReadForInstance returns all messages targeted at a specific instance.
+func (s *Store) ReadForInstance(instanceID string) ([]Message, error) {
+	if instanceID == "" {
+		return nil, fmt.Errorf("mailbox: instanceID is required")
+	}
+	return s.readIndex(s.dirForRecipient(instanceID))
+}
+
+// ReadAll returns all messages across broadcast and a specific instance mailbox,
+// sorted chronologically by timestamp.
+func (s *Store) ReadAll(instanceID string) ([]Message, error) {
+	broadcast, err := s.ReadBroadcast()
+	if err != nil {
+		return nil, err
+	}
+
+	targeted, err := s.ReadForInstance(instanceID)
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]Message, 0, len(broadcast)+len(targeted))
+	all = append(all, broadcast...)
+	all = append(all, targeted...)
+
+	sortMessages(all)
+	return all, nil
+}
+
+// dirForRecipient returns the mailbox directory for a given recipient.
+func (s *Store) dirForRecipient(recipient string) string {
+	return filepath.Join(s.sessionDir, mailboxDir, recipient)
+}
+
+// readIndex reads all messages from an index.jsonl file.
+// Returns nil (not error) if the file does not exist.
+func (s *Store) readIndex(dir string) ([]Message, error) {
+	path := filepath.Join(dir, indexFile)
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("mailbox: open index: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var messages []Message
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var msg Message
+		if err := json.Unmarshal(line, &msg); err != nil {
+			// Skip malformed lines rather than failing entirely
+			continue
+		}
+		messages = append(messages, msg)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("mailbox: scan index: %w", err)
+	}
+
+	return messages, nil
+}
+
+// atomicAppend appends data to a file under a mutex to serialize writes.
+// Each JSONL line is small enough that O_APPEND provides atomicity guarantees
+// on POSIX systems (writes under PIPE_BUF are atomic).
+func (s *Store) atomicAppend(path string, data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("mailbox: open index for append: %w", err)
+	}
+
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("mailbox: append to index: %w", err)
+	}
+
+	return f.Close()
+}
+
+// idCounter provides per-process uniqueness for message IDs.
+var idCounter atomic.Uint64
+
+// generateID produces a unique message ID using timestamp, PID, and atomic counter.
+func generateID() string {
+	return fmt.Sprintf("msg-%d-%d-%d", time.Now().UnixNano(), os.Getpid(), idCounter.Add(1))
+}

--- a/internal/mailbox/store_test.go
+++ b/internal/mailbox/store_test.go
@@ -1,0 +1,415 @@
+package mailbox
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestStore_Send(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	msg := Message{
+		From: "inst-1",
+		To:   "inst-2",
+		Type: MessageDiscovery,
+		Body: "hello",
+	}
+
+	if err := store.Send(msg); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	// Verify the file was created
+	indexPath := filepath.Join(dir, mailboxDir, "inst-2", indexFile)
+	if _, err := os.Stat(indexPath); err != nil {
+		t.Fatalf("index file not created: %v", err)
+	}
+}
+
+func TestStore_Send_AutoPopulatesFields(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	msg := Message{
+		From: "inst-1",
+		To:   "inst-2",
+		Type: MessageStatus,
+		Body: "working",
+	}
+
+	if err := store.Send(msg); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	messages, err := store.ReadForInstance("inst-2")
+	if err != nil {
+		t.Fatalf("ReadForInstance() error = %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+
+	if messages[0].ID == "" {
+		t.Error("expected auto-generated ID, got empty string")
+	}
+	if messages[0].Timestamp.IsZero() {
+		t.Error("expected auto-generated Timestamp, got zero")
+	}
+}
+
+func TestStore_Send_PreservesExistingIDAndTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	now := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	msg := Message{
+		ID:        "custom-id",
+		From:      "inst-1",
+		To:        "inst-2",
+		Type:      MessageStatus,
+		Body:      "update",
+		Timestamp: now,
+	}
+
+	if err := store.Send(msg); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	messages, err := store.ReadForInstance("inst-2")
+	if err != nil {
+		t.Fatalf("ReadForInstance() error = %v", err)
+	}
+
+	if messages[0].ID != "custom-id" {
+		t.Errorf("ID = %q, want %q", messages[0].ID, "custom-id")
+	}
+	if !messages[0].Timestamp.Equal(now) {
+		t.Errorf("Timestamp = %v, want %v", messages[0].Timestamp, now)
+	}
+}
+
+func TestStore_Send_ValidationErrors(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	tests := []struct {
+		name string
+		msg  Message
+	}{
+		{"empty from", Message{To: "inst-2", Type: MessageStatus, Body: "hi"}},
+		{"empty to", Message{From: "inst-1", Type: MessageStatus, Body: "hi"}},
+		{"empty type", Message{From: "inst-1", To: "inst-2", Body: "hi"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := store.Send(tt.msg); err == nil {
+				t.Error("expected error for invalid message, got nil")
+			}
+		})
+	}
+}
+
+func TestStore_ReadForInstance(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	// Send two messages to inst-2
+	for i, body := range []string{"first", "second"} {
+		msg := Message{
+			ID:        "msg-" + body,
+			From:      "inst-1",
+			To:        "inst-2",
+			Type:      MessageDiscovery,
+			Body:      body,
+			Timestamp: time.Now().Add(time.Duration(i) * time.Second),
+		}
+		if err := store.Send(msg); err != nil {
+			t.Fatalf("Send() error = %v", err)
+		}
+	}
+
+	messages, err := store.ReadForInstance("inst-2")
+	if err != nil {
+		t.Fatalf("ReadForInstance() error = %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(messages))
+	}
+	if messages[0].Body != "first" {
+		t.Errorf("messages[0].Body = %q, want %q", messages[0].Body, "first")
+	}
+	if messages[1].Body != "second" {
+		t.Errorf("messages[1].Body = %q, want %q", messages[1].Body, "second")
+	}
+}
+
+func TestStore_ReadForInstance_EmptyID(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	_, err := store.ReadForInstance("")
+	if err == nil {
+		t.Error("expected error for empty instanceID, got nil")
+	}
+}
+
+func TestStore_ReadForInstance_NoMessages(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	messages, err := store.ReadForInstance("inst-1")
+	if err != nil {
+		t.Fatalf("ReadForInstance() error = %v", err)
+	}
+	if messages != nil {
+		t.Errorf("expected nil for no messages, got %v", messages)
+	}
+}
+
+func TestStore_ReadBroadcast(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	msg := Message{
+		From: "inst-1",
+		To:   BroadcastRecipient,
+		Type: MessageWarning,
+		Body: "heads up everyone",
+	}
+	if err := store.Send(msg); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	messages, err := store.ReadBroadcast()
+	if err != nil {
+		t.Fatalf("ReadBroadcast() error = %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+	if messages[0].Body != "heads up everyone" {
+		t.Errorf("Body = %q, want %q", messages[0].Body, "heads up everyone")
+	}
+}
+
+func TestStore_ReadBroadcast_NoMessages(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	messages, err := store.ReadBroadcast()
+	if err != nil {
+		t.Fatalf("ReadBroadcast() error = %v", err)
+	}
+	if messages != nil {
+		t.Errorf("expected nil for no messages, got %v", messages)
+	}
+}
+
+func TestStore_ReadAll(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	base := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// Send a broadcast message (timestamp: t+1)
+	if err := store.Send(Message{
+		From:      "inst-1",
+		To:        BroadcastRecipient,
+		Type:      MessageWarning,
+		Body:      "broadcast",
+		Timestamp: base.Add(1 * time.Second),
+	}); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	// Send a targeted message (timestamp: t+0, earlier)
+	if err := store.Send(Message{
+		From:      "inst-1",
+		To:        "inst-2",
+		Type:      MessageDiscovery,
+		Body:      "targeted",
+		Timestamp: base,
+	}); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	messages, err := store.ReadAll("inst-2")
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(messages))
+	}
+
+	// Should be sorted chronologically: targeted first, broadcast second
+	if messages[0].Body != "targeted" {
+		t.Errorf("messages[0].Body = %q, want %q", messages[0].Body, "targeted")
+	}
+	if messages[1].Body != "broadcast" {
+		t.Errorf("messages[1].Body = %q, want %q", messages[1].Body, "broadcast")
+	}
+}
+
+func TestStore_ReadAll_BroadcastAndTargetedSeparate(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	// Message to inst-2 should not appear for inst-3
+	if err := store.Send(Message{
+		From: "inst-1",
+		To:   "inst-2",
+		Type: MessageDiscovery,
+		Body: "for inst-2 only",
+	}); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	// Broadcast should appear for both
+	if err := store.Send(Message{
+		From: "inst-1",
+		To:   BroadcastRecipient,
+		Type: MessageStatus,
+		Body: "for everyone",
+	}); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	// inst-3 should only see the broadcast
+	msgs, err := store.ReadAll("inst-3")
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message for inst-3, got %d", len(msgs))
+	}
+	if msgs[0].Body != "for everyone" {
+		t.Errorf("Body = %q, want %q", msgs[0].Body, "for everyone")
+	}
+}
+
+func TestStore_ConcurrentSend(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	var wg sync.WaitGroup
+	for i := range 20 {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			msg := Message{
+				From: "inst-1",
+				To:   "inst-2",
+				Type: MessageStatus,
+				Body: "msg",
+			}
+			if err := store.Send(msg); err != nil {
+				t.Errorf("Send() error = %v", err)
+			}
+			_ = n
+		}(i)
+	}
+	wg.Wait()
+
+	messages, err := store.ReadForInstance("inst-2")
+	if err != nil {
+		t.Fatalf("ReadForInstance() error = %v", err)
+	}
+	if len(messages) != 20 {
+		t.Errorf("expected 20 messages, got %d", len(messages))
+	}
+}
+
+func TestStore_MetadataRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	msg := Message{
+		From:     "inst-1",
+		To:       "inst-2",
+		Type:     MessageClaim,
+		Body:     "claiming file",
+		Metadata: map[string]any{"file": "main.go", "line": float64(42)},
+	}
+	if err := store.Send(msg); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	messages, err := store.ReadForInstance("inst-2")
+	if err != nil {
+		t.Fatalf("ReadForInstance() error = %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+
+	if messages[0].Metadata["file"] != "main.go" {
+		t.Errorf("Metadata[file] = %v, want %q", messages[0].Metadata["file"], "main.go")
+	}
+	// JSON numbers unmarshal as float64
+	if messages[0].Metadata["line"] != float64(42) {
+		t.Errorf("Metadata[line] = %v, want %v", messages[0].Metadata["line"], float64(42))
+	}
+}
+
+func TestStore_NilMetadataOmitted(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	msg := Message{
+		From: "inst-1",
+		To:   "inst-2",
+		Type: MessageStatus,
+		Body: "no metadata",
+	}
+	if err := store.Send(msg); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	messages, err := store.ReadForInstance("inst-2")
+	if err != nil {
+		t.Fatalf("ReadForInstance() error = %v", err)
+	}
+	if messages[0].Metadata != nil {
+		t.Errorf("expected nil Metadata, got %v", messages[0].Metadata)
+	}
+}
+
+func TestStore_DirectoryStructure(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	// Send broadcast
+	if err := store.Send(Message{
+		From: "inst-1",
+		To:   BroadcastRecipient,
+		Type: MessageStatus,
+		Body: "broadcast",
+	}); err != nil {
+		t.Fatalf("Send broadcast error = %v", err)
+	}
+
+	// Send targeted
+	if err := store.Send(Message{
+		From: "inst-1",
+		To:   "inst-2",
+		Type: MessageStatus,
+		Body: "targeted",
+	}); err != nil {
+		t.Fatalf("Send targeted error = %v", err)
+	}
+
+	// Verify directory structure
+	broadcastDir := filepath.Join(dir, mailboxDir, BroadcastRecipient)
+	if _, err := os.Stat(broadcastDir); err != nil {
+		t.Errorf("broadcast directory not created: %v", err)
+	}
+
+	instanceDir := filepath.Join(dir, mailboxDir, "inst-2")
+	if _, err := os.Stat(instanceDir); err != nil {
+		t.Errorf("instance directory not created: %v", err)
+	}
+}

--- a/internal/mailbox/types.go
+++ b/internal/mailbox/types.go
@@ -1,0 +1,64 @@
+package mailbox
+
+import "time"
+
+// MessageType identifies the kind of inter-instance message.
+type MessageType string
+
+const (
+	// MessageDiscovery shares findings with other instances.
+	MessageDiscovery MessageType = "discovery"
+
+	// MessageClaim declares ownership of a file or module.
+	MessageClaim MessageType = "claim"
+
+	// MessageRelease relinquishes previously claimed ownership.
+	MessageRelease MessageType = "release"
+
+	// MessageWarning alerts other instances about potential issues.
+	MessageWarning MessageType = "warning"
+
+	// MessageQuestion requests help from other instances.
+	MessageQuestion MessageType = "question"
+
+	// MessageAnswer responds to a question from another instance.
+	MessageAnswer MessageType = "answer"
+
+	// MessageStatus provides a progress update.
+	MessageStatus MessageType = "status"
+)
+
+// BroadcastRecipient is the special "to" value for messages intended for all instances.
+const BroadcastRecipient = "broadcast"
+
+// Message represents a single inter-instance communication.
+type Message struct {
+	ID        string         `json:"id"`
+	From      string         `json:"from"`
+	To        string         `json:"to"`
+	Type      MessageType    `json:"type"`
+	Body      string         `json:"body"`
+	Timestamp time.Time      `json:"timestamp"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+}
+
+// IsBroadcast returns true if the message is addressed to all instances.
+func (m Message) IsBroadcast() bool {
+	return m.To == BroadcastRecipient
+}
+
+// Valid message types for validation.
+var validMessageTypes = map[MessageType]bool{
+	MessageDiscovery: true,
+	MessageClaim:     true,
+	MessageRelease:   true,
+	MessageWarning:   true,
+	MessageQuestion:  true,
+	MessageAnswer:    true,
+	MessageStatus:    true,
+}
+
+// ValidateMessageType returns true if the given type is a known message type.
+func ValidateMessageType(t MessageType) bool {
+	return validMessageTypes[t]
+}

--- a/internal/mailbox/types_test.go
+++ b/internal/mailbox/types_test.go
@@ -1,0 +1,117 @@
+package mailbox
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMessage_IsBroadcast(t *testing.T) {
+	tests := []struct {
+		name string
+		to   string
+		want bool
+	}{
+		{"broadcast recipient", BroadcastRecipient, true},
+		{"specific instance", "instance-1", false},
+		{"empty recipient", "", false},
+		{"coordinator", "coordinator", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := Message{To: tt.to}
+			if got := msg.IsBroadcast(); got != tt.want {
+				t.Errorf("Message.IsBroadcast() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateMessageType(t *testing.T) {
+	tests := []struct {
+		name     string
+		msgType  MessageType
+		expected bool
+	}{
+		{"discovery", MessageDiscovery, true},
+		{"claim", MessageClaim, true},
+		{"release", MessageRelease, true},
+		{"warning", MessageWarning, true},
+		{"question", MessageQuestion, true},
+		{"answer", MessageAnswer, true},
+		{"status", MessageStatus, true},
+		{"unknown type", MessageType("unknown"), false},
+		{"empty type", MessageType(""), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ValidateMessageType(tt.msgType); got != tt.expected {
+				t.Errorf("ValidateMessageType(%q) = %v, want %v", tt.msgType, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMessageType_Constants(t *testing.T) {
+	// Verify all constants have the expected string values.
+	tests := []struct {
+		name     string
+		msgType  MessageType
+		expected string
+	}{
+		{"discovery", MessageDiscovery, "discovery"},
+		{"claim", MessageClaim, "claim"},
+		{"release", MessageRelease, "release"},
+		{"warning", MessageWarning, "warning"},
+		{"question", MessageQuestion, "question"},
+		{"answer", MessageAnswer, "answer"},
+		{"status", MessageStatus, "status"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if string(tt.msgType) != tt.expected {
+				t.Errorf("MessageType %s = %q, want %q", tt.name, tt.msgType, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBroadcastRecipient(t *testing.T) {
+	if BroadcastRecipient != "broadcast" {
+		t.Errorf("BroadcastRecipient = %q, want %q", BroadcastRecipient, "broadcast")
+	}
+}
+
+func TestMessage_Fields(t *testing.T) {
+	now := time.Now()
+	msg := Message{
+		ID:        "msg-123",
+		From:      "instance-1",
+		To:        "instance-2",
+		Type:      MessageDiscovery,
+		Body:      "found a helper",
+		Timestamp: now,
+		Metadata:  map[string]any{"file": "utils.go"},
+	}
+
+	if msg.ID != "msg-123" {
+		t.Errorf("ID = %q, want %q", msg.ID, "msg-123")
+	}
+	if msg.From != "instance-1" {
+		t.Errorf("From = %q, want %q", msg.From, "instance-1")
+	}
+	if msg.To != "instance-2" {
+		t.Errorf("To = %q, want %q", msg.To, "instance-2")
+	}
+	if msg.Type != MessageDiscovery {
+		t.Errorf("Type = %q, want %q", msg.Type, MessageDiscovery)
+	}
+	if msg.Body != "found a helper" {
+		t.Errorf("Body = %q, want %q", msg.Body, "found a helper")
+	}
+	if !msg.Timestamp.Equal(now) {
+		t.Errorf("Timestamp = %v, want %v", msg.Timestamp, now)
+	}
+	if msg.Metadata["file"] != "utils.go" {
+		t.Errorf("Metadata[file] = %v, want %q", msg.Metadata["file"], "utils.go")
+	}
+}

--- a/internal/taskqueue/deps.go
+++ b/internal/taskqueue/deps.go
@@ -1,0 +1,112 @@
+package taskqueue
+
+// isClaimable returns true if the task can be claimed: it must be pending
+// and all of its dependencies must be in the completed state.
+func (q *TaskQueue) isClaimable(task *QueuedTask) bool {
+	if task.Status != TaskPending {
+		return false
+	}
+	for _, depID := range task.DependsOn {
+		dep, ok := q.tasks[depID]
+		if !ok || dep.Status != TaskCompleted {
+			return false
+		}
+	}
+	return true
+}
+
+// unblockedBy returns the IDs of tasks that become claimable after the
+// given task completes. A task is newly claimable if all of its dependencies
+// are now completed and it is still in the pending state.
+func (q *TaskQueue) unblockedBy(taskID string) []string {
+	var unblocked []string
+	for _, id := range q.order {
+		task := q.tasks[id]
+		if task.Status != TaskPending {
+			continue
+		}
+		dependsOnCompleted := false
+		allDepsCompleted := true
+		for _, depID := range task.DependsOn {
+			if depID == taskID {
+				dependsOnCompleted = true
+			}
+			dep, ok := q.tasks[depID]
+			if !ok || dep.Status != TaskCompleted {
+				allDepsCompleted = false
+			}
+		}
+		if dependsOnCompleted && allDepsCompleted {
+			unblocked = append(unblocked, id)
+		}
+	}
+	return unblocked
+}
+
+// buildPriorityOrder computes the task ordering used for claim selection.
+// Tasks are ordered by execution group (topological level), then by priority
+// within each group. This preserves the natural dependency ordering while
+// respecting priority for tasks at the same level.
+func buildPriorityOrder(tasks map[string]*QueuedTask) []string {
+	if len(tasks) == 0 {
+		return nil
+	}
+
+	// Compute in-degree for topological sort
+	inDegree := make(map[string]int, len(tasks))
+	dependents := make(map[string][]string, len(tasks))
+	for id, task := range tasks {
+		inDegree[id] = 0
+		_ = task // initialize all
+	}
+	for id, task := range tasks {
+		for _, depID := range task.DependsOn {
+			if _, ok := tasks[depID]; ok {
+				inDegree[id]++
+				dependents[depID] = append(dependents[depID], id)
+			}
+		}
+	}
+
+	// BFS-based topological sort, collecting tasks level by level
+	var order []string
+	var queue []string
+	for id, deg := range inDegree {
+		if deg == 0 {
+			queue = append(queue, id)
+		}
+	}
+
+	for len(queue) > 0 {
+		// Sort current level by priority (lower = higher priority)
+		sortByPriority(queue, tasks)
+		order = append(order, queue...)
+
+		var next []string
+		for _, id := range queue {
+			for _, depID := range dependents[id] {
+				inDegree[depID]--
+				if inDegree[depID] == 0 {
+					next = append(next, depID)
+				}
+			}
+		}
+		queue = next
+	}
+
+	return order
+}
+
+// sortByPriority sorts task IDs by their priority value (lower first),
+// using insertion sort since the slices are typically small.
+func sortByPriority(ids []string, tasks map[string]*QueuedTask) {
+	for i := 1; i < len(ids); i++ {
+		key := ids[i]
+		j := i - 1
+		for j >= 0 && tasks[ids[j]].Priority > tasks[key].Priority {
+			ids[j+1] = ids[j]
+			j--
+		}
+		ids[j+1] = key
+	}
+}

--- a/internal/taskqueue/deps_test.go
+++ b/internal/taskqueue/deps_test.go
@@ -1,0 +1,210 @@
+package taskqueue
+
+import (
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/ultraplan"
+)
+
+func TestIsClaimable(t *testing.T) {
+	tasks := map[string]*QueuedTask{
+		"a": {PlannedTask: ultraplan.PlannedTask{ID: "a", DependsOn: []string{}}, Status: TaskCompleted},
+		"b": {PlannedTask: ultraplan.PlannedTask{ID: "b", DependsOn: []string{"a"}}, Status: TaskPending},
+		"c": {PlannedTask: ultraplan.PlannedTask{ID: "c", DependsOn: []string{"a", "d"}}, Status: TaskPending},
+		"d": {PlannedTask: ultraplan.PlannedTask{ID: "d", DependsOn: []string{}}, Status: TaskRunning},
+		"e": {PlannedTask: ultraplan.PlannedTask{ID: "e", DependsOn: []string{}}, Status: TaskClaimed},
+		"f": {PlannedTask: ultraplan.PlannedTask{ID: "f", DependsOn: []string{}}, Status: TaskPending},
+	}
+	q := &TaskQueue{tasks: tasks}
+
+	tests := []struct {
+		taskID    string
+		claimable bool
+	}{
+		{"a", false}, // completed, not pending
+		{"b", true},  // pending, dep "a" is completed
+		{"c", false}, // pending, but dep "d" is running
+		{"d", false}, // running, not pending
+		{"e", false}, // claimed, not pending
+		{"f", true},  // pending, no deps
+	}
+	for _, tt := range tests {
+		t.Run(tt.taskID, func(t *testing.T) {
+			got := q.isClaimable(tasks[tt.taskID])
+			if got != tt.claimable {
+				t.Errorf("isClaimable(%q) = %v, want %v", tt.taskID, got, tt.claimable)
+			}
+		})
+	}
+}
+
+func TestIsClaimable_MissingDependency(t *testing.T) {
+	tasks := map[string]*QueuedTask{
+		"a": {PlannedTask: ultraplan.PlannedTask{ID: "a", DependsOn: []string{"nonexistent"}}, Status: TaskPending},
+	}
+	q := &TaskQueue{tasks: tasks}
+
+	if q.isClaimable(tasks["a"]) {
+		t.Error("isClaimable should return false when dependency does not exist in queue")
+	}
+}
+
+func TestUnblockedBy(t *testing.T) {
+	tasks := map[string]*QueuedTask{
+		"a": {PlannedTask: ultraplan.PlannedTask{ID: "a", DependsOn: []string{}}, Status: TaskCompleted},
+		"b": {PlannedTask: ultraplan.PlannedTask{ID: "b", DependsOn: []string{"a"}}, Status: TaskPending},
+		"c": {PlannedTask: ultraplan.PlannedTask{ID: "c", DependsOn: []string{"a", "d"}}, Status: TaskPending},
+		"d": {PlannedTask: ultraplan.PlannedTask{ID: "d", DependsOn: []string{}}, Status: TaskCompleted},
+		"e": {PlannedTask: ultraplan.PlannedTask{ID: "e", DependsOn: []string{"a"}}, Status: TaskRunning},
+	}
+	order := []string{"a", "b", "c", "d", "e"}
+	q := &TaskQueue{tasks: tasks, order: order}
+
+	// Completing "a" should unblock "b" (dep "a" done) and "c" (deps "a" + "d" done)
+	// but not "e" (already running)
+	got := q.unblockedBy("a")
+	want := map[string]bool{"b": true, "c": true}
+	if len(got) != len(want) {
+		t.Fatalf("unblockedBy(a) returned %v, want keys %v", got, want)
+	}
+	for _, id := range got {
+		if !want[id] {
+			t.Errorf("unblockedBy(a) included unexpected task %q", id)
+		}
+	}
+}
+
+func TestUnblockedBy_PartialDeps(t *testing.T) {
+	tasks := map[string]*QueuedTask{
+		"a": {PlannedTask: ultraplan.PlannedTask{ID: "a", DependsOn: []string{}}, Status: TaskCompleted},
+		"b": {PlannedTask: ultraplan.PlannedTask{ID: "b", DependsOn: []string{}}, Status: TaskRunning},
+		"c": {PlannedTask: ultraplan.PlannedTask{ID: "c", DependsOn: []string{"a", "b"}}, Status: TaskPending},
+	}
+	order := []string{"a", "b", "c"}
+	q := &TaskQueue{tasks: tasks, order: order}
+
+	// Completing "a" should NOT unblock "c" because "b" is still running
+	got := q.unblockedBy("a")
+	if len(got) != 0 {
+		t.Errorf("unblockedBy(a) = %v, want empty (b still running)", got)
+	}
+}
+
+func TestBuildPriorityOrder(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		order := buildPriorityOrder(nil)
+		if order != nil {
+			t.Errorf("buildPriorityOrder(nil) = %v, want nil", order)
+		}
+	})
+
+	t.Run("no dependencies", func(t *testing.T) {
+		tasks := map[string]*QueuedTask{
+			"c": {PlannedTask: ultraplan.PlannedTask{ID: "c", Priority: 2, DependsOn: []string{}}},
+			"a": {PlannedTask: ultraplan.PlannedTask{ID: "a", Priority: 0, DependsOn: []string{}}},
+			"b": {PlannedTask: ultraplan.PlannedTask{ID: "b", Priority: 1, DependsOn: []string{}}},
+		}
+		order := buildPriorityOrder(tasks)
+		if len(order) != 3 {
+			t.Fatalf("expected 3 tasks, got %d", len(order))
+		}
+		// All at same level, sorted by priority
+		if order[0] != "a" || order[1] != "b" || order[2] != "c" {
+			t.Errorf("order = %v, want [a b c]", order)
+		}
+	})
+
+	t.Run("linear chain", func(t *testing.T) {
+		tasks := map[string]*QueuedTask{
+			"c": {PlannedTask: ultraplan.PlannedTask{ID: "c", Priority: 0, DependsOn: []string{"b"}}},
+			"a": {PlannedTask: ultraplan.PlannedTask{ID: "a", Priority: 0, DependsOn: []string{}}},
+			"b": {PlannedTask: ultraplan.PlannedTask{ID: "b", Priority: 0, DependsOn: []string{"a"}}},
+		}
+		order := buildPriorityOrder(tasks)
+		if len(order) != 3 {
+			t.Fatalf("expected 3 tasks, got %d", len(order))
+		}
+		if order[0] != "a" || order[1] != "b" || order[2] != "c" {
+			t.Errorf("order = %v, want [a b c]", order)
+		}
+	})
+
+	t.Run("diamond", func(t *testing.T) {
+		tasks := map[string]*QueuedTask{
+			"a": {PlannedTask: ultraplan.PlannedTask{ID: "a", Priority: 0, DependsOn: []string{}}},
+			"b": {PlannedTask: ultraplan.PlannedTask{ID: "b", Priority: 0, DependsOn: []string{"a"}}},
+			"c": {PlannedTask: ultraplan.PlannedTask{ID: "c", Priority: 1, DependsOn: []string{"a"}}},
+			"d": {PlannedTask: ultraplan.PlannedTask{ID: "d", Priority: 0, DependsOn: []string{"b", "c"}}},
+		}
+		order := buildPriorityOrder(tasks)
+		if len(order) != 4 {
+			t.Fatalf("expected 4 tasks, got %d", len(order))
+		}
+		// a must come first, d must come last
+		if order[0] != "a" {
+			t.Errorf("order[0] = %q, want a", order[0])
+		}
+		if order[3] != "d" {
+			t.Errorf("order[3] = %q, want d", order[3])
+		}
+		// b and c should be ordered by priority (b=0, c=1)
+		if order[1] != "b" || order[2] != "c" {
+			t.Errorf("order[1:3] = %v, want [b c]", order[1:3])
+		}
+	})
+
+	t.Run("wide parallel", func(t *testing.T) {
+		// 5 tasks, all independent, different priorities
+		tasks := map[string]*QueuedTask{
+			"e": {PlannedTask: ultraplan.PlannedTask{ID: "e", Priority: 4, DependsOn: []string{}}},
+			"d": {PlannedTask: ultraplan.PlannedTask{ID: "d", Priority: 3, DependsOn: []string{}}},
+			"c": {PlannedTask: ultraplan.PlannedTask{ID: "c", Priority: 2, DependsOn: []string{}}},
+			"b": {PlannedTask: ultraplan.PlannedTask{ID: "b", Priority: 1, DependsOn: []string{}}},
+			"a": {PlannedTask: ultraplan.PlannedTask{ID: "a", Priority: 0, DependsOn: []string{}}},
+		}
+		order := buildPriorityOrder(tasks)
+		if len(order) != 5 {
+			t.Fatalf("expected 5 tasks, got %d", len(order))
+		}
+		for i, want := range []string{"a", "b", "c", "d", "e"} {
+			if order[i] != want {
+				t.Errorf("order[%d] = %q, want %q", i, order[i], want)
+			}
+		}
+	})
+}
+
+func TestSortByPriority(t *testing.T) {
+	tasks := map[string]*QueuedTask{
+		"a": {PlannedTask: ultraplan.PlannedTask{ID: "a", Priority: 5}},
+		"b": {PlannedTask: ultraplan.PlannedTask{ID: "b", Priority: 1}},
+		"c": {PlannedTask: ultraplan.PlannedTask{ID: "c", Priority: 3}},
+		"d": {PlannedTask: ultraplan.PlannedTask{ID: "d", Priority: -1}},
+	}
+	ids := []string{"a", "b", "c", "d"}
+	sortByPriority(ids, tasks)
+
+	want := []string{"d", "b", "c", "a"}
+	for i, id := range ids {
+		if id != want[i] {
+			t.Errorf("sortByPriority()[%d] = %q, want %q", i, id, want[i])
+		}
+	}
+}
+
+func TestSortByPriority_EmptyAndSingle(t *testing.T) {
+	tasks := map[string]*QueuedTask{
+		"a": {PlannedTask: ultraplan.PlannedTask{ID: "a", Priority: 1}},
+	}
+
+	// Empty slice should not panic
+	sortByPriority(nil, tasks)
+	sortByPriority([]string{}, tasks)
+
+	// Single element
+	ids := []string{"a"}
+	sortByPriority(ids, tasks)
+	if ids[0] != "a" {
+		t.Errorf("sortByPriority single = %v, want [a]", ids)
+	}
+}

--- a/internal/taskqueue/doc.go
+++ b/internal/taskqueue/doc.go
@@ -1,0 +1,28 @@
+// Package taskqueue provides a dynamic task queue with dependency-aware
+// claiming and work-stealing for Ultra-Plan execution.
+//
+// Instead of static execution order batches where all tasks in group N must
+// complete before group N+1 starts, taskqueue allows instances to claim the
+// next available task as soon as its dependencies are satisfied. This keeps
+// instances busy and reduces overall execution time.
+//
+// The core type is [TaskQueue], which holds all tasks from a [ultraplan.PlanSpec]
+// and provides thread-safe operations for claiming, completing, and failing tasks.
+// Dependencies are tracked internally so that completing a task automatically
+// unblocks downstream tasks for claiming.
+//
+// Queue state can be persisted to disk and restored, enabling crash recovery
+// during long-running plan executions.
+//
+// Usage:
+//
+//	queue := taskqueue.NewFromPlan(planSpec)
+//
+//	// Instance claims next available task
+//	task, err := queue.ClaimNext("instance-1")
+//	if task != nil {
+//	    queue.MarkRunning(task.ID)
+//	    // ... execute task ...
+//	    unblocked, err := queue.Complete(task.ID)
+//	}
+package taskqueue

--- a/internal/taskqueue/flock.go
+++ b/internal/taskqueue/flock.go
@@ -1,0 +1,82 @@
+package taskqueue
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+const lockFileName = "taskqueue.lock"
+
+// FileLock provides cross-process mutual exclusion using flock(2).
+// Used to protect queue state files when multiple Claudio processes
+// may be accessing the same session directory.
+type FileLock struct {
+	path string
+	file *os.File
+}
+
+// NewFileLock creates a FileLock for the given directory. The lock file
+// is created inside dir as "taskqueue.lock". Call Lock/Unlock to
+// acquire and release.
+func NewFileLock(dir string) *FileLock {
+	return &FileLock{
+		path: filepath.Join(dir, lockFileName),
+	}
+}
+
+// Lock acquires an exclusive file lock, blocking until available.
+// The lock file is created if it does not exist.
+func (fl *FileLock) Lock() error {
+	f, err := os.OpenFile(fl.path, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return fmt.Errorf("open lock file: %w", err)
+	}
+	fl.file = f
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		fl.file = nil
+		return fmt.Errorf("flock: %w", err)
+	}
+	return nil
+}
+
+// TryLock attempts to acquire the lock without blocking.
+// Returns true if the lock was acquired, false if it is held by another process.
+func (fl *FileLock) TryLock() (bool, error) {
+	f, err := os.OpenFile(fl.path, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return false, fmt.Errorf("open lock file: %w", err)
+	}
+
+	err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		_ = f.Close()
+		if err == syscall.EWOULDBLOCK {
+			return false, nil
+		}
+		return false, fmt.Errorf("flock: %w", err)
+	}
+
+	fl.file = f
+	return true, nil
+}
+
+// Unlock releases the file lock and closes the lock file.
+func (fl *FileLock) Unlock() error {
+	if fl.file == nil {
+		return nil
+	}
+
+	if err := syscall.Flock(int(fl.file.Fd()), syscall.LOCK_UN); err != nil {
+		_ = fl.file.Close()
+		fl.file = nil
+		return fmt.Errorf("funlock: %w", err)
+	}
+
+	err := fl.file.Close()
+	fl.file = nil
+	return err
+}

--- a/internal/taskqueue/flock_test.go
+++ b/internal/taskqueue/flock_test.go
@@ -1,0 +1,101 @@
+package taskqueue
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileLock_LockUnlock(t *testing.T) {
+	dir := t.TempDir()
+	fl := NewFileLock(dir)
+
+	if err := fl.Lock(); err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+
+	// Lock file should exist
+	lockPath := filepath.Join(dir, lockFileName)
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Errorf("lock file should exist: %v", err)
+	}
+
+	if err := fl.Unlock(); err != nil {
+		t.Fatalf("Unlock: %v", err)
+	}
+}
+
+func TestFileLock_UnlockWithoutLock(t *testing.T) {
+	dir := t.TempDir()
+	fl := NewFileLock(dir)
+
+	// Unlock without Lock should be a no-op
+	if err := fl.Unlock(); err != nil {
+		t.Fatalf("Unlock without Lock should not error: %v", err)
+	}
+}
+
+func TestFileLock_TryLock(t *testing.T) {
+	dir := t.TempDir()
+	fl := NewFileLock(dir)
+
+	acquired, err := fl.TryLock()
+	if err != nil {
+		t.Fatalf("TryLock: %v", err)
+	}
+	if !acquired {
+		t.Error("TryLock should succeed when lock is available")
+	}
+
+	// Second TryLock from a different FileLock should fail (same process
+	// can re-acquire on some OSes, but different fd should block)
+	fl2 := NewFileLock(dir)
+	acquired2, err := fl2.TryLock()
+	if err != nil {
+		t.Fatalf("TryLock2: %v", err)
+	}
+	// On some UNIX systems, flock is per-fd not per-process, so the
+	// second fd from the same process might succeed. This is acceptable
+	// since cross-process is the real use case. Just verify no error.
+	if acquired2 {
+		_ = fl2.Unlock()
+	}
+
+	if err := fl.Unlock(); err != nil {
+		t.Fatalf("Unlock: %v", err)
+	}
+}
+
+func TestFileLock_LockInvalidDir(t *testing.T) {
+	fl := NewFileLock("/nonexistent/dir/path")
+	if err := fl.Lock(); err == nil {
+		t.Error("Lock should fail for nonexistent directory")
+	}
+}
+
+func TestFileLock_TryLockInvalidDir(t *testing.T) {
+	fl := NewFileLock("/nonexistent/dir/path")
+	_, err := fl.TryLock()
+	if err == nil {
+		t.Error("TryLock should fail for nonexistent directory")
+	}
+}
+
+func TestFileLock_ReusableAfterUnlock(t *testing.T) {
+	dir := t.TempDir()
+	fl := NewFileLock(dir)
+
+	// Lock, unlock, lock again
+	if err := fl.Lock(); err != nil {
+		t.Fatalf("Lock 1: %v", err)
+	}
+	if err := fl.Unlock(); err != nil {
+		t.Fatalf("Unlock 1: %v", err)
+	}
+	if err := fl.Lock(); err != nil {
+		t.Fatalf("Lock 2: %v", err)
+	}
+	if err := fl.Unlock(); err != nil {
+		t.Fatalf("Unlock 2: %v", err)
+	}
+}

--- a/internal/taskqueue/persist.go
+++ b/internal/taskqueue/persist.go
@@ -1,0 +1,84 @@
+package taskqueue
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const stateFileName = "taskqueue-state.json"
+
+// persistedState is the serializable representation of the queue.
+type persistedState struct {
+	Tasks map[string]*QueuedTask `json:"tasks"`
+	Order []string               `json:"order"`
+}
+
+// SaveState writes the queue state to a JSON file in the given directory.
+// The write is atomic: data is written to a temporary file first, then
+// renamed into place. A file lock is held during the operation for
+// cross-process safety.
+func (q *TaskQueue) SaveState(dir string) error {
+	fl := NewFileLock(dir)
+	if err := fl.Lock(); err != nil {
+		return fmt.Errorf("acquire lock: %w", err)
+	}
+	defer func() { _ = fl.Unlock() }()
+
+	q.mu.Lock()
+	data, err := json.MarshalIndent(persistedState{
+		Tasks: q.tasks,
+		Order: q.order,
+	}, "", "  ")
+	q.mu.Unlock()
+	if err != nil {
+		return fmt.Errorf("marshal queue state: %w", err)
+	}
+
+	target := filepath.Join(dir, stateFileName)
+	tmp := target + ".tmp"
+
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return fmt.Errorf("write temp file: %w", err)
+	}
+
+	if err := os.Rename(tmp, target); err != nil {
+		_ = os.Remove(tmp) // best-effort cleanup
+		return fmt.Errorf("rename temp file: %w", err)
+	}
+
+	return nil
+}
+
+// LoadState restores a TaskQueue from a previously saved state file
+// in the given directory. A file lock is held during the read for
+// cross-process safety.
+func LoadState(dir string) (*TaskQueue, error) {
+	fl := NewFileLock(dir)
+	if err := fl.Lock(); err != nil {
+		return nil, fmt.Errorf("acquire lock: %w", err)
+	}
+	defer func() { _ = fl.Unlock() }()
+
+	target := filepath.Join(dir, stateFileName)
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		return nil, fmt.Errorf("read state file: %w", err)
+	}
+
+	var state persistedState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("unmarshal queue state: %w", err)
+	}
+
+	if state.Tasks == nil {
+		state.Tasks = make(map[string]*QueuedTask)
+	}
+	if state.Order == nil {
+		state.Order = []string{}
+	}
+
+	return newFromTasks(state.Tasks, state.Order), nil
+}

--- a/internal/taskqueue/persist_test.go
+++ b/internal/taskqueue/persist_test.go
@@ -1,0 +1,186 @@
+package taskqueue
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSaveAndLoadState(t *testing.T) {
+	q := NewFromPlan(makePlan())
+
+	// Modify some state
+	_, _ = q.ClaimNext("inst-1") // claims task-1
+	_ = q.MarkRunning("task-1")
+	_, _ = q.Complete("task-1")
+	_, _ = q.ClaimNext("inst-2") // claims task-3
+
+	dir := t.TempDir()
+	if err := q.SaveState(dir); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	// Verify file exists
+	statePath := filepath.Join(dir, stateFileName)
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("state file not found: %v", err)
+	}
+
+	// Load it back
+	loaded, err := LoadState(dir)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+
+	// Verify task states
+	if loaded.tasks["task-1"].Status != TaskCompleted {
+		t.Errorf("task-1 status = %s, want completed", loaded.tasks["task-1"].Status)
+	}
+	if loaded.tasks["task-3"].Status != TaskClaimed {
+		t.Errorf("task-3 status = %s, want claimed", loaded.tasks["task-3"].Status)
+	}
+	if loaded.tasks["task-3"].ClaimedBy != "inst-2" {
+		t.Errorf("task-3 ClaimedBy = %q, want inst-2", loaded.tasks["task-3"].ClaimedBy)
+	}
+	if loaded.tasks["task-2"].Status != TaskPending {
+		t.Errorf("task-2 status = %s, want pending", loaded.tasks["task-2"].Status)
+	}
+
+	// Verify order is preserved
+	if len(loaded.order) != len(q.order) {
+		t.Fatalf("order length = %d, want %d", len(loaded.order), len(q.order))
+	}
+	for i, id := range loaded.order {
+		if id != q.order[i] {
+			t.Errorf("order[%d] = %q, want %q", i, id, q.order[i])
+		}
+	}
+}
+
+func TestSaveState_AtomicWrite(t *testing.T) {
+	q := NewFromPlan(makePlan())
+	dir := t.TempDir()
+
+	if err := q.SaveState(dir); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	// Temp file should not exist after save
+	tmp := filepath.Join(dir, stateFileName+".tmp")
+	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
+		t.Error("temp file should be removed after atomic rename")
+	}
+}
+
+func TestSaveState_InvalidDirectory(t *testing.T) {
+	q := NewFromPlan(makePlan())
+	err := q.SaveState("/nonexistent/directory/path")
+	if err == nil {
+		t.Error("SaveState to nonexistent directory should fail")
+	}
+}
+
+func TestLoadState_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	_, err := LoadState(dir)
+	if err == nil {
+		t.Error("LoadState from empty directory should fail")
+	}
+}
+
+func TestLoadState_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, stateFileName)
+	if err := os.WriteFile(path, []byte("not json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadState(dir)
+	if err == nil {
+		t.Error("LoadState with invalid JSON should fail")
+	}
+}
+
+func TestLoadState_EmptyState(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, stateFileName)
+	if err := os.WriteFile(path, []byte(`{}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadState(dir)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if loaded.tasks == nil {
+		t.Error("tasks should be initialized, not nil")
+	}
+	if loaded.order == nil {
+		t.Error("order should be initialized, not nil")
+	}
+}
+
+func TestRoundTrip_PreservesTimestamps(t *testing.T) {
+	q := NewFromPlan(makePlan())
+	_, _ = q.ClaimNext("inst-1")
+	_ = q.MarkRunning("task-1")
+	_, _ = q.Complete("task-1")
+
+	dir := t.TempDir()
+	if err := q.SaveState(dir); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	loaded, err := LoadState(dir)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+
+	original := q.tasks["task-1"]
+	restored := loaded.tasks["task-1"]
+
+	if original.ClaimedAt == nil || restored.ClaimedAt == nil {
+		t.Fatal("ClaimedAt should be non-nil")
+	}
+	if !original.ClaimedAt.Round(time.Millisecond).Equal(restored.ClaimedAt.Round(time.Millisecond)) {
+		t.Errorf("ClaimedAt mismatch: %v vs %v", original.ClaimedAt, restored.ClaimedAt)
+	}
+
+	if original.CompletedAt == nil || restored.CompletedAt == nil {
+		t.Fatal("CompletedAt should be non-nil")
+	}
+	if !original.CompletedAt.Round(time.Millisecond).Equal(restored.CompletedAt.Round(time.Millisecond)) {
+		t.Errorf("CompletedAt mismatch: %v vs %v", original.CompletedAt, restored.CompletedAt)
+	}
+}
+
+func TestLoadedQueue_IsOperational(t *testing.T) {
+	q := NewFromPlan(makePlan())
+	_, _ = q.ClaimNext("inst-1") // task-1
+	_ = q.MarkRunning("task-1")
+	_, _ = q.Complete("task-1")
+
+	dir := t.TempDir()
+	_ = q.SaveState(dir)
+
+	loaded, err := LoadState(dir)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+
+	// Should be able to claim task-2 now (task-1 is completed)
+	task, err := loaded.ClaimNext("inst-2")
+	if err != nil {
+		t.Fatalf("ClaimNext on loaded queue: %v", err)
+	}
+	if task == nil {
+		t.Fatal("expected to claim task from loaded queue")
+	}
+	// task-2 depends on task-1 which is completed, so it's claimable
+	// task-3 has no deps and is also claimable, but task-2 may come first by order
+	// Both are valid
+	if task.ID != "task-2" && task.ID != "task-3" {
+		t.Errorf("claimed %q, want task-2 or task-3", task.ID)
+	}
+}

--- a/internal/taskqueue/queue.go
+++ b/internal/taskqueue/queue.go
@@ -1,0 +1,276 @@
+package taskqueue
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/ultraplan"
+)
+
+// Default maximum retries for failed tasks.
+const defaultMaxRetries = 2
+
+// Sentinel errors returned by queue operations.
+var (
+	ErrTaskNotFound      = errors.New("task not found")
+	ErrInvalidTransition = errors.New("invalid status transition")
+)
+
+// TaskQueue manages a set of tasks with dependency-aware claiming.
+// All methods are safe for concurrent use via an internal mutex.
+type TaskQueue struct {
+	mu     sync.Mutex
+	tasks  map[string]*QueuedTask // taskID -> task
+	claims map[string]string      // taskID -> instanceID
+	order  []string               // task IDs in priority/topological order
+}
+
+// NewFromPlan creates a TaskQueue from an Ultra-Plan specification.
+// Each PlannedTask is embedded into a QueuedTask, preserving all
+// planning fields. Dependencies come from each task's DependsOn field.
+func NewFromPlan(plan *ultraplan.PlanSpec) *TaskQueue {
+	tasks := make(map[string]*QueuedTask, len(plan.Tasks))
+	claims := make(map[string]string)
+	for i := range plan.Tasks {
+		pt := plan.Tasks[i]
+		if pt.DependsOn == nil {
+			pt.DependsOn = []string{}
+		}
+		tasks[pt.ID] = &QueuedTask{
+			PlannedTask: pt,
+			Status:      TaskPending,
+			MaxRetries:  defaultMaxRetries,
+		}
+	}
+
+	order := buildPriorityOrder(tasks)
+
+	return &TaskQueue{
+		tasks:  tasks,
+		claims: claims,
+		order:  order,
+	}
+}
+
+// newFromTasks creates a TaskQueue from pre-built task maps and order.
+// Used internally for loading persisted state.
+func newFromTasks(tasks map[string]*QueuedTask, order []string) *TaskQueue {
+	claims := make(map[string]string)
+	for id, task := range tasks {
+		if task.ClaimedBy != "" {
+			claims[id] = task.ClaimedBy
+		}
+	}
+	return &TaskQueue{
+		tasks:  tasks,
+		claims: claims,
+		order:  order,
+	}
+}
+
+// ClaimNext returns the next claimable task for the given instance.
+// A task is claimable if it is pending and all its dependencies are completed.
+// Returns nil with no error if no tasks are currently available.
+func (q *TaskQueue) ClaimNext(instanceID string) (*QueuedTask, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if instanceID == "" {
+		return nil, errors.New("instanceID must not be empty")
+	}
+
+	for _, id := range q.order {
+		task := q.tasks[id]
+		if q.isClaimable(task) {
+			now := time.Now()
+			task.Status = TaskClaimed
+			task.ClaimedBy = instanceID
+			task.ClaimedAt = &now
+			q.claims[task.ID] = instanceID
+			// Return a copy to avoid data races on the internal task pointer.
+			cp := *task
+			return &cp, nil
+		}
+	}
+	return nil, nil
+}
+
+// MarkRunning transitions a claimed task to the running state.
+func (q *TaskQueue) MarkRunning(taskID string) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	task, ok := q.tasks[taskID]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrTaskNotFound, taskID)
+	}
+	if task.Status != TaskClaimed {
+		return fmt.Errorf("%w: cannot transition %s from %s to running", ErrInvalidTransition, taskID, task.Status)
+	}
+	task.Status = TaskRunning
+	return nil
+}
+
+// Complete marks a task as completed and returns the IDs of tasks
+// that are newly claimable as a result.
+func (q *TaskQueue) Complete(taskID string) ([]string, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	task, ok := q.tasks[taskID]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrTaskNotFound, taskID)
+	}
+	if task.Status != TaskRunning && task.Status != TaskClaimed {
+		return nil, fmt.Errorf("%w: cannot complete task %s in status %s", ErrInvalidTransition, taskID, task.Status)
+	}
+	now := time.Now()
+	task.Status = TaskCompleted
+	task.CompletedAt = &now
+
+	unblocked := q.unblockedBy(taskID)
+	return unblocked, nil
+}
+
+// Fail marks a task as failed. If retries remain, the task is returned
+// to pending status for re-claiming. Otherwise it is permanently failed.
+func (q *TaskQueue) Fail(taskID, failureContext string) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	task, ok := q.tasks[taskID]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrTaskNotFound, taskID)
+	}
+	if task.Status != TaskRunning && task.Status != TaskClaimed {
+		return fmt.Errorf("%w: cannot fail task %s in status %s", ErrInvalidTransition, taskID, task.Status)
+	}
+
+	task.RetryCount++
+	task.FailureContext = failureContext
+
+	if task.RetryCount <= task.MaxRetries {
+		// Return to pending for retry
+		task.Status = TaskPending
+		task.ClaimedBy = ""
+		task.ClaimedAt = nil
+		delete(q.claims, taskID)
+	} else {
+		// Permanently failed
+		now := time.Now()
+		task.Status = TaskFailed
+		task.CompletedAt = &now
+	}
+	return nil
+}
+
+// Release returns a claimed or running task back to pending status.
+// Used for stale claim cleanup when an instance dies.
+func (q *TaskQueue) Release(taskID string) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	task, ok := q.tasks[taskID]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrTaskNotFound, taskID)
+	}
+	if task.Status != TaskClaimed && task.Status != TaskRunning {
+		return fmt.Errorf("%w: cannot release task %s in status %s", ErrInvalidTransition, taskID, task.Status)
+	}
+
+	task.Status = TaskPending
+	task.ClaimedBy = ""
+	task.ClaimedAt = nil
+	delete(q.claims, taskID)
+	return nil
+}
+
+// Status returns a snapshot of the current queue state counts.
+func (q *TaskQueue) Status() QueueStatus {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	var s QueueStatus
+	s.Total = len(q.tasks)
+	for _, task := range q.tasks {
+		switch task.Status {
+		case TaskPending:
+			s.Pending++
+		case TaskClaimed:
+			s.Claimed++
+		case TaskRunning:
+			s.Running++
+		case TaskCompleted:
+			s.Completed++
+		case TaskFailed:
+			s.Failed++
+		}
+	}
+	return s
+}
+
+// IsComplete returns true when all tasks are in a terminal state
+// (completed or permanently failed).
+func (q *TaskQueue) IsComplete() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	for _, task := range q.tasks {
+		if !task.Status.IsTerminal() {
+			return false
+		}
+	}
+	return len(q.tasks) > 0
+}
+
+// GetTask returns the task with the given ID, or nil if not found.
+func (q *TaskQueue) GetTask(taskID string) *QueuedTask {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	task, ok := q.tasks[taskID]
+	if !ok {
+		return nil
+	}
+	// Return a copy to avoid data races
+	cp := *task
+	return &cp
+}
+
+// ReleaseStaleClaimed releases tasks that have been claimed but not marked
+// running before the given cutoff time. Returns the IDs of released tasks.
+// This is used for recovering from instances that died while holding a claim.
+func (q *TaskQueue) ReleaseStaleClaimed(cutoff time.Time) []string {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	var released []string
+	for _, task := range q.tasks {
+		if task.Status == TaskClaimed && task.ClaimedAt != nil && task.ClaimedAt.Before(cutoff) {
+			task.Status = TaskPending
+			task.ClaimedBy = ""
+			task.ClaimedAt = nil
+			delete(q.claims, task.ID)
+			released = append(released, task.ID)
+		}
+	}
+	return released
+}
+
+// GetInstanceTasks returns all tasks claimed by or running on the given instance.
+func (q *TaskQueue) GetInstanceTasks(instanceID string) []*QueuedTask {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	var result []*QueuedTask
+	for _, id := range q.order {
+		task := q.tasks[id]
+		if task.ClaimedBy == instanceID {
+			cp := *task
+			result = append(result, &cp)
+		}
+	}
+	return result
+}

--- a/internal/taskqueue/queue_events.go
+++ b/internal/taskqueue/queue_events.go
@@ -1,0 +1,157 @@
+package taskqueue
+
+import (
+	"sync"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/event"
+)
+
+// EventQueue wraps a TaskQueue and publishes events to an event bus
+// whenever queue operations occur.
+type EventQueue struct {
+	mu  sync.Mutex
+	q   *TaskQueue
+	bus *event.Bus
+}
+
+// NewEventQueue creates an EventQueue that publishes events on the given bus.
+func NewEventQueue(q *TaskQueue, bus *event.Bus) *EventQueue {
+	return &EventQueue{q: q, bus: bus}
+}
+
+// ClaimNext claims the next available task and publishes a TaskClaimedEvent
+// and a QueueDepthChangedEvent.
+func (eq *EventQueue) ClaimNext(instanceID string) (*QueuedTask, error) {
+	eq.mu.Lock()
+	defer eq.mu.Unlock()
+
+	task, err := eq.q.ClaimNext(instanceID)
+	if err != nil {
+		return nil, err
+	}
+	if task == nil {
+		return nil, nil
+	}
+
+	eq.bus.Publish(event.NewTaskClaimedEvent(task.ID, instanceID))
+	eq.publishDepth()
+	return task, nil
+}
+
+// MarkRunning transitions a task to running and publishes a QueueDepthChangedEvent.
+func (eq *EventQueue) MarkRunning(taskID string) error {
+	eq.mu.Lock()
+	defer eq.mu.Unlock()
+
+	if err := eq.q.MarkRunning(taskID); err != nil {
+		return err
+	}
+	eq.publishDepth()
+	return nil
+}
+
+// Complete marks a task completed and publishes a QueueDepthChangedEvent.
+// Returns the list of newly unblocked task IDs.
+func (eq *EventQueue) Complete(taskID string) ([]string, error) {
+	eq.mu.Lock()
+	defer eq.mu.Unlock()
+
+	unblocked, err := eq.q.Complete(taskID)
+	if err != nil {
+		return nil, err
+	}
+	eq.publishDepth()
+	return unblocked, nil
+}
+
+// Fail marks a task as failed and publishes a QueueDepthChangedEvent.
+func (eq *EventQueue) Fail(taskID, failureContext string) error {
+	eq.mu.Lock()
+	defer eq.mu.Unlock()
+
+	if err := eq.q.Fail(taskID, failureContext); err != nil {
+		return err
+	}
+	eq.publishDepth()
+	return nil
+}
+
+// Release returns a task to the queue and publishes TaskReleasedEvent
+// and QueueDepthChangedEvent.
+func (eq *EventQueue) Release(taskID, reason string) error {
+	eq.mu.Lock()
+	defer eq.mu.Unlock()
+
+	if err := eq.q.Release(taskID); err != nil {
+		return err
+	}
+	eq.bus.Publish(event.NewTaskReleasedEvent(taskID, reason))
+	eq.publishDepth()
+	return nil
+}
+
+// Status returns the current queue status snapshot.
+func (eq *EventQueue) Status() QueueStatus {
+	return eq.q.Status()
+}
+
+// IsComplete returns true when all tasks are in a terminal state.
+func (eq *EventQueue) IsComplete() bool {
+	return eq.q.IsComplete()
+}
+
+// GetTask returns the task with the given ID.
+func (eq *EventQueue) GetTask(taskID string) *QueuedTask {
+	return eq.q.GetTask(taskID)
+}
+
+// GetInstanceTasks returns all tasks for the given instance.
+func (eq *EventQueue) GetInstanceTasks(instanceID string) []*QueuedTask {
+	return eq.q.GetInstanceTasks(instanceID)
+}
+
+// SaveState persists the queue state to disk.
+func (eq *EventQueue) SaveState(dir string) error {
+	return eq.q.SaveState(dir)
+}
+
+// publishDepth publishes a QueueDepthChangedEvent with current counts.
+// Must be called while eq.mu is held.
+func (eq *EventQueue) publishDepth() {
+	s := eq.q.Status()
+	eq.bus.Publish(event.NewQueueDepthChangedEvent(
+		s.Pending, s.Claimed, s.Running, s.Completed, s.Failed, s.Total,
+	))
+}
+
+// Ensure the new event types satisfy the Event interface at compile time.
+var (
+	_ event.Event = event.TaskClaimedEvent{}
+	_ event.Event = event.TaskReleasedEvent{}
+	_ event.Event = event.QueueDepthChangedEvent{}
+)
+
+// Ensure error sentinels are usable with errors.Is.
+var (
+	_ error = ErrTaskNotFound
+	_ error = ErrInvalidTransition
+)
+
+// ClaimStaleBefore releases tasks that have been claimed but not marked
+// running before the given cutoff time. This is useful for recovering from
+// instances that died while holding a claim.
+func (eq *EventQueue) ClaimStaleBefore(cutoff time.Time) []string {
+	eq.mu.Lock()
+	defer eq.mu.Unlock()
+
+	released := eq.q.ReleaseStaleClaimed(cutoff)
+
+	for _, id := range released {
+		eq.bus.Publish(event.NewTaskReleasedEvent(id, "stale_claim"))
+	}
+	if len(released) > 0 {
+		eq.publishDepth()
+	}
+	return released
+}

--- a/internal/taskqueue/queue_events_test.go
+++ b/internal/taskqueue/queue_events_test.go
@@ -1,0 +1,448 @@
+package taskqueue
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/event"
+	"github.com/Iron-Ham/claudio/internal/ultraplan"
+)
+
+func makeEventPlan() *ultraplan.PlanSpec {
+	return &ultraplan.PlanSpec{
+		ID: "event-test",
+		Tasks: []ultraplan.PlannedTask{
+			{
+				ID:            "t1",
+				Title:         "Task 1",
+				Description:   "First",
+				DependsOn:     []string{},
+				EstComplexity: ultraplan.ComplexityLow,
+			},
+			{
+				ID:            "t2",
+				Title:         "Task 2",
+				Description:   "Second",
+				DependsOn:     []string{"t1"},
+				EstComplexity: ultraplan.ComplexityMedium,
+			},
+		},
+	}
+}
+
+type eventCollector struct {
+	mu     sync.Mutex
+	events []event.Event
+}
+
+func (c *eventCollector) handler(e event.Event) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, e)
+}
+
+func (c *eventCollector) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.events)
+}
+
+func (c *eventCollector) findByType(eventType string) []event.Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var found []event.Event
+	for _, e := range c.events {
+		if e.EventType() == eventType {
+			found = append(found, e)
+		}
+	}
+	return found
+}
+
+func TestEventQueue_ClaimNext(t *testing.T) {
+	bus := event.NewBus()
+	col := &eventCollector{}
+	bus.SubscribeAll(col.handler)
+
+	q := NewFromPlan(makeEventPlan())
+	eq := NewEventQueue(q, bus)
+
+	task, err := eq.ClaimNext("inst-1")
+	if err != nil {
+		t.Fatalf("ClaimNext: %v", err)
+	}
+	if task == nil {
+		t.Fatal("expected a task")
+	}
+
+	claimed := col.findByType("queue.task_claimed")
+	if len(claimed) != 1 {
+		t.Fatalf("expected 1 TaskClaimedEvent, got %d", len(claimed))
+	}
+	ce := claimed[0].(event.TaskClaimedEvent)
+	if ce.TaskID != task.ID {
+		t.Errorf("TaskClaimedEvent.TaskID = %q, want %q", ce.TaskID, task.ID)
+	}
+	if ce.InstanceID != "inst-1" {
+		t.Errorf("TaskClaimedEvent.InstanceID = %q, want inst-1", ce.InstanceID)
+	}
+
+	depth := col.findByType("queue.depth_changed")
+	if len(depth) != 1 {
+		t.Fatalf("expected 1 QueueDepthChangedEvent, got %d", len(depth))
+	}
+	de := depth[0].(event.QueueDepthChangedEvent)
+	if de.Claimed != 1 {
+		t.Errorf("QueueDepthChangedEvent.Claimed = %d, want 1", de.Claimed)
+	}
+}
+
+func TestEventQueue_ClaimNext_NilReturnsNoEvents(t *testing.T) {
+	bus := event.NewBus()
+	col := &eventCollector{}
+	bus.SubscribeAll(col.handler)
+
+	plan := &ultraplan.PlanSpec{
+		ID: "empty",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "t1", DependsOn: []string{"t2"}, EstComplexity: ultraplan.ComplexityLow},
+			{ID: "t2", DependsOn: []string{"t1"}, EstComplexity: ultraplan.ComplexityLow},
+		},
+	}
+	q := NewFromPlan(plan)
+	eq := NewEventQueue(q, bus)
+
+	// Circular deps means nothing claimable. ClaimNext should return nil
+	// and no events should be published.
+	task, err := eq.ClaimNext("inst-1")
+	if err != nil {
+		t.Fatalf("ClaimNext: %v", err)
+	}
+	if task != nil {
+		t.Errorf("expected nil task, got %q", task.ID)
+	}
+	if col.count() != 0 {
+		t.Errorf("expected 0 events, got %d", col.count())
+	}
+}
+
+func TestEventQueue_MarkRunning(t *testing.T) {
+	bus := event.NewBus()
+	col := &eventCollector{}
+	bus.SubscribeAll(col.handler)
+
+	q := NewFromPlan(makeEventPlan())
+	eq := NewEventQueue(q, bus)
+	task, _ := eq.ClaimNext("inst-1")
+
+	// Clear collector
+	*col = eventCollector{}
+
+	if err := eq.MarkRunning(task.ID); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	depth := col.findByType("queue.depth_changed")
+	if len(depth) != 1 {
+		t.Fatalf("expected 1 QueueDepthChangedEvent, got %d", len(depth))
+	}
+	de := depth[0].(event.QueueDepthChangedEvent)
+	if de.Running != 1 {
+		t.Errorf("Running = %d, want 1", de.Running)
+	}
+}
+
+func TestEventQueue_MarkRunning_Error(t *testing.T) {
+	bus := event.NewBus()
+	col := &eventCollector{}
+	bus.SubscribeAll(col.handler)
+
+	q := NewFromPlan(makeEventPlan())
+	eq := NewEventQueue(q, bus)
+
+	err := eq.MarkRunning("t1") // still pending, not claimed
+	if err == nil {
+		t.Error("expected error for pending task")
+	}
+	if col.count() != 0 {
+		t.Errorf("expected 0 events on error, got %d", col.count())
+	}
+}
+
+func TestEventQueue_Complete(t *testing.T) {
+	bus := event.NewBus()
+	col := &eventCollector{}
+	bus.SubscribeAll(col.handler)
+
+	q := NewFromPlan(makeEventPlan())
+	eq := NewEventQueue(q, bus)
+	task, _ := eq.ClaimNext("inst-1")
+	_ = eq.MarkRunning(task.ID)
+
+	*col = eventCollector{}
+
+	unblocked, err := eq.Complete(task.ID)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(unblocked) != 1 || unblocked[0] != "t2" {
+		t.Errorf("unblocked = %v, want [t2]", unblocked)
+	}
+
+	depth := col.findByType("queue.depth_changed")
+	if len(depth) != 1 {
+		t.Fatalf("expected 1 QueueDepthChangedEvent, got %d", len(depth))
+	}
+	de := depth[0].(event.QueueDepthChangedEvent)
+	if de.Completed != 1 {
+		t.Errorf("Completed = %d, want 1", de.Completed)
+	}
+}
+
+func TestEventQueue_Complete_Error(t *testing.T) {
+	bus := event.NewBus()
+	col := &eventCollector{}
+	bus.SubscribeAll(col.handler)
+
+	q := NewFromPlan(makeEventPlan())
+	eq := NewEventQueue(q, bus)
+
+	_, err := eq.Complete("nonexistent")
+	if err == nil {
+		t.Error("expected error")
+	}
+	if col.count() != 0 {
+		t.Errorf("expected 0 events on error, got %d", col.count())
+	}
+}
+
+func TestEventQueue_Fail(t *testing.T) {
+	bus := event.NewBus()
+	col := &eventCollector{}
+	bus.SubscribeAll(col.handler)
+
+	q := NewFromPlan(makeEventPlan())
+	eq := NewEventQueue(q, bus)
+	task, _ := eq.ClaimNext("inst-1")
+	_ = eq.MarkRunning(task.ID)
+
+	*col = eventCollector{}
+
+	if err := eq.Fail(task.ID, "crash"); err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+
+	depth := col.findByType("queue.depth_changed")
+	if len(depth) != 1 {
+		t.Fatalf("expected 1 QueueDepthChangedEvent, got %d", len(depth))
+	}
+}
+
+func TestEventQueue_Fail_Error(t *testing.T) {
+	bus := event.NewBus()
+	col := &eventCollector{}
+	bus.SubscribeAll(col.handler)
+
+	q := NewFromPlan(makeEventPlan())
+	eq := NewEventQueue(q, bus)
+
+	err := eq.Fail("nonexistent", "err")
+	if err == nil {
+		t.Error("expected error")
+	}
+	if col.count() != 0 {
+		t.Errorf("expected 0 events on error, got %d", col.count())
+	}
+}
+
+func TestEventQueue_Release(t *testing.T) {
+	bus := event.NewBus()
+	col := &eventCollector{}
+	bus.SubscribeAll(col.handler)
+
+	q := NewFromPlan(makeEventPlan())
+	eq := NewEventQueue(q, bus)
+	task, _ := eq.ClaimNext("inst-1")
+
+	*col = eventCollector{}
+
+	if err := eq.Release(task.ID, "instance_died"); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	released := col.findByType("queue.task_released")
+	if len(released) != 1 {
+		t.Fatalf("expected 1 TaskReleasedEvent, got %d", len(released))
+	}
+	re := released[0].(event.TaskReleasedEvent)
+	if re.TaskID != task.ID {
+		t.Errorf("TaskReleasedEvent.TaskID = %q, want %q", re.TaskID, task.ID)
+	}
+	if re.Reason != "instance_died" {
+		t.Errorf("TaskReleasedEvent.Reason = %q, want instance_died", re.Reason)
+	}
+
+	depth := col.findByType("queue.depth_changed")
+	if len(depth) != 1 {
+		t.Fatalf("expected 1 QueueDepthChangedEvent, got %d", len(depth))
+	}
+}
+
+func TestEventQueue_Release_Error(t *testing.T) {
+	bus := event.NewBus()
+	col := &eventCollector{}
+	bus.SubscribeAll(col.handler)
+
+	q := NewFromPlan(makeEventPlan())
+	eq := NewEventQueue(q, bus)
+
+	err := eq.Release("nonexistent", "reason")
+	if err == nil {
+		t.Error("expected error")
+	}
+	if col.count() != 0 {
+		t.Errorf("expected 0 events on error, got %d", col.count())
+	}
+}
+
+func TestEventQueue_Passthrough(t *testing.T) {
+	bus := event.NewBus()
+	q := NewFromPlan(makeEventPlan())
+	eq := NewEventQueue(q, bus)
+
+	// Status
+	s := eq.Status()
+	if s.Total != 2 {
+		t.Errorf("Status().Total = %d, want 2", s.Total)
+	}
+
+	// IsComplete
+	if eq.IsComplete() {
+		t.Error("IsComplete should be false")
+	}
+
+	// GetTask
+	task := eq.GetTask("t1")
+	if task == nil {
+		t.Error("GetTask returned nil")
+	}
+
+	// GetInstanceTasks
+	_, _ = eq.ClaimNext("inst-1")
+	tasks := eq.GetInstanceTasks("inst-1")
+	if len(tasks) != 1 {
+		t.Errorf("GetInstanceTasks = %d, want 1", len(tasks))
+	}
+
+	// SaveState
+	dir := t.TempDir()
+	if err := eq.SaveState(dir); err != nil {
+		t.Errorf("SaveState: %v", err)
+	}
+}
+
+func TestEventQueue_ClaimStaleBefore(t *testing.T) {
+	bus := event.NewBus()
+	col := &eventCollector{}
+	bus.SubscribeAll(col.handler)
+
+	plan := &ultraplan.PlanSpec{
+		ID: "stale-test",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "t1", DependsOn: []string{}, EstComplexity: ultraplan.ComplexityLow},
+			{ID: "t2", DependsOn: []string{}, EstComplexity: ultraplan.ComplexityLow},
+		},
+	}
+	q := NewFromPlan(plan)
+	eq := NewEventQueue(q, bus)
+
+	// Claim both tasks
+	_, _ = eq.ClaimNext("inst-1")
+	_, _ = eq.ClaimNext("inst-2")
+
+	// Manually set task-1 claimed time to the past
+	q.mu.Lock()
+	past := time.Now().Add(-10 * time.Minute)
+	q.tasks["t1"].ClaimedAt = &past
+	q.mu.Unlock()
+
+	*col = eventCollector{}
+
+	// Release claims older than 5 minutes
+	cutoff := time.Now().Add(-5 * time.Minute)
+	released := eq.ClaimStaleBefore(cutoff)
+
+	if len(released) != 1 || released[0] != "t1" {
+		t.Errorf("released = %v, want [t1]", released)
+	}
+
+	// Check task is back to pending
+	task := eq.GetTask("t1")
+	if task.Status != TaskPending {
+		t.Errorf("t1 status = %s, want pending", task.Status)
+	}
+
+	// Check events
+	releasedEvents := col.findByType("queue.task_released")
+	if len(releasedEvents) != 1 {
+		t.Fatalf("expected 1 TaskReleasedEvent, got %d", len(releasedEvents))
+	}
+	re := releasedEvents[0].(event.TaskReleasedEvent)
+	if re.Reason != "stale_claim" {
+		t.Errorf("Reason = %q, want stale_claim", re.Reason)
+	}
+
+	depthEvents := col.findByType("queue.depth_changed")
+	if len(depthEvents) != 1 {
+		t.Fatalf("expected 1 QueueDepthChangedEvent, got %d", len(depthEvents))
+	}
+}
+
+func TestEventQueue_ClaimStaleBefore_NoneStale(t *testing.T) {
+	bus := event.NewBus()
+	col := &eventCollector{}
+	bus.SubscribeAll(col.handler)
+
+	q := NewFromPlan(makeEventPlan())
+	eq := NewEventQueue(q, bus)
+	_, _ = eq.ClaimNext("inst-1")
+
+	*col = eventCollector{}
+
+	// All claims are fresh
+	cutoff := time.Now().Add(-5 * time.Minute)
+	released := eq.ClaimStaleBefore(cutoff)
+
+	if len(released) != 0 {
+		t.Errorf("released = %v, want empty", released)
+	}
+	if col.count() != 0 {
+		t.Errorf("expected 0 events, got %d", col.count())
+	}
+}
+
+func TestNewEventTypes_SatisfyInterface(t *testing.T) {
+	// Verify the constructors produce valid events
+	claimed := event.NewTaskClaimedEvent("task-1", "inst-1")
+	if claimed.EventType() != "queue.task_claimed" {
+		t.Errorf("TaskClaimedEvent.EventType() = %q", claimed.EventType())
+	}
+	if claimed.Timestamp().IsZero() {
+		t.Error("TaskClaimedEvent timestamp should not be zero")
+	}
+
+	released := event.NewTaskReleasedEvent("task-1", "stale")
+	if released.EventType() != "queue.task_released" {
+		t.Errorf("TaskReleasedEvent.EventType() = %q", released.EventType())
+	}
+
+	depth := event.NewQueueDepthChangedEvent(1, 2, 3, 4, 5, 15)
+	if depth.EventType() != "queue.depth_changed" {
+		t.Errorf("QueueDepthChangedEvent.EventType() = %q", depth.EventType())
+	}
+	if depth.Pending != 1 || depth.Claimed != 2 || depth.Running != 3 ||
+		depth.Completed != 4 || depth.Failed != 5 || depth.Total != 15 {
+		t.Errorf("QueueDepthChangedEvent fields incorrect: %+v", depth)
+	}
+}

--- a/internal/taskqueue/queue_test.go
+++ b/internal/taskqueue/queue_test.go
@@ -1,0 +1,774 @@
+package taskqueue
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/ultraplan"
+)
+
+func makePlan() *ultraplan.PlanSpec {
+	return &ultraplan.PlanSpec{
+		ID:        "test-plan",
+		Objective: "test",
+		Tasks: []ultraplan.PlannedTask{
+			{
+				ID:            "task-1",
+				Title:         "First task",
+				Description:   "Do first thing",
+				Files:         []string{"a.go"},
+				DependsOn:     []string{},
+				Priority:      0,
+				EstComplexity: ultraplan.ComplexityLow,
+			},
+			{
+				ID:            "task-2",
+				Title:         "Second task",
+				Description:   "Do second thing",
+				Files:         []string{"b.go"},
+				DependsOn:     []string{"task-1"},
+				Priority:      0,
+				EstComplexity: ultraplan.ComplexityMedium,
+			},
+			{
+				ID:            "task-3",
+				Title:         "Third task",
+				Description:   "Do third thing",
+				DependsOn:     nil,
+				Priority:      1,
+				EstComplexity: ultraplan.ComplexityHigh,
+			},
+		},
+		DependencyGraph: map[string][]string{
+			"task-1": {},
+			"task-2": {"task-1"},
+			"task-3": {},
+		},
+	}
+}
+
+func TestNewFromPlan(t *testing.T) {
+	plan := makePlan()
+	q := NewFromPlan(plan)
+
+	if len(q.tasks) != 3 {
+		t.Fatalf("expected 3 tasks, got %d", len(q.tasks))
+	}
+	if len(q.order) != 3 {
+		t.Fatalf("expected 3 in order, got %d", len(q.order))
+	}
+
+	// All tasks should be pending
+	for _, task := range q.tasks {
+		if task.Status != TaskPending {
+			t.Errorf("task %q status = %s, want pending", task.ID, task.Status)
+		}
+	}
+
+	// task-1 should come before task-2 in order (dependency)
+	idx := make(map[string]int)
+	for i, id := range q.order {
+		idx[id] = i
+	}
+	if idx["task-1"] > idx["task-2"] {
+		t.Errorf("task-1 (idx %d) should come before task-2 (idx %d)", idx["task-1"], idx["task-2"])
+	}
+
+	// Check DependsOn is never nil
+	for _, task := range q.tasks {
+		if task.DependsOn == nil {
+			t.Errorf("task %q DependsOn should not be nil", task.ID)
+		}
+	}
+
+	// Check EstComplexity is preserved via embedded PlannedTask
+	if q.tasks["task-1"].EstComplexity != ultraplan.ComplexityLow {
+		t.Errorf("task-1 EstComplexity = %q, want %q", q.tasks["task-1"].EstComplexity, ultraplan.ComplexityLow)
+	}
+
+	// Check that PlannedTask fields are accessible via embedding
+	if q.tasks["task-1"].Title != "First task" {
+		t.Errorf("task-1 Title = %q, want %q", q.tasks["task-1"].Title, "First task")
+	}
+	if len(q.tasks["task-1"].Files) != 1 || q.tasks["task-1"].Files[0] != "a.go" {
+		t.Errorf("task-1 Files = %v, want [a.go]", q.tasks["task-1"].Files)
+	}
+
+	// Claims map should be initialized and empty
+	if q.claims == nil {
+		t.Error("claims map should be initialized")
+	}
+	if len(q.claims) != 0 {
+		t.Errorf("claims should be empty, got %d entries", len(q.claims))
+	}
+}
+
+func TestClaimNext(t *testing.T) {
+	plan := makePlan()
+	q := NewFromPlan(plan)
+
+	// First claim should get task-1 or task-3 (both have no deps, task-1 has priority 0)
+	task, err := q.ClaimNext("inst-1")
+	if err != nil {
+		t.Fatalf("ClaimNext: %v", err)
+	}
+	if task == nil {
+		t.Fatal("ClaimNext returned nil, expected a task")
+	}
+	// task-1 has priority 0, task-3 has priority 1, so task-1 first
+	if task.ID != "task-1" {
+		t.Errorf("first claim = %q, want task-1", task.ID)
+	}
+	if task.Status != TaskClaimed {
+		t.Errorf("claimed task status = %s, want claimed", task.Status)
+	}
+	if task.ClaimedBy != "inst-1" {
+		t.Errorf("claimed task ClaimedBy = %q, want inst-1", task.ClaimedBy)
+	}
+	if task.ClaimedAt == nil {
+		t.Error("claimed task ClaimedAt should not be nil")
+	}
+
+	// Claims map should be updated
+	if q.claims["task-1"] != "inst-1" {
+		t.Errorf("claims[task-1] = %q, want inst-1", q.claims["task-1"])
+	}
+
+	// Second claim should get task-3 (task-2 depends on task-1 which is only claimed)
+	task2, err := q.ClaimNext("inst-2")
+	if err != nil {
+		t.Fatalf("ClaimNext: %v", err)
+	}
+	if task2 == nil {
+		t.Fatal("ClaimNext returned nil, expected task-3")
+	}
+	if task2.ID != "task-3" {
+		t.Errorf("second claim = %q, want task-3", task2.ID)
+	}
+
+	// Third claim should return nil (task-2 blocked, others claimed)
+	task3, err := q.ClaimNext("inst-3")
+	if err != nil {
+		t.Fatalf("ClaimNext: %v", err)
+	}
+	if task3 != nil {
+		t.Errorf("third claim = %q, want nil", task3.ID)
+	}
+}
+
+func TestClaimNext_EmptyInstanceID(t *testing.T) {
+	plan := makePlan()
+	q := NewFromPlan(plan)
+
+	_, err := q.ClaimNext("")
+	if err == nil {
+		t.Error("ClaimNext with empty instanceID should return error")
+	}
+}
+
+func TestClaimNext_ConcurrentClaims(t *testing.T) {
+	// Create a plan with many independent tasks
+	plan := &ultraplan.PlanSpec{
+		ID: "concurrent-test",
+		Tasks: func() []ultraplan.PlannedTask {
+			var tasks []ultraplan.PlannedTask
+			for i := 0; i < 20; i++ {
+				tasks = append(tasks, ultraplan.PlannedTask{
+					ID:            fmt.Sprintf("task-%d", i),
+					Title:         fmt.Sprintf("Task %d", i),
+					DependsOn:     []string{},
+					Priority:      i,
+					EstComplexity: ultraplan.ComplexityLow,
+				})
+			}
+			return tasks
+		}(),
+	}
+	q := NewFromPlan(plan)
+
+	const numGoroutines = 10
+	var wg sync.WaitGroup
+	claimed := make(chan string, 20)
+
+	wg.Add(numGoroutines)
+	for g := 0; g < numGoroutines; g++ {
+		go func(instanceID string) {
+			defer wg.Done()
+			for {
+				task, err := q.ClaimNext(instanceID)
+				if err != nil {
+					t.Errorf("ClaimNext error: %v", err)
+					return
+				}
+				if task == nil {
+					return // no more tasks
+				}
+				claimed <- task.ID
+				_ = q.MarkRunning(task.ID)
+				_, _ = q.Complete(task.ID)
+			}
+		}(fmt.Sprintf("inst-%d", g))
+	}
+
+	wg.Wait()
+	close(claimed)
+
+	// Collect all claimed task IDs
+	seen := make(map[string]bool)
+	for id := range claimed {
+		if seen[id] {
+			t.Errorf("task %q was claimed more than once", id)
+		}
+		seen[id] = true
+	}
+
+	// All 20 tasks should have been claimed exactly once
+	if len(seen) != 20 {
+		t.Errorf("expected 20 unique claims, got %d", len(seen))
+	}
+
+	// Queue should be complete
+	if !q.IsComplete() {
+		t.Error("queue should be complete after all tasks claimed and completed")
+	}
+}
+
+func TestClaimNext_ConcurrentWithDeps(t *testing.T) {
+	// Diamond dependency: a -> b, a -> c, b+c -> d
+	plan := &ultraplan.PlanSpec{
+		ID: "concurrent-deps",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "a", DependsOn: []string{}, Priority: 0, EstComplexity: ultraplan.ComplexityLow},
+			{ID: "b", DependsOn: []string{"a"}, Priority: 0, EstComplexity: ultraplan.ComplexityLow},
+			{ID: "c", DependsOn: []string{"a"}, Priority: 1, EstComplexity: ultraplan.ComplexityLow},
+			{ID: "d", DependsOn: []string{"b", "c"}, Priority: 0, EstComplexity: ultraplan.ComplexityLow},
+		},
+	}
+	q := NewFromPlan(plan)
+
+	const numGoroutines = 4
+	var wg sync.WaitGroup
+	claimed := make(chan string, 10)
+
+	wg.Add(numGoroutines)
+	for g := 0; g < numGoroutines; g++ {
+		go func(instanceID string) {
+			defer wg.Done()
+			for {
+				task, err := q.ClaimNext(instanceID)
+				if err != nil {
+					t.Errorf("ClaimNext error: %v", err)
+					return
+				}
+				if task == nil {
+					// Check if queue is complete
+					if q.IsComplete() {
+						return
+					}
+					// Might need to wait for deps
+					time.Sleep(time.Millisecond)
+					if q.IsComplete() {
+						return
+					}
+					continue
+				}
+				claimed <- task.ID
+				_ = q.MarkRunning(task.ID)
+				_, _ = q.Complete(task.ID)
+			}
+		}(fmt.Sprintf("inst-%d", g))
+	}
+
+	wg.Wait()
+	close(claimed)
+
+	seen := make(map[string]bool)
+	for id := range claimed {
+		if seen[id] {
+			t.Errorf("task %q was claimed more than once", id)
+		}
+		seen[id] = true
+	}
+
+	if len(seen) != 4 {
+		t.Errorf("expected 4 unique claims, got %d", len(seen))
+	}
+	if !q.IsComplete() {
+		t.Errorf("queue should be complete")
+	}
+}
+
+func TestMarkRunning(t *testing.T) {
+	plan := makePlan()
+	q := NewFromPlan(plan)
+
+	task, _ := q.ClaimNext("inst-1")
+
+	if err := q.MarkRunning(task.ID); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+	if q.tasks[task.ID].Status != TaskRunning {
+		t.Errorf("status = %s, want running", q.tasks[task.ID].Status)
+	}
+
+	// Cannot mark running again
+	if err := q.MarkRunning(task.ID); err == nil {
+		t.Error("MarkRunning on running task should fail")
+	}
+}
+
+func TestMarkRunning_NotFound(t *testing.T) {
+	q := NewFromPlan(makePlan())
+	if err := q.MarkRunning("nonexistent"); err == nil {
+		t.Error("MarkRunning on nonexistent task should fail")
+	}
+}
+
+func TestMarkRunning_PendingTask(t *testing.T) {
+	q := NewFromPlan(makePlan())
+	if err := q.MarkRunning("task-1"); err == nil {
+		t.Error("MarkRunning on pending task should fail")
+	}
+}
+
+func TestComplete(t *testing.T) {
+	plan := makePlan()
+	q := NewFromPlan(plan)
+
+	// Claim and run task-1
+	task, _ := q.ClaimNext("inst-1")
+	_ = q.MarkRunning(task.ID)
+
+	unblocked, err := q.Complete(task.ID)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if q.tasks[task.ID].Status != TaskCompleted {
+		t.Errorf("status = %s, want completed", q.tasks[task.ID].Status)
+	}
+	if q.tasks[task.ID].CompletedAt == nil {
+		t.Error("CompletedAt should not be nil")
+	}
+
+	// Should unblock task-2
+	if len(unblocked) != 1 || unblocked[0] != "task-2" {
+		t.Errorf("unblocked = %v, want [task-2]", unblocked)
+	}
+}
+
+func TestComplete_FromClaimed(t *testing.T) {
+	q := NewFromPlan(makePlan())
+	_, _ = q.ClaimNext("inst-1") // claims task-1
+
+	// Complete directly from claimed state (allowed)
+	unblocked, err := q.Complete("task-1")
+	if err != nil {
+		t.Fatalf("Complete from claimed: %v", err)
+	}
+	if q.tasks["task-1"].Status != TaskCompleted {
+		t.Errorf("status = %s, want completed", q.tasks["task-1"].Status)
+	}
+	if len(unblocked) != 1 || unblocked[0] != "task-2" {
+		t.Errorf("unblocked = %v, want [task-2]", unblocked)
+	}
+}
+
+func TestComplete_NotFound(t *testing.T) {
+	q := NewFromPlan(makePlan())
+	_, err := q.Complete("nonexistent")
+	if err == nil {
+		t.Error("Complete on nonexistent task should fail")
+	}
+}
+
+func TestComplete_InvalidTransition(t *testing.T) {
+	q := NewFromPlan(makePlan())
+	// task-1 is pending
+	_, err := q.Complete("task-1")
+	if err == nil {
+		t.Error("Complete on pending task should fail")
+	}
+}
+
+func TestFail_WithRetries(t *testing.T) {
+	plan := makePlan()
+	q := NewFromPlan(plan)
+
+	task, _ := q.ClaimNext("inst-1")
+	_ = q.MarkRunning(task.ID)
+
+	// First failure, retries remain
+	if err := q.Fail(task.ID, "timeout"); err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+	if q.tasks[task.ID].Status != TaskPending {
+		t.Errorf("status = %s, want pending (retry)", q.tasks[task.ID].Status)
+	}
+	if q.tasks[task.ID].RetryCount != 1 {
+		t.Errorf("RetryCount = %d, want 1", q.tasks[task.ID].RetryCount)
+	}
+	if q.tasks[task.ID].FailureContext != "timeout" {
+		t.Errorf("FailureContext = %q, want timeout", q.tasks[task.ID].FailureContext)
+	}
+	if q.tasks[task.ID].ClaimedBy != "" {
+		t.Error("ClaimedBy should be cleared on retry")
+	}
+	if q.tasks[task.ID].ClaimedAt != nil {
+		t.Error("ClaimedAt should be nil on retry")
+	}
+	// Claims map should be cleared
+	if _, ok := q.claims[task.ID]; ok {
+		t.Error("claims map should not contain failed task on retry")
+	}
+}
+
+func TestFail_ExhaustedRetries(t *testing.T) {
+	plan := makePlan()
+	q := NewFromPlan(plan)
+
+	// Exhaust all retries (default 2)
+	for i := 0; i <= defaultMaxRetries; i++ {
+		task, _ := q.ClaimNext("inst-1")
+		if task == nil {
+			t.Fatalf("iteration %d: expected task, got nil", i)
+		}
+		_ = q.MarkRunning(task.ID)
+		if err := q.Fail(task.ID, "fail"); err != nil {
+			t.Fatalf("iteration %d Fail: %v", i, err)
+		}
+	}
+
+	// After exhausting retries, task-1 should be permanently failed
+	if q.tasks["task-1"].Status != TaskFailed {
+		t.Errorf("status = %s, want failed", q.tasks["task-1"].Status)
+	}
+	if q.tasks["task-1"].CompletedAt == nil {
+		t.Error("CompletedAt should be set when permanently failed")
+	}
+}
+
+func TestFail_Redistribution(t *testing.T) {
+	plan := &ultraplan.PlanSpec{
+		ID: "redistribution",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "a", DependsOn: []string{}, EstComplexity: ultraplan.ComplexityLow},
+		},
+	}
+	q := NewFromPlan(plan)
+
+	// Instance 1 claims and fails
+	task, _ := q.ClaimNext("inst-1")
+	_ = q.MarkRunning(task.ID)
+	_ = q.Fail(task.ID, "instance died")
+
+	// Different instance can now claim the task
+	task2, err := q.ClaimNext("inst-2")
+	if err != nil {
+		t.Fatalf("ClaimNext after fail: %v", err)
+	}
+	if task2 == nil {
+		t.Fatal("expected failed task to be re-claimable")
+	}
+	if task2.ID != "a" {
+		t.Errorf("re-claimed task = %q, want a", task2.ID)
+	}
+	if task2.ClaimedBy != "inst-2" {
+		t.Errorf("re-claimed by = %q, want inst-2", task2.ClaimedBy)
+	}
+	if task2.RetryCount != 1 {
+		t.Errorf("RetryCount = %d, want 1", task2.RetryCount)
+	}
+}
+
+func TestFail_NotFound(t *testing.T) {
+	q := NewFromPlan(makePlan())
+	if err := q.Fail("nonexistent", "err"); err == nil {
+		t.Error("Fail on nonexistent task should fail")
+	}
+}
+
+func TestFail_InvalidTransition(t *testing.T) {
+	q := NewFromPlan(makePlan())
+	if err := q.Fail("task-1", "err"); err == nil {
+		t.Error("Fail on pending task should fail")
+	}
+}
+
+func TestRelease(t *testing.T) {
+	plan := makePlan()
+	q := NewFromPlan(plan)
+
+	task, _ := q.ClaimNext("inst-1")
+
+	if err := q.Release(task.ID); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if q.tasks[task.ID].Status != TaskPending {
+		t.Errorf("status = %s, want pending", q.tasks[task.ID].Status)
+	}
+	if q.tasks[task.ID].ClaimedBy != "" {
+		t.Error("ClaimedBy should be cleared")
+	}
+	if q.tasks[task.ID].ClaimedAt != nil {
+		t.Error("ClaimedAt should be nil")
+	}
+	// Claims map should be cleared
+	if _, ok := q.claims[task.ID]; ok {
+		t.Error("claims map should not contain released task")
+	}
+}
+
+func TestRelease_Running(t *testing.T) {
+	q := NewFromPlan(makePlan())
+	task, _ := q.ClaimNext("inst-1")
+	_ = q.MarkRunning(task.ID)
+
+	if err := q.Release(task.ID); err != nil {
+		t.Fatalf("Release running task: %v", err)
+	}
+	if q.tasks[task.ID].Status != TaskPending {
+		t.Errorf("status = %s, want pending", q.tasks[task.ID].Status)
+	}
+}
+
+func TestRelease_NotFound(t *testing.T) {
+	q := NewFromPlan(makePlan())
+	if err := q.Release("nonexistent"); err == nil {
+		t.Error("Release on nonexistent task should fail")
+	}
+}
+
+func TestRelease_InvalidTransition(t *testing.T) {
+	q := NewFromPlan(makePlan())
+	// task-1 is pending
+	if err := q.Release("task-1"); err == nil {
+		t.Error("Release on pending task should fail")
+	}
+}
+
+func TestStatus(t *testing.T) {
+	plan := makePlan()
+	q := NewFromPlan(plan)
+
+	s := q.Status()
+	if s.Total != 3 {
+		t.Errorf("Total = %d, want 3", s.Total)
+	}
+	if s.Pending != 3 {
+		t.Errorf("Pending = %d, want 3", s.Pending)
+	}
+
+	// Claim one
+	_, _ = q.ClaimNext("inst-1")
+	s = q.Status()
+	if s.Claimed != 1 {
+		t.Errorf("Claimed = %d, want 1", s.Claimed)
+	}
+	if s.Pending != 2 {
+		t.Errorf("Pending = %d, want 2", s.Pending)
+	}
+
+	// Run it
+	_ = q.MarkRunning("task-1")
+	s = q.Status()
+	if s.Running != 1 {
+		t.Errorf("Running = %d, want 1", s.Running)
+	}
+	if s.Claimed != 0 {
+		t.Errorf("Claimed = %d, want 0", s.Claimed)
+	}
+
+	// Complete it
+	_, _ = q.Complete("task-1")
+	s = q.Status()
+	if s.Completed != 1 {
+		t.Errorf("Completed = %d, want 1", s.Completed)
+	}
+}
+
+func TestIsComplete(t *testing.T) {
+	plan := &ultraplan.PlanSpec{
+		ID: "test",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "a", DependsOn: []string{}, EstComplexity: ultraplan.ComplexityLow},
+		},
+	}
+	q := NewFromPlan(plan)
+
+	if q.IsComplete() {
+		t.Error("IsComplete should be false with pending tasks")
+	}
+
+	task, _ := q.ClaimNext("inst-1")
+	_ = q.MarkRunning(task.ID)
+	_, _ = q.Complete(task.ID)
+
+	if !q.IsComplete() {
+		t.Error("IsComplete should be true when all tasks completed")
+	}
+}
+
+func TestIsComplete_Empty(t *testing.T) {
+	plan := &ultraplan.PlanSpec{ID: "test"}
+	q := NewFromPlan(plan)
+
+	// Empty queue should not be considered complete
+	if q.IsComplete() {
+		t.Error("IsComplete should be false for empty queue")
+	}
+}
+
+func TestIsComplete_WithFailed(t *testing.T) {
+	plan := &ultraplan.PlanSpec{
+		ID: "test",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "a", DependsOn: []string{}, EstComplexity: ultraplan.ComplexityLow},
+		},
+	}
+	q := NewFromPlan(plan)
+	q.tasks["a"].MaxRetries = 0
+
+	task, _ := q.ClaimNext("inst-1")
+	_ = q.MarkRunning(task.ID)
+	_ = q.Fail(task.ID, "error")
+
+	if !q.IsComplete() {
+		t.Error("IsComplete should be true when all tasks are terminal (failed)")
+	}
+}
+
+func TestGetTask(t *testing.T) {
+	q := NewFromPlan(makePlan())
+
+	task := q.GetTask("task-1")
+	if task == nil {
+		t.Fatal("GetTask returned nil")
+	}
+	if task.ID != "task-1" {
+		t.Errorf("GetTask ID = %q, want task-1", task.ID)
+	}
+	if task.Title != "First task" {
+		t.Errorf("GetTask Title = %q, want First task", task.Title)
+	}
+
+	// Returned value is a copy
+	task.Title = "modified"
+	original := q.GetTask("task-1")
+	if original.Title == "modified" {
+		t.Error("GetTask should return a copy, not a reference")
+	}
+}
+
+func TestGetTask_NotFound(t *testing.T) {
+	q := NewFromPlan(makePlan())
+	if q.GetTask("nonexistent") != nil {
+		t.Error("GetTask for nonexistent ID should return nil")
+	}
+}
+
+func TestGetInstanceTasks(t *testing.T) {
+	q := NewFromPlan(makePlan())
+
+	// Claim task-1 for inst-1
+	_, _ = q.ClaimNext("inst-1")
+	// Claim task-3 for inst-1 as well
+	_, _ = q.ClaimNext("inst-1")
+
+	tasks := q.GetInstanceTasks("inst-1")
+	if len(tasks) != 2 {
+		t.Fatalf("GetInstanceTasks = %d tasks, want 2", len(tasks))
+	}
+
+	ids := make(map[string]bool)
+	for _, task := range tasks {
+		ids[task.ID] = true
+	}
+	if !ids["task-1"] || !ids["task-3"] {
+		t.Errorf("GetInstanceTasks = %v, want task-1 and task-3", ids)
+	}
+}
+
+func TestGetInstanceTasks_Empty(t *testing.T) {
+	q := NewFromPlan(makePlan())
+	tasks := q.GetInstanceTasks("inst-1")
+	if len(tasks) != 0 {
+		t.Errorf("GetInstanceTasks = %d tasks, want 0", len(tasks))
+	}
+}
+
+func TestGetInstanceTasks_ReturnsCopies(t *testing.T) {
+	q := NewFromPlan(makePlan())
+	_, _ = q.ClaimNext("inst-1")
+
+	tasks := q.GetInstanceTasks("inst-1")
+	tasks[0].Title = "modified"
+
+	original := q.GetTask("task-1")
+	if original.Title == "modified" {
+		t.Error("GetInstanceTasks should return copies")
+	}
+}
+
+func TestFullWorkflow(t *testing.T) {
+	plan := makePlan()
+	q := NewFromPlan(plan)
+
+	// Instance 1 claims task-1, Instance 2 claims task-3
+	t1, _ := q.ClaimNext("inst-1")
+	t3, _ := q.ClaimNext("inst-2")
+
+	if t1.ID != "task-1" {
+		t.Fatalf("expected task-1, got %s", t1.ID)
+	}
+	if t3.ID != "task-3" {
+		t.Fatalf("expected task-3, got %s", t3.ID)
+	}
+
+	// Both start running
+	_ = q.MarkRunning(t1.ID)
+	_ = q.MarkRunning(t3.ID)
+
+	// Nothing claimable yet (task-2 blocked on task-1)
+	none, _ := q.ClaimNext("inst-3")
+	if none != nil {
+		t.Fatalf("expected nil, got %s", none.ID)
+	}
+
+	// Complete task-1, unblocking task-2
+	unblocked, _ := q.Complete(t1.ID)
+	if len(unblocked) != 1 || unblocked[0] != "task-2" {
+		t.Errorf("unblocked = %v, want [task-2]", unblocked)
+	}
+
+	// Now inst-1 can claim task-2
+	t2, _ := q.ClaimNext("inst-1")
+	if t2.ID != "task-2" {
+		t.Fatalf("expected task-2, got %s", t2.ID)
+	}
+	_ = q.MarkRunning(t2.ID)
+
+	// Complete remaining tasks
+	_, _ = q.Complete(t3.ID)
+	_, _ = q.Complete(t2.ID)
+
+	if !q.IsComplete() {
+		t.Error("queue should be complete")
+	}
+	s := q.Status()
+	if s.Completed != 3 {
+		t.Errorf("Completed = %d, want 3", s.Completed)
+	}
+}
+
+func TestClaimNext_TimestampIsSet(t *testing.T) {
+	q := NewFromPlan(makePlan())
+	before := time.Now()
+	task, _ := q.ClaimNext("inst-1")
+	after := time.Now()
+
+	if task.ClaimedAt.Before(before) || task.ClaimedAt.After(after) {
+		t.Errorf("ClaimedAt %v not in expected range [%v, %v]", task.ClaimedAt, before, after)
+	}
+}

--- a/internal/taskqueue/types.go
+++ b/internal/taskqueue/types.go
@@ -1,0 +1,78 @@
+package taskqueue
+
+import (
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/ultraplan"
+)
+
+// TaskStatus represents the current state of a queued task.
+type TaskStatus string
+
+const (
+	// TaskPending indicates the task is waiting to be claimed.
+	TaskPending TaskStatus = "pending"
+
+	// TaskClaimed indicates the task has been claimed by an instance
+	// but has not yet started running.
+	TaskClaimed TaskStatus = "claimed"
+
+	// TaskRunning indicates the task is actively being executed.
+	TaskRunning TaskStatus = "running"
+
+	// TaskCompleted indicates the task finished successfully.
+	TaskCompleted TaskStatus = "completed"
+
+	// TaskFailed indicates the task failed and exhausted all retries.
+	TaskFailed TaskStatus = "failed"
+)
+
+// String returns the string representation of the task status.
+func (s TaskStatus) String() string {
+	return string(s)
+}
+
+// IsTerminal returns true if this status represents a final state.
+func (s TaskStatus) IsTerminal() bool {
+	return s == TaskCompleted || s == TaskFailed
+}
+
+// QueuedTask wraps an ultraplan.PlannedTask with execution state for the
+// dynamic task queue. It embeds the planned task so all planning fields
+// (ID, Title, Description, Files, DependsOn, Priority, EstComplexity)
+// are directly accessible.
+type QueuedTask struct {
+	// PlannedTask is the underlying task from the plan.
+	ultraplan.PlannedTask
+
+	// Status is the current execution state.
+	Status TaskStatus `json:"status"`
+
+	// ClaimedBy is the instance ID that claimed this task.
+	ClaimedBy string `json:"claimed_by,omitempty"`
+
+	// ClaimedAt is when the task was claimed.
+	ClaimedAt *time.Time `json:"claimed_at,omitempty"`
+
+	// CompletedAt is when the task reached a terminal state.
+	CompletedAt *time.Time `json:"completed_at,omitempty"`
+
+	// RetryCount is the number of retry attempts so far.
+	RetryCount int `json:"retry_count"`
+
+	// MaxRetries is the maximum number of retry attempts allowed.
+	MaxRetries int `json:"max_retries"`
+
+	// FailureContext contains error context from the most recent failure.
+	FailureContext string `json:"failure_context,omitempty"`
+}
+
+// QueueStatus is a snapshot of the queue's current state counts.
+type QueueStatus struct {
+	Total     int `json:"total"`
+	Pending   int `json:"pending"`
+	Claimed   int `json:"claimed"`
+	Running   int `json:"running"`
+	Completed int `json:"completed"`
+	Failed    int `json:"failed"`
+}

--- a/internal/taskqueue/types_test.go
+++ b/internal/taskqueue/types_test.go
@@ -1,0 +1,43 @@
+package taskqueue
+
+import "testing"
+
+func TestTaskStatus_String(t *testing.T) {
+	tests := []struct {
+		status TaskStatus
+		want   string
+	}{
+		{TaskPending, "pending"},
+		{TaskClaimed, "claimed"},
+		{TaskRunning, "running"},
+		{TaskCompleted, "completed"},
+		{TaskFailed, "failed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.status.String(); got != tt.want {
+				t.Errorf("TaskStatus.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTaskStatus_IsTerminal(t *testing.T) {
+	tests := []struct {
+		status   TaskStatus
+		terminal bool
+	}{
+		{TaskPending, false},
+		{TaskClaimed, false},
+		{TaskRunning, false},
+		{TaskCompleted, true},
+		{TaskFailed, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status.String(), func(t *testing.T) {
+			if got := tt.status.IsTerminal(); got != tt.terminal {
+				t.Errorf("TaskStatus(%q).IsTerminal() = %v, want %v", tt.status, got, tt.terminal)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements the two foundational packages for Orchestration 2.0 (Phase 1 — P0 priority):

- **`internal/mailbox/`** — File-based inter-instance messaging system enabling cross-instance communication during orchestration. Supports broadcast and targeted messages with 7 message types (discovery, claim, release, warning, question, answer, status). Includes prompt injection formatting and event bus integration.
- **`internal/taskqueue/`** — Dependency-aware dynamic task queue with self-claiming and work-stealing, replacing static execution batch ordering. Instances claim tasks as dependencies are satisfied, eliminating idle time between execution groups. Includes failed task retry, stale claim cleanup, atomic state persistence with flock, and event bus integration.
- **`internal/event/types.go`** — New event types for mailbox messages (`MailboxMessageEvent`) and task queue operations (`TaskClaimedEvent`, `TaskReleasedEvent`, `QueueDepthChangedEvent`).

Test coverage: mailbox 90.2%, taskqueue 95.4%.

Closes #629
Closes #630

## Architecture

### Mailbox (`internal/mailbox/`)

```
.claudio/mailbox/{sessionID}/
    broadcast/index.jsonl    -- messages to all instances
    {instanceID}/index.jsonl -- messages to a specific instance
```

- **Store**: Low-level JSONL storage with mutex + `O_APPEND` atomicity (POSIX guarantee for writes < PIPE_BUF)
- **Mailbox**: High-level facade combining broadcast + targeted delivery, with polling-based `Watch()`
- **FormatForPrompt**: Converts messages into structured text for Claude prompt injection
- **Events**: Each `Send()` publishes a `MailboxMessageEvent` to the event bus

### Task Queue (`internal/taskqueue/`)

- **TaskQueue**: Core queue with `ClaimNext()` (dependency-aware), `Complete()`, `Fail()` (with retry), `Release()`
- **EventQueue**: Decorator that wraps `TaskQueue` and publishes events (claimed, released, depth changed) without coupling the core queue to the event bus
- **Persistence**: Atomic JSON state persistence via temp-file + `os.Rename` with `flock` cross-process locking
- **Dependencies**: BFS topological ordering with priority-weighted tie-breaking

## Test Plan

### Automated Tests (run these first)

```bash
# Run all tests with race detector
go test -race ./internal/mailbox/... ./internal/taskqueue/...

# Run with coverage
go test -cover ./internal/mailbox/... ./internal/taskqueue/...

# Lint check
golangci-lint run ./internal/mailbox/... ./internal/taskqueue/...
```

### Manual Verification: Mailbox Package

1. **Message round-trip**: Create a `Store`, `Send()` a message, `ReadAll()` it back — verify fields match
2. **Broadcast delivery**: Send to `"broadcast"` recipient, verify both `ReadBroadcast()` and `ReadAll("any-instance")` return it
3. **Targeted delivery**: Send to `"instance-1"`, verify `ReadForInstance("instance-1")` returns it but `ReadForInstance("instance-2")` does not
4. **Watch polling**: Call `Watch()`, send a message from another goroutine, verify the callback fires within the poll interval
5. **Watch cancel**: Call `Watch()`, then invoke the returned cancel function — verify no more callbacks fire
6. **FormatForPrompt**: Pass multiple messages of different types, verify the output groups by type with `<mailbox-messages>` wrapper
7. **Filesystem persistence**: Verify `index.jsonl` files appear under the session directory in the correct structure

### Manual Verification: Task Queue Package

1. **Dependency ordering**: Create a plan where task B depends on task A — verify `ClaimNext()` returns A first, and B becomes claimable only after `Complete("A")`
2. **Concurrent claiming**: From two goroutines, call `ClaimNext()` simultaneously — verify each gets a different task (no double-claiming)
3. **Fail and retry**: `Fail()` a task — verify it returns to pending. Fail it again past `MaxRetries` — verify it moves to permanently failed
4. **Stale claim cleanup**: Claim a task, wait past the cutoff, call `ReleaseStaleClaimed()` — verify the task returns to pending
5. **State persistence round-trip**: `SaveState()` to a temp directory, then `LoadState()` from the same directory — verify all task statuses, claims, and order are preserved
6. **Event bus integration**: Use `EventQueue`, claim a task — verify a `TaskClaimedEvent` and `QueueDepthChangedEvent` are published. Complete it — verify a `TaskCompletedEvent` is published
7. **Cross-process locking**: From two goroutines, call `SaveState()` concurrently — verify no file corruption (the flock serializes writes)

### Manual Verification: Event Types

1. Verify all new event types in `internal/event/types.go` have constructors that set the correct `eventType` string
2. Verify event types compile and are importable from other packages

## Risk Areas

### Low Risk — Isolated New Code
These packages are entirely new additions under `internal/`. They have **no callers yet** in the existing codebase. The only modification to existing code is adding new event types to `internal/event/types.go`, which is additive-only (no existing types or functions were changed).

### Things to Watch

| Area | Risk | Rationale |
|------|------|-----------|
| `internal/event/types.go` | **Very Low** | Additive only — 4 new event types appended to an existing file. No existing types modified. |
| `internal/mailbox/` | **None** | Brand new package, no existing callers. |
| `internal/taskqueue/` | **None** | Brand new package, no existing callers. |
| `CHANGELOG.md` | **Very Low** | Two lines added to Unreleased section. |
| Filesystem layout (`.claudio/mailbox/`) | **Low** | New directory structure created on first mailbox write. Won't interfere with existing session directories. |
| `go.sum` / `go.mod` | **None** | No new external dependencies added. All imports are stdlib + internal. |

### Known Limitations (Addressed in Future Phases)

- **Mailbox `Watch()` is polling-based**: Uses `time.Ticker` rather than `fsnotify`. Adequate for the expected message volume but will be replaced with filesystem watchers in Phase 2 (#631).
- **No cross-process locking on mailbox writes**: The mailbox relies on `O_APPEND` atomicity for small writes. This is safe for JSONL lines under PIPE_BUF (4KB on Linux, 512B on macOS) but should be monitored.
- **`readIndex` silently skips malformed JSONL lines**: Intentional for resilience, but means a corrupted line is lost without logging.