### PR TITLE
Self-improving AGENTS.md with directory-scoped guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Self-Improving AGENTS.md** - Restructured AGENTS.md into a living document with a self-improvement protocol that instructs agents to update guidelines based on their learnings. Added agent-curated sections (Architecture Map, Known Pitfalls, Codebase Patterns, Testing Notes, Build & Toolchain) seeded with knowledge from codebase review. Created directory-level AGENTS.md files for `internal/mailbox/`, `internal/taskqueue/`, and `internal/tui/` with package-specific pitfalls and patterns.
+
 ### Added
 
 - **Inter-Instance Mailbox** - File-based messaging system (`internal/mailbox/`) enabling cross-instance communication during orchestration. Supports broadcast and targeted messages with types including discovery, claim, release, warning, question, answer, and status. Includes prompt injection formatting and event bus integration. (#629)

--- a/internal/mailbox/AGENTS.md
+++ b/internal/mailbox/AGENTS.md
@@ -1,0 +1,25 @@
+# mailbox — Agent Guidelines
+
+> **Living document.** Update this file when you learn something specific to this package.
+> Same rules as the root `AGENTS.md` — see its Self-Improvement Protocol.
+
+See `doc.go` for package overview and API usage.
+
+## Pitfalls
+
+- **O_APPEND atomicity** — File writes use `O_APPEND` which is atomic for writes smaller than `PIPE_BUF` (4096 bytes on most systems), but is not crash-safe without `fsync`. This is an accepted trade-off — messages may be lost on hard crash but won't be corrupted or interleaved.
+- **Message ID uniqueness** — `time.UnixNano()` alone is not unique under concurrent access. IDs are generated using an atomic counter combined with PID and timestamp. If you modify ID generation, ensure uniqueness under parallel `Send()` calls.
+- **Store mutex scope** — The `Store` holds a `sync.Mutex` for in-process thread safety. Any method that reads or writes the JSONL file must hold the lock for the entire operation, including the JSON marshal/unmarshal step — not just the file I/O.
+
+## File Layout
+
+```
+.claudio/mailbox/{sessionID}/
+    broadcast/index.jsonl    -- messages to all instances
+    {instanceID}/index.jsonl -- messages to a specific instance
+```
+
+## Testing
+
+- Use `t.TempDir()` for all persistence tests — avoids cross-test pollution and auto-cleans.
+- The `Store` tests exercise concurrent writes via goroutines; always run with `-race`.

--- a/internal/mailbox/CLAUDE.md
+++ b/internal/mailbox/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/internal/taskqueue/AGENTS.md
+++ b/internal/taskqueue/AGENTS.md
@@ -1,0 +1,26 @@
+# taskqueue — Agent Guidelines
+
+> **Living document.** Update this file when you learn something specific to this package.
+> Same rules as the root `AGENTS.md` — see its Self-Improvement Protocol.
+
+See `doc.go` for package overview and API usage.
+
+## Pitfalls
+
+- **Wrapper type mutex access** — `EventQueue` wraps `TaskQueue` to publish events. Never access `TaskQueue`'s internal mutex from `EventQueue`. If `EventQueue` needs new synchronized behavior, add a public method on `TaskQueue` and call it from the wrapper.
+- **Copy-on-return semantics** — `ClaimNext()` and `GetTask()` return value copies of internal structs, not pointers. This prevents callers from mutating queue state through the returned value. Maintain this pattern when adding new accessor methods.
+- **Persistence locking** — State persistence uses temp file + `os.Rename` with `flock` for crash safety. The flock is process-level; multiple goroutines within the same process coordinate via the `TaskQueue` mutex, not the flock.
+
+## EventQueue Decorator
+
+The `EventQueue` type wraps `TaskQueue` to publish events to the event bus without coupling core queue logic to `internal/event`. Key rules:
+
+- **Do not** add event publishing directly to `TaskQueue` — always go through `EventQueue`.
+- `EventQueue` methods should delegate to the underlying `TaskQueue` method, then publish the event based on the result.
+- When adding a new `TaskQueue` method that should emit events, add a corresponding `EventQueue` wrapper.
+
+## Testing
+
+- Use `t.TempDir()` for persistence tests — the queue writes state files to disk.
+- **Event bus testing pattern** — Subscribe to specific event types and wait on a channel with a timeout. Do not use `time.Sleep`. See `queue_events_test.go` for examples.
+- Always run with `-race` — the queue is designed for concurrent access from multiple goroutines.

--- a/internal/taskqueue/CLAUDE.md
+++ b/internal/taskqueue/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/internal/tui/AGENTS.md
+++ b/internal/tui/AGENTS.md
@@ -1,0 +1,15 @@
+# tui — Agent Guidelines
+
+> **Living document.** Update this file when you learn something specific to this package.
+> Same rules as the root `AGENTS.md` — see its Self-Improvement Protocol.
+
+## Pitfalls
+
+- **Bubble Tea Cmd closures** — `tea.Cmd` functions must not capture mutable state by pointer. If you need to pass data into a Cmd, copy it into the closure at creation time. Capturing a pointer to model fields causes data races since the Bubble Tea runtime may execute the Cmd concurrently with the next `Update()` call.
+
+## Architecture
+
+- The TUI uses the [Bubble Tea](https://github.com/charmbracelet/bubbletea) framework (Elm architecture: Model → Update → View).
+- `model.go` holds the top-level model; `update/` and `view/` separate the Update and View logic.
+- `msg/` defines custom `tea.Msg` types for internal communication between components.
+- `styles/` centralizes lipgloss styling — prefer reusing existing styles over creating new ones.

--- a/internal/tui/CLAUDE.md
+++ b/internal/tui/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Restructures AGENTS.md from a static copy of CLAUDE.md into a living document with a self-improvement protocol
- Agents are now instructed to update AGENTS.md (root or directory-level) based on their learnings as part of every commit
- Adds agent-curated knowledge sections (Architecture Map, Known Pitfalls, Codebase Patterns, Testing Notes, Build & Toolchain) seeded with findings from codebase review
- Creates directory-level AGENTS.md files for `internal/mailbox/`, `internal/taskqueue/`, and `internal/tui/` with package-specific pitfalls and patterns (each with a CLAUDE.md symlink)

## Test plan
- [ ] Verify CLAUDE.md symlink at root still resolves to AGENTS.md
- [ ] Verify each directory-level CLAUDE.md symlink resolves to its AGENTS.md
- [ ] Read through self-improvement protocol for clarity and actionability
- [ ] Confirm no base guidelines from CLAUDE.md were lost (formatting, linting, testing, changelog, pre-commit checklist all present)