### PR TITLE
Add pipeline orchestration for plan decomposition and multi-phase execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,6 +307,7 @@ This is not exhaustive — update it when you add or discover undocumented packa
 - `internal/scaling/` — Queue-depth-based elastic scaling policies *(has `AGENTS.md`)*
 - `internal/taskqueue/` — Dependency-aware task queue with persistence *(has `AGENTS.md`)*
 - `internal/team/` — Multi-team orchestration with dependency ordering, budget tracking, and inter-team routing *(has `AGENTS.md`)*
+- `internal/pipeline/` — Plan decomposer and multi-phase team pipeline *(has `AGENTS.md`)*
 - `internal/tui/` — Bubble Tea terminal UI components *(has `AGENTS.md`)*
 - `internal/worktree/` — Git worktree creation and management
 
@@ -327,6 +328,8 @@ These are real issues agents have encountered in this codebase. Package-specific
 
 - **Map iteration ordering** — Go map iteration is non-deterministic. When output must be stable (tests, serialization, UI), sort the keys first.
 - **Mutex scope during marshaling** — `json.MarshalIndent` on a map must hold the mutex through the entire marshal, not just while copying the map. The marshal reads the map's values lazily.
+- **Synchronous event bus and lock re-entrancy** — `event.Bus.Publish` runs handlers inline in the caller's goroutine. If a handler acquires a lock that the publisher already holds, deadlock results. The `team.Manager` uses a two-phase pattern (register under lock, start outside lock) specifically to avoid this. See `internal/team/AGENTS.md` for details.
+- **Store state before publishing events** — When an event handler may look up the state you're about to set, store it first. Example: `pipeline.runPhase` stores the Manager in `p.managers[phase]` before publishing `PipelinePhaseChangedEvent`, so handlers calling `p.Manager(phase)` don't get nil.
 
 ---
 
@@ -337,6 +340,8 @@ Patterns and conventions observed in this codebase that aren't covered by the ge
 - **Error wrapping** — Use `fmt.Errorf("context: %w", err)` consistently. The context should describe what operation failed, not repeat the inner error.
 - **Constructor naming** — `NewXxx` functions return `(*Xxx, error)` when initialization can fail, or `*Xxx` when it cannot. Don't return an interface from a constructor.
 - **File organization** — Each package keeps types, logic, and tests in separate files when the package is non-trivial (e.g., `types.go`, `queue.go`, `queue_test.go`).
+- **Decorator chain** — Orchestration 2.0 builds behavior via stacked decorators: `TaskQueue → EventQueue → Gate`. Higher-level packages (`team`, `pipeline`) compose these decorators through `coordination.Hub`. When adding new orchestration behavior, consider whether it fits as a new decorator layer rather than modifying existing ones.
+- **One-Manager-per-phase** — The `pipeline` package creates a fresh `team.Manager` per pipeline phase (planning, execution, review, consolidation). This keeps event subscriptions, completion monitors, and budget tracking scoped to each phase and avoids cross-phase interference.
 
 ---
 
@@ -346,6 +351,8 @@ Testing patterns specific to this codebase, beyond the general testing guideline
 
 - **Race detector** — Always run `go test -race ./...` before committing concurrent code. The CI enforces this.
 - **Temp directories for persistence tests** — Use `t.TempDir()` for tests that exercise file-based persistence (taskqueue, mailbox). This auto-cleans on test completion.
+- **Channel-based event assertions** — For async event-driven tests, subscribe to the bus with a buffered channel and use `select` with a timeout. Never use `time.Sleep` for event synchronization. See `internal/team/manager_test.go` and `internal/pipeline/pipeline_test.go` for examples.
+- **Disable rebalance loop in team/pipeline tests** — Use `coordination.WithRebalanceInterval(-1)` when constructing Managers in tests to prevent the adaptive lead's periodic rebalance from interfering with deterministic test behavior.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Pipeline Orchestration** - Plan decomposer and multi-phase pipeline (`internal/pipeline/`) for team-based execution. Groups tasks by file affinity using union-find, then orchestrates sequential phases (planning → execution → review → consolidation). Each phase runs its own Manager with scoped teams. Adds pipeline lifecycle events and dynamic team addition to the team Manager. (Phase 3 of Orchestrator of Orchestrators, #637)
+
 - **Multi-Team Execution** - Multi-team orchestration layer (`internal/team/`) that runs multiple teams in parallel, each with its own Coordination Hub. Supports inter-team dependency ordering, per-team budget tracking with exhaustion detection, and inter-team message routing via existing mailbox infrastructure. Adds team lifecycle events (created, phase changed, completed, budget exhausted) and inter-team message events to the event bus. (#637)
 
 - **Coordination Hub** - Integration hub (`internal/coordination/`) that wires all Orchestration 2.0 components together for a single session. Creates the full task pipeline (TaskQueue → EventQueue → Gate), event-driven observers (Adaptive Lead, Scaling Monitor), and communication infrastructure (Context Propagator, File Lock Registry, Mailbox). Provides a single `Start`/`Stop` lifecycle and accessor methods for all components. (#637)

--- a/internal/event/types.go
+++ b/internal/event/types.go
@@ -722,6 +722,69 @@ func NewTeamBudgetExhaustedEvent(teamID string, maxIn, maxOut, usedIn, usedOut i
 }
 
 // -----------------------------------------------------------------------------
+// Team Dynamic Management Events
+// -----------------------------------------------------------------------------
+
+// TeamDynamicAddedEvent is emitted when a team is dynamically added to a
+// running manager (after Start).
+type TeamDynamicAddedEvent struct {
+	baseEvent
+	TeamID   string // Unique identifier for the team
+	TeamName string // Human-readable team name
+	Phase    string // Team's initial phase (working or blocked)
+}
+
+// NewTeamDynamicAddedEvent creates a TeamDynamicAddedEvent.
+func NewTeamDynamicAddedEvent(teamID, teamName, phase string) TeamDynamicAddedEvent {
+	return TeamDynamicAddedEvent{
+		baseEvent: newBaseEvent("team.dynamic_added"),
+		TeamID:    teamID,
+		TeamName:  teamName,
+		Phase:     phase,
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Pipeline Lifecycle Events
+// -----------------------------------------------------------------------------
+
+// PipelinePhaseChangedEvent is emitted when the pipeline transitions between phases.
+type PipelinePhaseChangedEvent struct {
+	baseEvent
+	PipelineID    string // Unique identifier for the pipeline
+	PreviousPhase string // Previous phase (e.g., "planning", "execution")
+	CurrentPhase  string // New phase (e.g., "execution", "review")
+}
+
+// NewPipelinePhaseChangedEvent creates a PipelinePhaseChangedEvent.
+func NewPipelinePhaseChangedEvent(pipelineID, previousPhase, currentPhase string) PipelinePhaseChangedEvent {
+	return PipelinePhaseChangedEvent{
+		baseEvent:     newBaseEvent("pipeline.phase_changed"),
+		PipelineID:    pipelineID,
+		PreviousPhase: previousPhase,
+		CurrentPhase:  currentPhase,
+	}
+}
+
+// PipelineCompletedEvent is emitted when a pipeline finishes.
+type PipelineCompletedEvent struct {
+	baseEvent
+	PipelineID string // Unique identifier for the pipeline
+	Success    bool   // True if the pipeline completed without failures
+	PhasesRun  int    // Number of phases that were executed
+}
+
+// NewPipelineCompletedEvent creates a PipelineCompletedEvent.
+func NewPipelineCompletedEvent(pipelineID string, success bool, phasesRun int) PipelineCompletedEvent {
+	return PipelineCompletedEvent{
+		baseEvent:  newBaseEvent("pipeline.completed"),
+		PipelineID: pipelineID,
+		Success:    success,
+		PhasesRun:  phasesRun,
+	}
+}
+
+// -----------------------------------------------------------------------------
 // Inter-Team Communication Events
 // -----------------------------------------------------------------------------
 

--- a/internal/pipeline/AGENTS.md
+++ b/internal/pipeline/AGENTS.md
@@ -1,0 +1,48 @@
+# pipeline — Agent Guidelines
+
+> **Living document.** Update this file when you learn something specific to this package.
+> Same rules as the root `AGENTS.md` — see its Self-Improvement Protocol.
+
+See `doc.go` for package overview and API usage.
+
+## Architecture
+
+The pipeline package implements Phase 3 of the Orchestrator of Orchestrators. It decomposes a `PlanSpec` into teams and orchestrates multi-phase execution.
+
+**Core Components:**
+- **Decomposer** — Groups tasks by file affinity using union-find, producing `team.Spec` instances for the execution phase plus optional planning, review, and consolidation teams.
+- **Pipeline** — Runs a multi-phase session (planning → execution → review → consolidation → done). Each phase creates its own `team.Manager`, registers teams, runs them to completion, and advances to the next phase.
+
+**Phase Flow:**
+```
+Pipeline.Start(ctx)
+  ├─ PlanningTeam != nil → run planning phase
+  ├─ ExecutionTeams → run execution phase
+  ├─ ReviewTeam != nil → run review phase
+  ├─ ConsolidationTeam != nil → run consolidation phase
+  └─ All succeed → PhaseDone
+      Any fail → PhaseFailed
+```
+
+## Pitfalls
+
+- **One Manager per phase, not one for the whole pipeline** — Each phase creates a fresh `team.Manager`. This keeps each phase's event subscriptions, budget tracking, and completion monitoring scoped and prevents cross-phase interference. Attempting to add teams from different phases into a single Manager would cause confusion in the completion monitor.
+- **Manager's context, not caller's** — `AddTeamDynamic` on `team.Manager` uses the Manager's stored context (from `Start`), not the caller-provided context. Without this, `Stop` cannot cancel dynamically-added teams' monitor goroutines, causing `wg.Wait()` to hang.
+- **Pipeline.Start returns immediately** — The `run` goroutine handles phase sequencing. The caller drives the pipeline through `Stop()`, context cancellation, or by completing tasks in each phase's teams.
+- **Bus.Publish is synchronous** — Event handlers run in the caller's goroutine. This means `startTeamLocked` → monitor goroutine → `team.completed` → `onTeamCompleted` all chain through the same goroutine. The `AddTeamDynamic` split (register under lock, start outside lock) prevents deadlock with this chain.
+- **completeAllTeamTasks test helper must poll** — Due to async phase transitions, the test helper can't just complete tasks once and return. It must poll until all teams reach terminal phases, because some teams may not be started yet (blocked on deps) when the helper first runs.
+- **Store Manager in map BEFORE publishing phase events** — `runPhase` must call `p.managers[phase] = mgr` before publishing `PipelinePhaseChangedEvent`. Event handlers may call `p.Manager(phase)` and get nil if the order is wrong.
+- **Pipeline.run() goroutine must be tracked with WaitGroup** — `Stop()` calls `p.wg.Wait()` after cancelling context to guarantee the `run()` goroutine has exited. Without this, tests checking post-Stop state may race with the goroutine.
+- **fail() must receive phasesRun from caller** — The `fail()` helper publishes a `PipelineCompletedEvent`. It accepts a `phasesRun int` parameter rather than computing it, because the `run()` function already tracks this counter incrementally and passing it avoids redundant (and possibly wrong) recalculation.
+
+## Testing
+
+- Use `coordination.WithRebalanceInterval(-1)` on the pipeline's hub options to disable the adaptive lead's rebalance loop in tests.
+- Use `t.TempDir()` for the pipeline's `BaseDir`.
+- Event assertions use channel-based waiting with timeouts, not `time.Sleep`.
+- Always run with `-race` — the pipeline spawns goroutines via `run()` and team managers.
+- Use `failAllTeamTasks` helper to test failure paths; `completeAllTeamTasks` for success paths.
+
+## Coverage Notes
+
+The `run` function has some uncovered branches for failure paths in optional phases (planning, review, consolidation). These paths are structurally identical to the execution failure path (which is tested) and are difficult to test deterministically because they depend on async phase transitions and context cancellation timing.

--- a/internal/pipeline/CLAUDE.md
+++ b/internal/pipeline/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/internal/pipeline/decompose.go
+++ b/internal/pipeline/decompose.go
@@ -1,0 +1,343 @@
+package pipeline
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/Iron-Ham/claudio/internal/team"
+	"github.com/Iron-Ham/claudio/internal/ultraplan"
+)
+
+// Decompose takes a PlanSpec and produces team.Specs grouped by file affinity.
+//
+// Tasks that share at least one file are placed in the same team. Tasks with
+// no files are placed in their own single-task team. The result includes
+// optional planning, review, and consolidation team specs based on the config.
+func Decompose(plan *ultraplan.PlanSpec, cfg DecomposeConfig) (*DecomposeResult, error) {
+	if plan == nil {
+		return nil, errors.New("pipeline: plan is required")
+	}
+	if len(plan.Tasks) == 0 {
+		return nil, errors.New("pipeline: plan has no tasks")
+	}
+
+	cfg = cfg.defaults()
+
+	groups := groupByFileAffinity(plan.Tasks)
+
+	// Apply MaxTeamSize: split oversized groups.
+	if cfg.MaxTeamSize > 0 {
+		groups = splitOversized(groups, cfg.MaxTeamSize)
+	}
+
+	// Apply MinTeamSize: merge undersized groups.
+	if cfg.MinTeamSize > 1 {
+		groups = mergeUndersized(groups, plan.Tasks, cfg.MinTeamSize)
+	}
+
+	// Sort groups deterministically by first task ID in each group.
+	sort.Slice(groups, func(i, j int) bool {
+		return groups[i][0] < groups[j][0]
+	})
+
+	// Build task index for lookup.
+	taskIndex := make(map[string]ultraplan.PlannedTask, len(plan.Tasks))
+	for _, t := range plan.Tasks {
+		taskIndex[t.ID] = t
+	}
+
+	// Convert groups into team specs.
+	execTeams := make([]team.Spec, 0, len(groups))
+	for i, group := range groups {
+		tasks := make([]ultraplan.PlannedTask, 0, len(group))
+		for _, id := range group {
+			if t, ok := taskIndex[id]; ok {
+				tasks = append(tasks, t)
+			}
+		}
+
+		execTeams = append(execTeams, team.Spec{
+			ID:       fmt.Sprintf("exec-%d", i),
+			Name:     fmt.Sprintf("Execution Team %d", i),
+			Role:     team.RoleExecution,
+			Tasks:    tasks,
+			TeamSize: 1,
+		})
+	}
+
+	result := &DecomposeResult{
+		ExecutionTeams: execTeams,
+	}
+
+	if cfg.PlanningTeam {
+		result.PlanningTeam = makePlanningTeam(plan)
+	}
+	if cfg.ReviewTeam {
+		result.ReviewTeam = makeReviewTeam(plan)
+	}
+	if cfg.ConsolidationTeam {
+		result.ConsolidationTeam = makeConsolidationTeam(plan)
+	}
+
+	return result, nil
+}
+
+// groupByFileAffinity groups tasks by shared files using union-find.
+// Returns a slice of groups, each group being a sorted slice of task IDs.
+func groupByFileAffinity(tasks []ultraplan.PlannedTask) [][]string {
+	ids := make([]string, len(tasks))
+	for i, t := range tasks {
+		ids[i] = t.ID
+	}
+
+	uf := newUnionFind(ids)
+
+	// Build file → task ID index.
+	fileToTasks := make(map[string][]string)
+	for _, t := range tasks {
+		for _, f := range t.Files {
+			fileToTasks[f] = append(fileToTasks[f], t.ID)
+		}
+	}
+
+	// Union tasks that share files.
+	for _, taskIDs := range fileToTasks {
+		for i := 1; i < len(taskIDs); i++ {
+			uf.Union(taskIDs[0], taskIDs[i])
+		}
+	}
+
+	components := uf.Components()
+
+	// Sort task IDs within each component.
+	groups := make([][]string, 0, len(components))
+	for _, members := range components {
+		sort.Strings(members)
+		groups = append(groups, members)
+	}
+	return groups
+}
+
+// splitOversized splits groups that exceed maxSize by task priority.
+func splitOversized(groups [][]string, maxSize int) [][]string {
+	var result [][]string
+	for _, g := range groups {
+		if len(g) <= maxSize {
+			result = append(result, g)
+			continue
+		}
+		// Split into chunks of maxSize.
+		for i := 0; i < len(g); i += maxSize {
+			end := min(i+maxSize, len(g))
+			chunk := make([]string, end-i)
+			copy(chunk, g[i:end])
+			result = append(result, chunk)
+		}
+	}
+	return result
+}
+
+// mergeUndersized merges groups smaller than minSize into the nearest
+// neighbor by shared file count. Groups that cannot be merged (no shared
+// files with any other group) are left as-is.
+func mergeUndersized(groups [][]string, tasks []ultraplan.PlannedTask, minSize int) [][]string {
+	if len(groups) <= 1 {
+		return groups
+	}
+
+	// Build task → files index.
+	taskFiles := make(map[string]map[string]bool)
+	for _, t := range tasks {
+		s := make(map[string]bool, len(t.Files))
+		for _, f := range t.Files {
+			s[f] = true
+		}
+		taskFiles[t.ID] = s
+	}
+
+	// groupFiles returns the set of files touched by a group.
+	groupFiles := func(group []string) map[string]bool {
+		files := make(map[string]bool)
+		for _, id := range group {
+			for f := range taskFiles[id] {
+				files[f] = true
+			}
+		}
+		return files
+	}
+
+	// sharedFileCount returns the number of shared files between two groups.
+	sharedFileCount := func(a, b map[string]bool) int {
+		count := 0
+		for f := range a {
+			if b[f] {
+				count++
+			}
+		}
+		return count
+	}
+
+	// Iteratively merge undersized groups.
+	merged := make([][]string, len(groups))
+	copy(merged, groups)
+
+	changed := true
+	for changed {
+		changed = false
+		for i := 0; i < len(merged); i++ {
+			if len(merged[i]) >= minSize {
+				continue
+			}
+			// Find the best merge candidate.
+			bestJ := -1
+			bestShared := 0
+			filesI := groupFiles(merged[i])
+			for j := 0; j < len(merged); j++ {
+				if i == j {
+					continue
+				}
+				filesJ := groupFiles(merged[j])
+				shared := sharedFileCount(filesI, filesJ)
+				if shared > bestShared {
+					bestShared = shared
+					bestJ = j
+				}
+			}
+			if bestJ == -1 {
+				continue // no merge candidate
+			}
+			// Merge i into bestJ.
+			merged[bestJ] = append(merged[bestJ], merged[i]...)
+			sort.Strings(merged[bestJ])
+			merged = append(merged[:i], merged[i+1:]...)
+			changed = true
+			break // restart scan after mutation
+		}
+	}
+	return merged
+}
+
+// makePlanningTeam creates a planning team spec covering all tasks.
+func makePlanningTeam(plan *ultraplan.PlanSpec) *team.Spec {
+	return &team.Spec{
+		ID:         "planning",
+		Name:       "Planning Team",
+		Role:       team.RolePlanning,
+		Tasks:      []ultraplan.PlannedTask{planningMetaTask(plan)},
+		LeadPrompt: fmt.Sprintf("Plan the execution of: %s", plan.Objective),
+		TeamSize:   1,
+	}
+}
+
+// makeReviewTeam creates a review team spec that depends on all execution teams.
+func makeReviewTeam(plan *ultraplan.PlanSpec) *team.Spec {
+	return &team.Spec{
+		ID:         "review",
+		Name:       "Review Team",
+		Role:       team.RoleReview,
+		Tasks:      []ultraplan.PlannedTask{reviewMetaTask(plan)},
+		LeadPrompt: fmt.Sprintf("Review the execution results of: %s", plan.Objective),
+		TeamSize:   1,
+	}
+}
+
+// makeConsolidationTeam creates a consolidation team spec.
+func makeConsolidationTeam(plan *ultraplan.PlanSpec) *team.Spec {
+	return &team.Spec{
+		ID:         "consolidation",
+		Name:       "Consolidation Team",
+		Role:       team.RoleConsolidation,
+		Tasks:      []ultraplan.PlannedTask{consolidationMetaTask(plan)},
+		LeadPrompt: fmt.Sprintf("Consolidate results from: %s", plan.Objective),
+		TeamSize:   1,
+	}
+}
+
+// planningMetaTask creates a synthetic task for the planning phase.
+func planningMetaTask(plan *ultraplan.PlanSpec) ultraplan.PlannedTask {
+	return ultraplan.PlannedTask{
+		ID:    "meta-planning",
+		Title: "Collaborative Planning",
+		Description: fmt.Sprintf(
+			"Plan the decomposition and execution strategy for: %s (%d tasks)",
+			plan.Objective, len(plan.Tasks),
+		),
+	}
+}
+
+// reviewMetaTask creates a synthetic task for the review phase.
+func reviewMetaTask(plan *ultraplan.PlanSpec) ultraplan.PlannedTask {
+	return ultraplan.PlannedTask{
+		ID:    "meta-review",
+		Title: "Cross-Cutting Review",
+		Description: fmt.Sprintf(
+			"Review all execution results for integration issues: %s (%d tasks)",
+			plan.Objective, len(plan.Tasks),
+		),
+	}
+}
+
+// consolidationMetaTask creates a synthetic task for the consolidation phase.
+func consolidationMetaTask(plan *ultraplan.PlanSpec) ultraplan.PlannedTask {
+	return ultraplan.PlannedTask{
+		ID:    "meta-consolidation",
+		Title: "Parallel Merge Consolidation",
+		Description: fmt.Sprintf(
+			"Consolidate and merge results from: %s (%d tasks)",
+			plan.Objective, len(plan.Tasks),
+		),
+	}
+}
+
+// -- Union-Find implementation -----------------------------------------------
+
+type unionFind struct {
+	parent map[string]string
+	rank   map[string]int
+}
+
+func newUnionFind(keys []string) *unionFind {
+	uf := &unionFind{
+		parent: make(map[string]string, len(keys)),
+		rank:   make(map[string]int, len(keys)),
+	}
+	for _, k := range keys {
+		uf.parent[k] = k
+	}
+	return uf
+}
+
+func (uf *unionFind) Find(x string) string {
+	if uf.parent[x] != x {
+		uf.parent[x] = uf.Find(uf.parent[x]) // path compression
+	}
+	return uf.parent[x]
+}
+
+func (uf *unionFind) Union(x, y string) {
+	rx, ry := uf.Find(x), uf.Find(y)
+	if rx == ry {
+		return
+	}
+	// Union by rank.
+	switch {
+	case uf.rank[rx] < uf.rank[ry]:
+		uf.parent[rx] = ry
+	case uf.rank[rx] > uf.rank[ry]:
+		uf.parent[ry] = rx
+	default:
+		uf.parent[ry] = rx
+		uf.rank[rx]++
+	}
+}
+
+// Components returns the connected components: root → sorted member list.
+func (uf *unionFind) Components() map[string][]string {
+	comps := make(map[string][]string)
+	for k := range uf.parent {
+		root := uf.Find(k)
+		comps[root] = append(comps[root], k)
+	}
+	return comps
+}

--- a/internal/pipeline/decompose_test.go
+++ b/internal/pipeline/decompose_test.go
@@ -1,0 +1,472 @@
+package pipeline
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/team"
+	"github.com/Iron-Ham/claudio/internal/ultraplan"
+)
+
+func TestDecompose_NilPlan(t *testing.T) {
+	_, err := Decompose(nil, DecomposeConfig{})
+	if err == nil {
+		t.Fatal("expected error for nil plan")
+	}
+	if !strings.Contains(err.Error(), "plan is required") {
+		t.Errorf("error = %q, want containing 'plan is required'", err)
+	}
+}
+
+func TestDecompose_EmptyPlan(t *testing.T) {
+	plan := &ultraplan.PlanSpec{ID: "p1", Tasks: nil}
+	_, err := Decompose(plan, DecomposeConfig{})
+	if err == nil {
+		t.Fatal("expected error for empty plan")
+	}
+	if !strings.Contains(err.Error(), "no tasks") {
+		t.Errorf("error = %q, want containing 'no tasks'", err)
+	}
+}
+
+func TestDecompose_SingleTask(t *testing.T) {
+	plan := &ultraplan.PlanSpec{
+		ID: "p1",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "t1", Title: "Task 1", Files: []string{"a.go"}},
+		},
+	}
+
+	result, err := Decompose(plan, DecomposeConfig{})
+	if err != nil {
+		t.Fatalf("Decompose: %v", err)
+	}
+
+	if len(result.ExecutionTeams) != 1 {
+		t.Fatalf("ExecutionTeams = %d, want 1", len(result.ExecutionTeams))
+	}
+	if result.ExecutionTeams[0].ID != "exec-0" {
+		t.Errorf("team ID = %q, want %q", result.ExecutionTeams[0].ID, "exec-0")
+	}
+	if len(result.ExecutionTeams[0].Tasks) != 1 {
+		t.Errorf("tasks = %d, want 1", len(result.ExecutionTeams[0].Tasks))
+	}
+	if result.PlanningTeam != nil {
+		t.Error("PlanningTeam should be nil")
+	}
+	if result.ReviewTeam != nil {
+		t.Error("ReviewTeam should be nil")
+	}
+	if result.ConsolidationTeam != nil {
+		t.Error("ConsolidationTeam should be nil")
+	}
+}
+
+func TestDecompose_DisjointTasks(t *testing.T) {
+	plan := &ultraplan.PlanSpec{
+		ID: "p1",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "t1", Title: "Task 1", Files: []string{"a.go"}},
+			{ID: "t2", Title: "Task 2", Files: []string{"b.go"}},
+			{ID: "t3", Title: "Task 3", Files: []string{"c.go"}},
+		},
+	}
+
+	result, err := Decompose(plan, DecomposeConfig{})
+	if err != nil {
+		t.Fatalf("Decompose: %v", err)
+	}
+
+	if len(result.ExecutionTeams) != 3 {
+		t.Fatalf("ExecutionTeams = %d, want 3", len(result.ExecutionTeams))
+	}
+
+	// Each team should have exactly 1 task.
+	for i, team := range result.ExecutionTeams {
+		if len(team.Tasks) != 1 {
+			t.Errorf("team %d tasks = %d, want 1", i, len(team.Tasks))
+		}
+	}
+}
+
+func TestDecompose_SharedFiles(t *testing.T) {
+	plan := &ultraplan.PlanSpec{
+		ID: "p1",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "t1", Title: "Task 1", Files: []string{"shared.go", "a.go"}},
+			{ID: "t2", Title: "Task 2", Files: []string{"shared.go", "b.go"}},
+			{ID: "t3", Title: "Task 3", Files: []string{"c.go"}},
+		},
+	}
+
+	result, err := Decompose(plan, DecomposeConfig{})
+	if err != nil {
+		t.Fatalf("Decompose: %v", err)
+	}
+
+	// t1 and t2 share "shared.go" → one team. t3 is separate → second team.
+	if len(result.ExecutionTeams) != 2 {
+		t.Fatalf("ExecutionTeams = %d, want 2", len(result.ExecutionTeams))
+	}
+
+	// Find the team with 2 tasks.
+	var twoTaskTeam *team.Spec
+	for i := range result.ExecutionTeams {
+		if len(result.ExecutionTeams[i].Tasks) == 2 {
+			twoTaskTeam = &result.ExecutionTeams[i]
+			break
+		}
+	}
+	if twoTaskTeam == nil {
+		t.Fatal("expected one team with 2 tasks")
+	}
+
+	ids := make(map[string]bool)
+	for _, task := range twoTaskTeam.Tasks {
+		ids[task.ID] = true
+	}
+	if !ids["t1"] || !ids["t2"] {
+		t.Errorf("shared team should contain t1 and t2, got %v", ids)
+	}
+}
+
+func TestDecompose_TransitiveAffinity(t *testing.T) {
+	// t1 shares "x.go" with t2; t2 shares "y.go" with t3.
+	// All three should be in the same team.
+	plan := &ultraplan.PlanSpec{
+		ID: "p1",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "t1", Title: "Task 1", Files: []string{"x.go"}},
+			{ID: "t2", Title: "Task 2", Files: []string{"x.go", "y.go"}},
+			{ID: "t3", Title: "Task 3", Files: []string{"y.go"}},
+		},
+	}
+
+	result, err := Decompose(plan, DecomposeConfig{})
+	if err != nil {
+		t.Fatalf("Decompose: %v", err)
+	}
+
+	if len(result.ExecutionTeams) != 1 {
+		t.Fatalf("ExecutionTeams = %d, want 1 (transitive)", len(result.ExecutionTeams))
+	}
+	if len(result.ExecutionTeams[0].Tasks) != 3 {
+		t.Errorf("tasks = %d, want 3", len(result.ExecutionTeams[0].Tasks))
+	}
+}
+
+func TestDecompose_NoFiles(t *testing.T) {
+	plan := &ultraplan.PlanSpec{
+		ID: "p1",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "t1", Title: "Task 1"}, // no files
+			{ID: "t2", Title: "Task 2"}, // no files
+		},
+	}
+
+	result, err := Decompose(plan, DecomposeConfig{})
+	if err != nil {
+		t.Fatalf("Decompose: %v", err)
+	}
+
+	// Each task has no files so can't be grouped → each in its own team.
+	if len(result.ExecutionTeams) != 2 {
+		t.Fatalf("ExecutionTeams = %d, want 2", len(result.ExecutionTeams))
+	}
+}
+
+func TestDecompose_MaxTeamSize(t *testing.T) {
+	// 3 tasks sharing the same file, max team size = 2.
+	plan := &ultraplan.PlanSpec{
+		ID: "p1",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "t1", Title: "Task 1", Files: []string{"shared.go"}},
+			{ID: "t2", Title: "Task 2", Files: []string{"shared.go"}},
+			{ID: "t3", Title: "Task 3", Files: []string{"shared.go"}},
+		},
+	}
+
+	result, err := Decompose(plan, DecomposeConfig{MaxTeamSize: 2})
+	if err != nil {
+		t.Fatalf("Decompose: %v", err)
+	}
+
+	// Should be split into 2 teams: one with 2, one with 1.
+	if len(result.ExecutionTeams) != 2 {
+		t.Fatalf("ExecutionTeams = %d, want 2", len(result.ExecutionTeams))
+	}
+
+	totalTasks := 0
+	for _, team := range result.ExecutionTeams {
+		totalTasks += len(team.Tasks)
+		if len(team.Tasks) > 2 {
+			t.Errorf("team %q has %d tasks, exceeds max of 2", team.ID, len(team.Tasks))
+		}
+	}
+	if totalTasks != 3 {
+		t.Errorf("total tasks = %d, want 3", totalTasks)
+	}
+}
+
+func TestDecompose_MinTeamSize(t *testing.T) {
+	// t1 and t2 share "a.go"; t3 has "b.go" (disjoint but shares "c.go" with t1).
+	plan := &ultraplan.PlanSpec{
+		ID: "p1",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "t1", Title: "Task 1", Files: []string{"a.go", "c.go"}},
+			{ID: "t2", Title: "Task 2", Files: []string{"a.go"}},
+			{ID: "t3", Title: "Task 3", Files: []string{"b.go", "c.go"}},
+			{ID: "t4", Title: "Task 4", Files: []string{"d.go"}},
+		},
+	}
+
+	result, err := Decompose(plan, DecomposeConfig{MinTeamSize: 2})
+	if err != nil {
+		t.Fatalf("Decompose: %v", err)
+	}
+
+	// t1, t2, t3 all connected via union-find (t1-t2 via a.go, t1-t3 via c.go).
+	// t4 is alone and undersized (1 < 2), but has no shared files with others,
+	// so it stays alone. So we should have 2 teams.
+	// Actually: t4 has d.go, no overlap. Since minSize merge only happens when
+	// there's a shared file, t4 stays undersized.
+	totalTasks := 0
+	for _, team := range result.ExecutionTeams {
+		totalTasks += len(team.Tasks)
+	}
+	if totalTasks != 4 {
+		t.Fatalf("total tasks = %d, want 4", totalTasks)
+	}
+}
+
+func TestDecompose_DeterministicOutput(t *testing.T) {
+	plan := &ultraplan.PlanSpec{
+		ID: "p1",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "zz-task", Title: "Last", Files: []string{"z.go"}},
+			{ID: "aa-task", Title: "First", Files: []string{"a.go"}},
+			{ID: "mm-task", Title: "Middle", Files: []string{"m.go"}},
+		},
+	}
+
+	// Run decompose multiple times and verify deterministic ordering.
+	var lastIDs []string
+	for i := range 5 {
+		result, err := Decompose(plan, DecomposeConfig{})
+		if err != nil {
+			t.Fatalf("Decompose: %v", err)
+		}
+
+		ids := make([]string, len(result.ExecutionTeams))
+		for j, team := range result.ExecutionTeams {
+			ids[j] = team.Tasks[0].ID
+		}
+
+		if lastIDs != nil {
+			for j := range ids {
+				if ids[j] != lastIDs[j] {
+					t.Fatalf("run %d: non-deterministic order: %v vs %v", i, ids, lastIDs)
+				}
+			}
+		}
+		lastIDs = ids
+	}
+
+	// Verify sorted order (aa, mm, zz).
+	if lastIDs[0] != "aa-task" || lastIDs[1] != "mm-task" || lastIDs[2] != "zz-task" {
+		t.Errorf("expected sorted order, got %v", lastIDs)
+	}
+}
+
+func TestDecompose_TeamSpecFields(t *testing.T) {
+	plan := &ultraplan.PlanSpec{
+		ID: "p1",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "t1", Title: "Task 1", Files: []string{"a.go"}},
+		},
+	}
+
+	result, err := Decompose(plan, DecomposeConfig{})
+	if err != nil {
+		t.Fatalf("Decompose: %v", err)
+	}
+
+	spec := result.ExecutionTeams[0]
+	if spec.Role != team.RoleExecution {
+		t.Errorf("Role = %v, want %v", spec.Role, team.RoleExecution)
+	}
+	if spec.TeamSize != 1 {
+		t.Errorf("TeamSize = %d, want 1", spec.TeamSize)
+	}
+	if spec.ID != "exec-0" {
+		t.Errorf("ID = %q, want %q", spec.ID, "exec-0")
+	}
+}
+
+func TestDecompose_WithPlanningTeam(t *testing.T) {
+	plan := &ultraplan.PlanSpec{
+		ID:        "p1",
+		Objective: "Build a widget",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "t1", Title: "Task 1"},
+		},
+	}
+
+	result, err := Decompose(plan, DecomposeConfig{PlanningTeam: true})
+	if err != nil {
+		t.Fatalf("Decompose: %v", err)
+	}
+
+	if result.PlanningTeam == nil {
+		t.Fatal("PlanningTeam should not be nil")
+	}
+	if result.PlanningTeam.ID != "planning" {
+		t.Errorf("ID = %q, want %q", result.PlanningTeam.ID, "planning")
+	}
+	if result.PlanningTeam.Role != team.RolePlanning {
+		t.Errorf("Role = %v, want %v", result.PlanningTeam.Role, team.RolePlanning)
+	}
+	if len(result.PlanningTeam.Tasks) != 1 {
+		t.Errorf("Tasks = %d, want 1", len(result.PlanningTeam.Tasks))
+	}
+	if result.PlanningTeam.Tasks[0].ID != "meta-planning" {
+		t.Errorf("task ID = %q, want %q", result.PlanningTeam.Tasks[0].ID, "meta-planning")
+	}
+}
+
+func TestDecompose_WithReviewTeam(t *testing.T) {
+	plan := &ultraplan.PlanSpec{
+		ID:        "p1",
+		Objective: "Build a widget",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "t1", Title: "Task 1"},
+		},
+	}
+
+	result, err := Decompose(plan, DecomposeConfig{ReviewTeam: true})
+	if err != nil {
+		t.Fatalf("Decompose: %v", err)
+	}
+
+	if result.ReviewTeam == nil {
+		t.Fatal("ReviewTeam should not be nil")
+	}
+	if result.ReviewTeam.ID != "review" {
+		t.Errorf("ID = %q, want %q", result.ReviewTeam.ID, "review")
+	}
+	if result.ReviewTeam.Role != team.RoleReview {
+		t.Errorf("Role = %v, want %v", result.ReviewTeam.Role, team.RoleReview)
+	}
+}
+
+func TestDecompose_WithConsolidationTeam(t *testing.T) {
+	plan := &ultraplan.PlanSpec{
+		ID:        "p1",
+		Objective: "Build a widget",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "t1", Title: "Task 1"},
+		},
+	}
+
+	result, err := Decompose(plan, DecomposeConfig{ConsolidationTeam: true})
+	if err != nil {
+		t.Fatalf("Decompose: %v", err)
+	}
+
+	if result.ConsolidationTeam == nil {
+		t.Fatal("ConsolidationTeam should not be nil")
+	}
+	if result.ConsolidationTeam.ID != "consolidation" {
+		t.Errorf("ID = %q, want %q", result.ConsolidationTeam.ID, "consolidation")
+	}
+	if result.ConsolidationTeam.Role != team.RoleConsolidation {
+		t.Errorf("Role = %v, want %v", result.ConsolidationTeam.Role, team.RoleConsolidation)
+	}
+}
+
+func TestDecompose_AllOptionalTeams(t *testing.T) {
+	plan := &ultraplan.PlanSpec{
+		ID:        "p1",
+		Objective: "Build a widget",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "t1", Title: "Task 1"},
+		},
+	}
+
+	result, err := Decompose(plan, DecomposeConfig{
+		PlanningTeam:      true,
+		ReviewTeam:        true,
+		ConsolidationTeam: true,
+	})
+	if err != nil {
+		t.Fatalf("Decompose: %v", err)
+	}
+
+	if result.PlanningTeam == nil {
+		t.Error("PlanningTeam should not be nil")
+	}
+	if result.ReviewTeam == nil {
+		t.Error("ReviewTeam should not be nil")
+	}
+	if result.ConsolidationTeam == nil {
+		t.Error("ConsolidationTeam should not be nil")
+	}
+}
+
+// -- Union-Find unit tests ---------------------------------------------------
+
+func TestUnionFind_BasicOperations(t *testing.T) {
+	uf := newUnionFind([]string{"a", "b", "c", "d"})
+
+	// Initially, 4 separate components.
+	comps := uf.Components()
+	if len(comps) != 4 {
+		t.Fatalf("components = %d, want 4", len(comps))
+	}
+
+	// Union a and b.
+	uf.Union("a", "b")
+	comps = uf.Components()
+	if len(comps) != 3 {
+		t.Fatalf("after union(a,b): components = %d, want 3", len(comps))
+	}
+
+	// Union b and c (transitive: a-b-c should be one component).
+	uf.Union("b", "c")
+	comps = uf.Components()
+	if len(comps) != 2 {
+		t.Fatalf("after union(b,c): components = %d, want 2", len(comps))
+	}
+
+	// a, b, c should have the same root.
+	if uf.Find("a") != uf.Find("b") || uf.Find("b") != uf.Find("c") {
+		t.Error("a, b, c should be in the same component")
+	}
+
+	// d should be separate.
+	if uf.Find("d") == uf.Find("a") {
+		t.Error("d should be in a separate component")
+	}
+}
+
+func TestUnionFind_Idempotent(t *testing.T) {
+	uf := newUnionFind([]string{"a", "b"})
+	uf.Union("a", "b")
+	uf.Union("a", "b") // second union should be no-op
+
+	comps := uf.Components()
+	if len(comps) != 1 {
+		t.Fatalf("components = %d, want 1", len(comps))
+	}
+}
+
+func TestUnionFind_SingleElement(t *testing.T) {
+	uf := newUnionFind([]string{"only"})
+	comps := uf.Components()
+	if len(comps) != 1 {
+		t.Fatalf("components = %d, want 1", len(comps))
+	}
+	if uf.Find("only") != "only" {
+		t.Errorf("Find(only) = %q, want %q", uf.Find("only"), "only")
+	}
+}

--- a/internal/pipeline/doc.go
+++ b/internal/pipeline/doc.go
@@ -1,0 +1,35 @@
+// Package pipeline provides plan decomposition and multi-phase team orchestration.
+//
+// It is Phase 3 of the Orchestrator of Orchestrators (issue #637), building on
+// the coordination.Hub (Phase 1) and team.Manager (Phase 2) layers.
+//
+// # Plan Decomposition
+//
+// [Decompose] takes a [ultraplan.PlanSpec] and groups its tasks into teams
+// based on file affinity. Tasks that share files are placed in the same team
+// using a union-find algorithm, ensuring that file conflicts stay within a
+// single team rather than across teams. The result is a [DecomposeResult]
+// containing execution teams plus optional planning, review, and consolidation
+// team specs.
+//
+// # Pipeline Orchestration
+//
+// [Pipeline] runs a multi-phase session: planning → execution → review →
+// consolidation → done. Each phase creates its own [team.Manager] and runs
+// the teams for that phase to completion before advancing. Phase transitions
+// publish events on the shared [event.Bus] for TUI reactivity.
+//
+// # Usage
+//
+//	p, _ := pipeline.NewPipeline(pipeline.PipelineConfig{
+//	    Bus:     bus,
+//	    BaseDir: "/tmp/session",
+//	    Plan:    plan,
+//	})
+//	result, _ := p.Decompose(pipeline.DecomposeConfig{
+//	    MaxTeamSize: 5,
+//	    ReviewTeam:  true,
+//	})
+//	_ = p.Start(ctx)
+//	defer p.Stop()
+package pipeline

--- a/internal/pipeline/options.go
+++ b/internal/pipeline/options.go
@@ -1,0 +1,15 @@
+package pipeline
+
+import "github.com/Iron-Ham/claudio/internal/coordination"
+
+// PipelineOption configures a Pipeline.
+type PipelineOption func(*pipelineConfig)
+
+// WithHubOptions sets coordination.Hub options that are forwarded to every
+// Manager created by the pipeline. Use this to configure scaling policies,
+// instance counts, timing parameters, etc.
+func WithHubOptions(opts ...coordination.Option) PipelineOption {
+	return func(c *pipelineConfig) {
+		c.hubOpts = append(c.hubOpts, opts...)
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1,0 +1,295 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+
+	"github.com/Iron-Ham/claudio/internal/event"
+	"github.com/Iron-Ham/claudio/internal/team"
+)
+
+// Pipeline orchestrates multi-phase team execution.
+//
+// It runs through sequential phases (planning → execution → review →
+// consolidation), creating a new [team.Manager] for each phase. The set of
+// phases is determined by the [DecomposeResult] produced by [Pipeline.Decompose].
+type Pipeline struct {
+	mu       sync.RWMutex
+	cfg      PipelineConfig
+	phase    PipelinePhase
+	managers map[PipelinePhase]*team.Manager
+	result   *DecomposeResult
+	cancel   context.CancelFunc
+	started  bool
+	pcfg     pipelineConfig
+	wg       sync.WaitGroup // tracks the run() goroutine
+}
+
+// NewPipeline creates a Pipeline with the given configuration and options.
+func NewPipeline(cfg PipelineConfig, opts ...PipelineOption) (*Pipeline, error) {
+	if cfg.Bus == nil {
+		return nil, errors.New("pipeline: Bus is required")
+	}
+	if cfg.BaseDir == "" {
+		return nil, errors.New("pipeline: BaseDir is required")
+	}
+	if cfg.Plan == nil {
+		return nil, errors.New("pipeline: Plan is required")
+	}
+
+	pc := &pipelineConfig{}
+	for _, opt := range opts {
+		opt(pc)
+	}
+
+	return &Pipeline{
+		cfg:      cfg,
+		managers: make(map[PipelinePhase]*team.Manager),
+		pcfg:     *pc,
+	}, nil
+}
+
+// Decompose runs the plan decomposer and stores the result for execution.
+// Must be called before Start.
+func (p *Pipeline) Decompose(dcfg DecomposeConfig) (*DecomposeResult, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.started {
+		return nil, errors.New("pipeline: cannot decompose after Start")
+	}
+
+	result, err := Decompose(p.cfg.Plan, dcfg)
+	if err != nil {
+		return nil, err
+	}
+
+	p.result = result
+	return result, nil
+}
+
+// Start begins multi-phase execution. Decompose must be called first.
+func (p *Pipeline) Start(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.started {
+		return errors.New("pipeline: already started")
+	}
+	if p.result == nil {
+		return errors.New("pipeline: Decompose must be called before Start")
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	p.cancel = cancel
+	p.started = true
+
+	// Run pipeline phases in a goroutine so Start returns immediately.
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		p.run(ctx)
+	}()
+
+	return nil
+}
+
+// Stop stops all running managers and the pipeline. It is idempotent.
+func (p *Pipeline) Stop() error {
+	p.mu.Lock()
+	if !p.started {
+		p.mu.Unlock()
+		return nil
+	}
+
+	if p.cancel != nil {
+		p.cancel()
+	}
+
+	for _, m := range p.managers {
+		_ = m.Stop()
+	}
+
+	p.started = false
+	p.mu.Unlock()
+
+	// Wait for the run() goroutine to finish outside the lock.
+	p.wg.Wait()
+	return nil
+}
+
+// Phase returns the pipeline's current phase.
+func (p *Pipeline) Phase() PipelinePhase {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.phase
+}
+
+// Manager returns the Manager for the given phase, or nil if that phase
+// has not been created yet.
+func (p *Pipeline) Manager(phase PipelinePhase) *team.Manager {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.managers[phase]
+}
+
+// Running returns whether the pipeline is currently started.
+func (p *Pipeline) Running() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.started
+}
+
+// run executes the pipeline phases sequentially.
+func (p *Pipeline) run(ctx context.Context) {
+	phasesRun := 0
+
+	// Planning phase.
+	if p.result.PlanningTeam != nil {
+		if err := p.runPhase(ctx, PhasePlanning, []team.Spec{*p.result.PlanningTeam}); err != nil {
+			p.fail(phasesRun)
+			return
+		}
+		phasesRun++
+	}
+
+	// Execution phase.
+	if len(p.result.ExecutionTeams) > 0 {
+		if err := p.runPhase(ctx, PhaseExecution, p.result.ExecutionTeams); err != nil {
+			p.fail(phasesRun)
+			return
+		}
+		phasesRun++
+	}
+
+	// Review phase.
+	if p.result.ReviewTeam != nil {
+		if err := p.runPhase(ctx, PhaseReview, []team.Spec{*p.result.ReviewTeam}); err != nil {
+			p.fail(phasesRun)
+			return
+		}
+		phasesRun++
+	}
+
+	// Consolidation phase.
+	if p.result.ConsolidationTeam != nil {
+		if err := p.runPhase(ctx, PhaseConsolidation, []team.Spec{*p.result.ConsolidationTeam}); err != nil {
+			p.fail(phasesRun)
+			return
+		}
+		phasesRun++
+	}
+
+	p.setPhase(PhaseDone)
+	p.cfg.Bus.Publish(event.NewPipelineCompletedEvent(p.cfg.Plan.ID, true, phasesRun))
+}
+
+// runPhase creates a Manager, registers teams, starts execution, and waits
+// for all teams to complete.
+func (p *Pipeline) runPhase(ctx context.Context, phase PipelinePhase, specs []team.Spec) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	phaseDir := filepath.Join(p.cfg.BaseDir, string(phase))
+	m, err := team.NewManager(team.ManagerConfig{
+		Bus:     p.cfg.Bus,
+		BaseDir: phaseDir,
+	}, team.WithHubOptions(p.pcfg.hubOpts...))
+	if err != nil {
+		return fmt.Errorf("pipeline: creating manager for %s: %w", phase, err)
+	}
+
+	// Store the Manager before publishing the phase-changed event so that
+	// subscribers calling p.Manager(phase) see the Manager immediately.
+	p.mu.Lock()
+	p.managers[phase] = m
+	p.mu.Unlock()
+
+	prev := p.setPhase(phase)
+	p.cfg.Bus.Publish(event.NewPipelinePhaseChangedEvent(
+		p.cfg.Plan.ID, string(prev), string(phase),
+	))
+
+	for _, spec := range specs {
+		if err := m.AddTeam(spec); err != nil {
+			return fmt.Errorf("pipeline: adding team %q to %s: %w", spec.ID, phase, err)
+		}
+	}
+
+	if err := m.Start(ctx); err != nil {
+		return fmt.Errorf("pipeline: starting %s: %w", phase, err)
+	}
+
+	// Wait for all teams in this phase to reach a terminal state.
+	if err := p.waitForCompletion(ctx, m); err != nil {
+		_ = m.Stop()
+		return err
+	}
+
+	// Check if any teams failed.
+	for _, s := range m.AllStatuses() {
+		if s.Phase == team.PhaseFailed {
+			_ = m.Stop()
+			return fmt.Errorf("pipeline: team %q failed in %s phase", s.ID, phase)
+		}
+	}
+
+	_ = m.Stop()
+	return nil
+}
+
+// waitForCompletion blocks until all teams in the manager have reached a
+// terminal phase, or the context is cancelled.
+func (p *Pipeline) waitForCompletion(ctx context.Context, m *team.Manager) error {
+	done := make(chan struct{}, 1)
+
+	checkDone := func() {
+		for _, s := range m.AllStatuses() {
+			if !s.Phase.IsTerminal() {
+				return
+			}
+		}
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	}
+
+	subID := p.cfg.Bus.Subscribe("team.completed", func(_ event.Event) {
+		checkDone()
+	})
+	defer p.cfg.Bus.Unsubscribe(subID)
+
+	// Check immediately in case all teams already completed.
+	checkDone()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-done:
+		return nil
+	}
+}
+
+// setPhase sets the pipeline's current phase and returns the previous phase.
+func (p *Pipeline) setPhase(phase PipelinePhase) PipelinePhase {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	prev := p.phase
+	p.phase = phase
+	return prev
+}
+
+// fail transitions the pipeline to the Failed phase and publishes a
+// PipelineCompletedEvent with the number of phases that ran before the failure.
+func (p *Pipeline) fail(phasesRun int) {
+	prev := p.setPhase(PhaseFailed)
+	p.cfg.Bus.Publish(event.NewPipelinePhaseChangedEvent(
+		p.cfg.Plan.ID, string(prev), string(PhaseFailed),
+	))
+	p.cfg.Bus.Publish(event.NewPipelineCompletedEvent(p.cfg.Plan.ID, false, phasesRun))
+}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1,0 +1,542 @@
+package pipeline
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/coordination"
+	"github.com/Iron-Ham/claudio/internal/event"
+	"github.com/Iron-Ham/claudio/internal/ultraplan"
+)
+
+func newTestPipeline(t *testing.T, plan *ultraplan.PlanSpec, opts ...PipelineOption) (*Pipeline, *event.Bus) {
+	t.Helper()
+	bus := event.NewBus()
+	cfg := PipelineConfig{
+		Bus:     bus,
+		BaseDir: t.TempDir(),
+		Plan:    plan,
+	}
+	// Always disable rebalance to avoid background goroutine interference.
+	opts = append(opts, WithHubOptions(coordination.WithRebalanceInterval(-1)))
+	p, err := NewPipeline(cfg, opts...)
+	if err != nil {
+		t.Fatalf("NewPipeline: %v", err)
+	}
+	return p, bus
+}
+
+func simplePlan() *ultraplan.PlanSpec {
+	return &ultraplan.PlanSpec{
+		ID:        "test-plan",
+		Objective: "Test objective",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "t1", Title: "Task 1", Files: []string{"a.go"}},
+		},
+	}
+}
+
+func TestNewPipeline_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     PipelineConfig
+		wantErr string
+	}{
+		{
+			name:    "missing bus",
+			cfg:     PipelineConfig{BaseDir: "/tmp", Plan: simplePlan()},
+			wantErr: "Bus is required",
+		},
+		{
+			name:    "missing dir",
+			cfg:     PipelineConfig{Bus: event.NewBus(), Plan: simplePlan()},
+			wantErr: "BaseDir is required",
+		},
+		{
+			name:    "missing plan",
+			cfg:     PipelineConfig{Bus: event.NewBus(), BaseDir: "/tmp"},
+			wantErr: "Plan is required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewPipeline(tt.cfg)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want containing %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPipeline_DecomposeBeforeStart(t *testing.T) {
+	p, _ := newTestPipeline(t, simplePlan())
+
+	result, err := p.Decompose(DecomposeConfig{})
+	if err != nil {
+		t.Fatalf("Decompose: %v", err)
+	}
+	if len(result.ExecutionTeams) != 1 {
+		t.Errorf("ExecutionTeams = %d, want 1", len(result.ExecutionTeams))
+	}
+}
+
+func TestPipeline_StartWithoutDecompose(t *testing.T) {
+	p, _ := newTestPipeline(t, simplePlan())
+
+	err := p.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected error starting without Decompose")
+	}
+	if !strings.Contains(err.Error(), "Decompose must be called") {
+		t.Errorf("error = %q, want containing 'Decompose must be called'", err.Error())
+	}
+}
+
+func TestPipeline_DecomposeAfterStart(t *testing.T) {
+	p, _ := newTestPipeline(t, simplePlan())
+
+	_, _ = p.Decompose(DecomposeConfig{})
+	_ = p.Start(context.Background())
+	defer func() { _ = p.Stop() }()
+
+	_, err := p.Decompose(DecomposeConfig{})
+	if err == nil {
+		t.Fatal("expected error decomposing after Start")
+	}
+}
+
+func TestPipeline_DoubleStart(t *testing.T) {
+	p, _ := newTestPipeline(t, simplePlan())
+	_, _ = p.Decompose(DecomposeConfig{})
+	_ = p.Start(context.Background())
+	defer func() { _ = p.Stop() }()
+
+	err := p.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected error for double start")
+	}
+}
+
+func TestPipeline_StopIdempotent(t *testing.T) {
+	p, _ := newTestPipeline(t, simplePlan())
+	_, _ = p.Decompose(DecomposeConfig{})
+	_ = p.Start(context.Background())
+
+	if err := p.Stop(); err != nil {
+		t.Fatalf("first Stop: %v", err)
+	}
+	if err := p.Stop(); err != nil {
+		t.Fatalf("second Stop: %v", err)
+	}
+}
+
+func TestPipeline_StopWithoutStart(t *testing.T) {
+	p, _ := newTestPipeline(t, simplePlan())
+	if err := p.Stop(); err != nil {
+		t.Fatalf("Stop without Start: %v", err)
+	}
+}
+
+func TestPipeline_ExecutionPhase(t *testing.T) {
+	plan := simplePlan()
+	p, bus := newTestPipeline(t, plan)
+
+	_, _ = p.Decompose(DecomposeConfig{})
+
+	// Collect pipeline phase changes.
+	phaseChanges := make(chan event.Event, 20)
+	bus.Subscribe("pipeline.phase_changed", func(e event.Event) {
+		phaseChanges <- e
+	})
+
+	completions := make(chan event.Event, 5)
+	bus.Subscribe("pipeline.completed", func(e event.Event) {
+		completions <- e
+	})
+
+	ctx := context.Background()
+	if err := p.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait for execution phase to begin.
+	waitForPipelinePhase(t, phaseChanges, "execution", 2*time.Second)
+
+	// Complete the execution team's tasks to advance the pipeline.
+	completeAllTeamTasks(t, p, PhaseExecution)
+
+	// Pipeline should complete.
+	select {
+	case e := <-completions:
+		pce := e.(event.PipelineCompletedEvent)
+		if !pce.Success {
+			t.Error("pipeline should have succeeded")
+		}
+		if pce.PhasesRun != 1 {
+			t.Errorf("PhasesRun = %d, want 1", pce.PhasesRun)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for pipeline completion")
+	}
+
+	if p.Phase() != PhaseDone {
+		t.Errorf("Phase = %v, want %v", p.Phase(), PhaseDone)
+	}
+}
+
+func TestPipeline_AllPhases(t *testing.T) {
+	plan := simplePlan()
+	p, bus := newTestPipeline(t, plan)
+
+	_, _ = p.Decompose(DecomposeConfig{
+		PlanningTeam:      true,
+		ReviewTeam:        true,
+		ConsolidationTeam: true,
+	})
+
+	phaseChanges := make(chan event.Event, 30)
+	bus.Subscribe("pipeline.phase_changed", func(e event.Event) {
+		phaseChanges <- e
+	})
+
+	completions := make(chan event.Event, 5)
+	bus.Subscribe("pipeline.completed", func(e event.Event) {
+		completions <- e
+	})
+
+	ctx := context.Background()
+	if err := p.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Planning phase.
+	waitForPipelinePhase(t, phaseChanges, "planning", 2*time.Second)
+	completeAllTeamTasks(t, p, PhasePlanning)
+
+	// Execution phase.
+	waitForPipelinePhase(t, phaseChanges, "execution", 2*time.Second)
+	completeAllTeamTasks(t, p, PhaseExecution)
+
+	// Review phase.
+	waitForPipelinePhase(t, phaseChanges, "review", 2*time.Second)
+	completeAllTeamTasks(t, p, PhaseReview)
+
+	// Consolidation phase.
+	waitForPipelinePhase(t, phaseChanges, "consolidation", 2*time.Second)
+	completeAllTeamTasks(t, p, PhaseConsolidation)
+
+	// Pipeline should complete.
+	select {
+	case e := <-completions:
+		pce := e.(event.PipelineCompletedEvent)
+		if !pce.Success {
+			t.Error("pipeline should have succeeded")
+		}
+		if pce.PhasesRun != 4 {
+			t.Errorf("PhasesRun = %d, want 4", pce.PhasesRun)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for pipeline completion")
+	}
+}
+
+func TestPipeline_ContextCancellation(t *testing.T) {
+	plan := simplePlan()
+	p, bus := newTestPipeline(t, plan)
+
+	_, _ = p.Decompose(DecomposeConfig{})
+
+	phaseChanges := make(chan event.Event, 20)
+	bus.Subscribe("pipeline.phase_changed", func(e event.Event) {
+		phaseChanges <- e
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := p.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait for execution to begin.
+	waitForPipelinePhase(t, phaseChanges, "execution", 2*time.Second)
+
+	// Cancel and let the pipeline fail gracefully.
+	cancel()
+
+	// Give time for the pipeline's run goroutine to handle cancellation.
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			// Pipeline should be in a terminal state or still running with cancelled context.
+			// Just stop it.
+			_ = p.Stop()
+			return
+		default:
+		}
+		phase := p.Phase()
+		if phase.IsTerminal() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	_ = p.Stop()
+}
+
+func TestPipeline_ManagerAccessor(t *testing.T) {
+	plan := simplePlan()
+	p, bus := newTestPipeline(t, plan)
+
+	_, _ = p.Decompose(DecomposeConfig{})
+
+	// Before start, no managers exist.
+	if m := p.Manager(PhaseExecution); m != nil {
+		t.Error("Manager should be nil before Start")
+	}
+
+	phaseChanges := make(chan event.Event, 20)
+	bus.Subscribe("pipeline.phase_changed", func(e event.Event) {
+		phaseChanges <- e
+	})
+
+	_ = p.Start(context.Background())
+	defer func() { _ = p.Stop() }()
+
+	// Wait for execution to begin.
+	waitForPipelinePhase(t, phaseChanges, "execution", 2*time.Second)
+
+	if m := p.Manager(PhaseExecution); m == nil {
+		t.Error("Manager should exist after execution phase starts")
+	}
+}
+
+func TestPipeline_RunningState(t *testing.T) {
+	plan := simplePlan()
+	p, _ := newTestPipeline(t, plan)
+
+	if p.Running() {
+		t.Error("should not be running before Start")
+	}
+
+	_, _ = p.Decompose(DecomposeConfig{})
+	_ = p.Start(context.Background())
+
+	if !p.Running() {
+		t.Error("should be running after Start")
+	}
+
+	_ = p.Stop()
+
+	if p.Running() {
+		t.Error("should not be running after Stop")
+	}
+}
+
+func TestPipeline_ExecutionFailure(t *testing.T) {
+	plan := simplePlan()
+	p, bus := newTestPipeline(t, plan)
+
+	_, _ = p.Decompose(DecomposeConfig{
+		ReviewTeam: true, // review phase should NOT run if execution fails
+	})
+
+	phaseChanges := make(chan event.Event, 20)
+	bus.Subscribe("pipeline.phase_changed", func(e event.Event) {
+		phaseChanges <- e
+	})
+
+	completions := make(chan event.Event, 5)
+	bus.Subscribe("pipeline.completed", func(e event.Event) {
+		completions <- e
+	})
+
+	_ = p.Start(context.Background())
+	defer func() { _ = p.Stop() }()
+
+	// Wait for execution phase.
+	waitForPipelinePhase(t, phaseChanges, "execution", 2*time.Second)
+
+	// Fail the task instead of completing it.
+	failAllTeamTasks(t, p, PhaseExecution)
+
+	// Pipeline should fail.
+	select {
+	case e := <-completions:
+		pce := e.(event.PipelineCompletedEvent)
+		if pce.Success {
+			t.Error("pipeline should have failed")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for pipeline failure")
+	}
+
+	if p.Phase() != PhaseFailed {
+		t.Errorf("Phase = %v, want %v", p.Phase(), PhaseFailed)
+	}
+}
+
+func TestPipeline_MultipleExecutionTeams(t *testing.T) {
+	plan := &ultraplan.PlanSpec{
+		ID:        "multi-plan",
+		Objective: "Multi team test",
+		Tasks: []ultraplan.PlannedTask{
+			{ID: "t1", Title: "Task 1", Files: []string{"a.go"}},
+			{ID: "t2", Title: "Task 2", Files: []string{"b.go"}},
+			{ID: "t3", Title: "Task 3", Files: []string{"c.go"}},
+		},
+	}
+	p, bus := newTestPipeline(t, plan)
+
+	result, _ := p.Decompose(DecomposeConfig{})
+	if len(result.ExecutionTeams) != 3 {
+		t.Fatalf("expected 3 execution teams, got %d", len(result.ExecutionTeams))
+	}
+
+	phaseChanges := make(chan event.Event, 20)
+	bus.Subscribe("pipeline.phase_changed", func(e event.Event) {
+		phaseChanges <- e
+	})
+	completions := make(chan event.Event, 5)
+	bus.Subscribe("pipeline.completed", func(e event.Event) {
+		completions <- e
+	})
+
+	_ = p.Start(context.Background())
+	defer func() { _ = p.Stop() }()
+
+	waitForPipelinePhase(t, phaseChanges, "execution", 2*time.Second)
+	completeAllTeamTasks(t, p, PhaseExecution)
+
+	select {
+	case e := <-completions:
+		pce := e.(event.PipelineCompletedEvent)
+		if !pce.Success {
+			t.Error("pipeline should have succeeded")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for pipeline completion")
+	}
+}
+
+// -- Test helpers ------------------------------------------------------------
+
+// waitForPipelinePhase waits for a specific pipeline phase change event.
+func waitForPipelinePhase(t *testing.T, ch <-chan event.Event, phase string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case e := <-ch:
+			pce := e.(event.PipelinePhaseChangedEvent)
+			if pce.CurrentPhase == phase {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for pipeline phase %q", phase)
+		}
+	}
+}
+
+// failAllTeamTasks fails all tasks in all teams for the given pipeline phase.
+func failAllTeamTasks(t *testing.T, p *Pipeline, phase PipelinePhase) {
+	t.Helper()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		m := p.Manager(phase)
+		if m != nil {
+			for _, s := range m.AllStatuses() {
+				tm := m.Team(s.ID)
+				if tm == nil {
+					continue
+				}
+				eq := tm.Hub().EventQueue()
+				for {
+					task, err := eq.ClaimNext("test-instance")
+					if err != nil || task == nil {
+						break
+					}
+					if err := eq.MarkRunning(task.ID); err != nil {
+						t.Fatalf("MarkRunning(%s): %v", task.ID, err)
+					}
+					if err := eq.Fail(task.ID, "intentional failure"); err != nil {
+						t.Fatalf("Fail(%s): %v", task.ID, err)
+					}
+				}
+			}
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for manager in phase %s", phase)
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}
+
+// completeAllTeamTasks completes all tasks in all teams for the given pipeline phase.
+// It polls until all teams are in terminal phases, claiming and completing tasks
+// as they become available.
+func completeAllTeamTasks(t *testing.T, p *Pipeline, phase PipelinePhase) {
+	t.Helper()
+
+	deadline := time.After(5 * time.Second)
+	for {
+		m := p.Manager(phase)
+		if m == nil {
+			select {
+			case <-deadline:
+				t.Fatalf("timed out waiting for manager in phase %s", phase)
+			default:
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
+		}
+
+		// Try to claim and complete tasks from all teams.
+		for _, s := range m.AllStatuses() {
+			tm := m.Team(s.ID)
+			if tm == nil {
+				continue
+			}
+			eq := tm.Hub().EventQueue()
+			for {
+				task, err := eq.ClaimNext("test-instance")
+				if err != nil || task == nil {
+					break
+				}
+				if err := eq.MarkRunning(task.ID); err != nil {
+					t.Fatalf("MarkRunning(%s): %v", task.ID, err)
+				}
+				if _, err := eq.Complete(task.ID); err != nil {
+					t.Fatalf("Complete(%s): %v", task.ID, err)
+				}
+			}
+		}
+
+		// Check if all teams are done.
+		allDone := true
+		for _, s := range m.AllStatuses() {
+			if !s.Phase.IsTerminal() {
+				allDone = false
+				break
+			}
+		}
+		if allDone {
+			return
+		}
+
+		select {
+		case <-deadline:
+			t.Fatalf("timed out completing tasks in phase %s", phase)
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -1,0 +1,78 @@
+package pipeline
+
+import (
+	"github.com/Iron-Ham/claudio/internal/coordination"
+	"github.com/Iron-Ham/claudio/internal/event"
+	"github.com/Iron-Ham/claudio/internal/team"
+	"github.com/Iron-Ham/claudio/internal/ultraplan"
+)
+
+// PipelinePhase represents a phase of the orchestration pipeline.
+type PipelinePhase string
+
+const (
+	// PhasePlanning indicates the pipeline is running a planning team.
+	PhasePlanning PipelinePhase = "planning"
+
+	// PhaseExecution indicates the pipeline is running execution teams.
+	PhaseExecution PipelinePhase = "execution"
+
+	// PhaseReview indicates the pipeline is running a review team.
+	PhaseReview PipelinePhase = "review"
+
+	// PhaseConsolidation indicates the pipeline is running a consolidation team.
+	PhaseConsolidation PipelinePhase = "consolidation"
+
+	// PhaseDone indicates the pipeline has completed successfully.
+	PhaseDone PipelinePhase = "done"
+
+	// PhaseFailed indicates the pipeline has failed.
+	PhaseFailed PipelinePhase = "failed"
+)
+
+// String returns the string representation of the phase.
+func (p PipelinePhase) String() string {
+	return string(p)
+}
+
+// IsTerminal returns true if this phase represents a final state.
+func (p PipelinePhase) IsTerminal() bool {
+	return p == PhaseDone || p == PhaseFailed
+}
+
+// PipelineConfig holds required dependencies for creating a Pipeline.
+type PipelineConfig struct {
+	Bus     *event.Bus          // Shared event bus for all phases
+	BaseDir string              // Base directory; per-phase subdirs created under this
+	Plan    *ultraplan.PlanSpec // The plan to decompose and execute
+}
+
+// DecomposeConfig configures how a plan is decomposed into teams.
+type DecomposeConfig struct {
+	MaxTeamSize       int  // Max tasks per team (0 = unlimited)
+	MinTeamSize       int  // Min tasks per team before merging (default: 1)
+	PlanningTeam      bool // Create a planning team phase
+	ReviewTeam        bool // Create a review team phase
+	ConsolidationTeam bool // Create a consolidation team phase
+}
+
+// defaults returns a copy of the config with defaults applied.
+func (c DecomposeConfig) defaults() DecomposeConfig {
+	if c.MinTeamSize < 1 {
+		c.MinTeamSize = 1
+	}
+	return c
+}
+
+// DecomposeResult holds the output of plan decomposition.
+type DecomposeResult struct {
+	ExecutionTeams    []team.Spec // Teams for the execution phase
+	PlanningTeam      *team.Spec  // Optional planning team (nil if disabled)
+	ReviewTeam        *team.Spec  // Optional review team (nil if disabled)
+	ConsolidationTeam *team.Spec  // Optional consolidation team (nil if disabled)
+}
+
+// pipelineConfig holds optional settings for the Pipeline.
+type pipelineConfig struct {
+	hubOpts []coordination.Option
+}

--- a/internal/pipeline/types_test.go
+++ b/internal/pipeline/types_test.go
@@ -1,0 +1,71 @@
+package pipeline
+
+import "testing"
+
+func TestPipelinePhase_String(t *testing.T) {
+	tests := []struct {
+		phase PipelinePhase
+		want  string
+	}{
+		{PhasePlanning, "planning"},
+		{PhaseExecution, "execution"},
+		{PhaseReview, "review"},
+		{PhaseConsolidation, "consolidation"},
+		{PhaseDone, "done"},
+		{PhaseFailed, "failed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.phase.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPipelinePhase_IsTerminal(t *testing.T) {
+	tests := []struct {
+		phase    PipelinePhase
+		terminal bool
+	}{
+		{PhasePlanning, false},
+		{PhaseExecution, false},
+		{PhaseReview, false},
+		{PhaseConsolidation, false},
+		{PhaseDone, true},
+		{PhaseFailed, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.phase.String(), func(t *testing.T) {
+			if got := tt.phase.IsTerminal(); got != tt.terminal {
+				t.Errorf("IsTerminal() = %v, want %v", got, tt.terminal)
+			}
+		})
+	}
+}
+
+func TestDecomposeConfig_Defaults(t *testing.T) {
+	t.Run("zero MinTeamSize becomes 1", func(t *testing.T) {
+		cfg := DecomposeConfig{MinTeamSize: 0}
+		got := cfg.defaults()
+		if got.MinTeamSize != 1 {
+			t.Errorf("MinTeamSize = %d, want 1", got.MinTeamSize)
+		}
+	})
+
+	t.Run("negative MinTeamSize becomes 1", func(t *testing.T) {
+		cfg := DecomposeConfig{MinTeamSize: -5}
+		got := cfg.defaults()
+		if got.MinTeamSize != 1 {
+			t.Errorf("MinTeamSize = %d, want 1", got.MinTeamSize)
+		}
+	})
+
+	t.Run("positive MinTeamSize preserved", func(t *testing.T) {
+		cfg := DecomposeConfig{MinTeamSize: 3}
+		got := cfg.defaults()
+		if got.MinTeamSize != 3 {
+			t.Errorf("MinTeamSize = %d, want 3", got.MinTeamSize)
+		}
+	})
+}

--- a/internal/team/AGENTS.md
+++ b/internal/team/AGENTS.md
@@ -10,10 +10,10 @@ See `doc.go` for package overview and API usage.
 The team package implements multi-team orchestration (Phase 2 of the Orchestrator of Orchestrators). It manages multiple teams running in parallel, each wrapping a `coordination.Hub`.
 
 **Core Components:**
-- **Manager** — Orchestrates team lifecycle, dependency ordering, and event routing. Teams are added before `Start`, then the manager handles cascading dependencies.
+- **Manager** — Orchestrates team lifecycle, dependency ordering, and event routing. Teams are added with `AddTeam` before `Start` or with `AddTeamDynamic` after. The manager handles cascading dependencies via `onTeamCompleted`.
 - **Team** — Wraps a `coordination.Hub` with team metadata, phase tracking, and budget monitoring.
-- **Router** — Delivers inter-team messages via each team's Hub mailbox as broadcasts. Uses `team:<teamID>` as the sender prefix.
-- **BudgetTracker** — Per-team resource monitoring via event bus. Publishes `TeamBudgetExhaustedEvent` when limits are exceeded.
+- **Router** — Delivers inter-team messages via each team's Hub mailbox as broadcasts. Uses `team:<teamID>` as the sender prefix. Delivery is best-effort; send errors are silently discarded so one failed delivery doesn't block a broadcast to others.
+- **BudgetTracker** — Per-team resource monitoring. The manager calls `Record()` after mapping instance metrics to teams. Does NOT subscribe to the event bus directly — the manager handles routing externally.
 
 **Dependency Flow:**
 ```
@@ -28,8 +28,11 @@ Manager.Start(ctx)
 - **Use EventQueue, not TaskQueue, for task operations** — The `monitorTeamCompletion` goroutine listens for `queue.depth_changed` events, which are only published by `EventQueue`. Operating directly on `TaskQueue` bypasses event publishing and the monitor won't detect completion. Use `hub.EventQueue()` or `hub.Gate()` for task lifecycle operations.
 - **Shared event bus, team-specific filtering** — All teams share one `event.Bus`. Event handlers must filter by team ID or instance membership. The `BudgetTracker` exposes `Record()` for the manager to call after mapping instances to teams.
 - **Insertion order for determinism** — `Manager.AllStatuses()` returns teams in insertion order using the `order` slice, not map iteration order. Always use the `order` slice for any deterministic iteration.
-- **AddTeam before Start only** — Adding teams after `Start` returns an error. Dynamic team addition is Phase 3 scope.
+- **AddTeam vs AddTeamDynamic** — `AddTeam` is for pre-Start registration. `AddTeamDynamic` can add teams after `Start` but uses a two-phase approach: register under lock, then start outside lock to prevent deadlock with the monitor goroutine's event chain.
+- **AddTeamDynamic uses Manager's context** — The `ctx` parameter on `AddTeamDynamic` is ignored; it uses the Manager's stored context (from `Start`) so `Stop` can cancel the new team's monitor goroutine. Passing a different context would cause `wg.Wait()` to hang on Stop.
 - **Manager holds write lock during startTeamLocked** — The `onTeamCompleted` handler acquires `m.mu` write lock. Since it's called from an event handler (which runs synchronously on the bus), avoid publishing events that would re-enter `onTeamCompleted` from within the lock.
+- **Failed dependencies do NOT unblock dependents** — `allDepsSatisfiedLocked` requires `PhaseDone`, not just any terminal phase. A failed dependency keeps dependent teams blocked forever. This is intentional — partial results from a failed team should not feed into dependent teams.
+- **Budget cleanup on Hub start failure** — `startTeamLocked` calls `t.budget.Stop()` if `t.hub.Start(ctx)` fails. Without this, the budget tracker leaks its "active" sentinel and appears started despite the team being in `PhaseFailed`.
 
 ## Testing
 

--- a/internal/team/budget_test.go
+++ b/internal/team/budget_test.go
@@ -131,21 +131,20 @@ func TestBudgetTracker_StartStop(t *testing.T) {
 	bus := event.NewBus()
 	bt := newBudgetTracker("team-1", TokenBudget{MaxInputTokens: 100}, bus)
 
-	initial := bus.SubscriptionCount()
-
+	// Start marks the tracker as active (no bus subscription needed — the
+	// manager routes events via Record externally).
 	bt.Start()
-	if bus.SubscriptionCount() <= initial {
-		t.Error("Start should add a subscription")
+
+	// Idempotent start should not panic.
+	bt.Start()
+
+	// Record should work while started.
+	bt.Record(10, 0, 0)
+	if bt.Usage().InputTokens != 10 {
+		t.Errorf("InputTokens = %d, want 10", bt.Usage().InputTokens)
 	}
 
-	// Idempotent start.
-	bt.Start()
-
+	// Stop and idempotent stop.
 	bt.Stop()
-	if bus.SubscriptionCount() != initial {
-		t.Error("Stop should remove the subscription")
-	}
-
-	// Idempotent stop.
 	bt.Stop()
 }

--- a/internal/team/router.go
+++ b/internal/team/router.go
@@ -103,7 +103,8 @@ func (r *Router) deliverToTeam(t *Team, msg InterTeamMessage) {
 		Body: fmt.Sprintf("[%s] %s", msg.Priority, msg.Content),
 	}
 
-	// Best-effort delivery — log errors but don't fail the route.
+	// Best-effort delivery — errors are ignored so that a single failed
+	// mailbox send does not prevent delivery to other teams in a broadcast.
 	_ = mb.Send(mbMsg)
 
 	r.bus.Publish(event.NewInterTeamMessageEvent(

--- a/internal/team/types_test.go
+++ b/internal/team/types_test.go
@@ -1,6 +1,7 @@
 package team
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Iron-Ham/claudio/internal/ultraplan"
@@ -144,7 +145,7 @@ func TestSpec_Validate(t *testing.T) {
 			} else {
 				if err == nil {
 					t.Errorf("Spec.Validate() = nil, want error containing %q", tt.wantErr)
-				} else if !contains(err.Error(), tt.wantErr) {
+				} else if !strings.Contains(err.Error(), tt.wantErr) {
 					t.Errorf("Spec.Validate() error = %q, want containing %q", err.Error(), tt.wantErr)
 				}
 			}
@@ -206,17 +207,4 @@ func TestInterTeamMessage_IsBroadcast(t *testing.T) {
 			}
 		})
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && searchString(s, substr)
-}
-
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Summary

Phase 3 of the Orchestrator of Orchestrators (#637): a plan decomposer and multi-phase pipeline that takes a `PlanSpec` and automatically creates, sequences, and runs the right teams across sequential phases.

**New package: `internal/pipeline/`**
- **Decomposer** — Groups tasks by file affinity using a union-find (disjoint set) algorithm. Tasks that share files are placed on the same team. Respects `MaxTeamSize` (splits large groups by priority) and `MinTeamSize` (merges small groups into nearest neighbor). Optionally generates planning, review, and consolidation team specs.
- **Pipeline** — Orchestrates multi-phase execution: planning → execution → review → consolidation → done. Each phase creates its own `team.Manager` with scoped event subscriptions and completion monitoring. Phase transitions are event-driven.
- **3 new event types** — `PipelinePhaseChangedEvent`, `PipelineCompletedEvent`, `TeamDynamicAddedEvent`

**Modifications to `internal/team/`**
- **`AddTeamDynamic`** — Adds a team to a running Manager. Uses a two-phase lock pattern (register under lock, start outside lock) to prevent deadlock with the synchronous event bus chain.
- **`buildAndRegisterTeamLocked`** — Extracted helper that deduplicates team creation between `AddTeam` and `AddTeamDynamic`.
- **Deep review fixes** — 14 issues identified and fixed across both Phase 2 and Phase 3 code, including: failed-dependency-blocks-dependent semantics, budget cleanup on hub failure, pipeline goroutine lifecycle tracking via WaitGroup, state-before-event-publish ordering, and test code simplification.

Stacked on #643 (Phase 2: Multi-Team Execution).
Closes Phase 3 scope of #637.

## Architecture

```
Pipeline.Start(ctx)
  ├─ Decompose(plan) → team specs grouped by file affinity
  ├─ PlanningTeam? → Manager(planning) → run to completion
  ├─ ExecutionTeams → Manager(execution) → run all teams (with deps)
  ├─ ReviewTeam? → Manager(review) → run to completion
  ├─ ConsolidationTeam? → Manager(consolidation) → run to completion
  └─ PhaseDone / PhaseFailed
```

Each phase gets a **fresh Manager** — this scopes event subscriptions, budget tracking, and completion monitoring to the phase lifetime, preventing cross-phase interference.

## Key Design Decisions

1. **Union-find for task decomposition** — O(n·α(n)) grouping by shared files. Deterministic output via sorted components. Well-understood algorithm with no external dependencies.
2. **Separate `pipeline` package** — Pipeline depends on `team`, not the reverse. Avoids god-package growth.
3. **One Manager per phase** — Simpler than adding/removing teams from a single long-lived Manager. Each phase's Manager is independent.
4. **`AddTeamDynamic` two-phase lock** — Register under write lock, start outside lock. Prevents deadlock because `startTeamLocked` → monitor goroutine → `team.completed` event → `onTeamCompleted` handler all chain through the synchronous event bus.
5. **Failed deps block forever** — `allDepsSatisfiedLocked` requires `PhaseDone`, not any terminal phase. A failed team's partial results should not feed into dependents.

## Test Plan

### Automated (all passing with `-race`)
- `go test -race -count=1 ./internal/pipeline/...` — 91.5% coverage
- `go test -race -count=1 ./internal/team/...` — 95.1% coverage
- `go test -race -count=1 ./...` — full suite, no regressions

### Manual Verification Steps

1. **Build verification**:
   ```bash
   go build ./...
   go vet ./...
   golangci-lint run
   ```

2. **Unit test with coverage**:
   ```bash
   go test -race -count=1 -coverprofile=coverage.out ./internal/pipeline/... ./internal/team/...
   go tool cover -func=coverage.out | grep -E "pipeline|team"
   ```

3. **Decomposer correctness** — Run pipeline tests and verify:
   - Tasks sharing files land on the same team
   - Disjoint tasks get separate teams
   - Single-task plans produce exactly one team
   - `MaxTeamSize` splits are respected
   - `MinTeamSize` merges small groups

4. **Pipeline phase transitions** — Verify via events:
   - Planning phase starts first (if enabled), then execution, review, consolidation
   - `PipelinePhaseChangedEvent` fires on each transition
   - `PipelineCompletedEvent` fires with correct `PhasesRun` count
   - Context cancellation causes `PhaseFailed`

5. **Dynamic team addition** — Verify:
   - `AddTeamDynamic` works after Manager.Start
   - New team starts immediately if deps are satisfied
   - New team enters Blocked phase if deps are not yet done
   - Blocked team unblocks when deps complete

6. **Failed dependency propagation** — Verify:
   - A failed team does NOT unblock its dependents
   - Dependents remain in `PhaseBlocked` forever

## Risk Assessment

| Risk | Likelihood | Impact | Mitigation |
|------|-----------|--------|------------|
| **Deadlock from synchronous event bus** | Low | High | Two-phase lock pattern in `AddTeamDynamic`; documented in AGENTS.md. Event handlers run inline, so lock ordering matters. |
| **Goroutine leak in Pipeline.run()** | Low | Medium | `WaitGroup` tracks the `run()` goroutine; `Stop()` cancels context then waits. Tests verify clean shutdown. |
| **Race in phase transition** | Low | High | All phase state is behind `sync.RWMutex`. Tested with `-race` flag. Manager stores state before publishing events. |
| **Union-find produces wrong groupings** | Very Low | Medium | Deterministic algorithm with comprehensive test cases (disjoint, overlapping, single-task, empty-files). |
| **Event bus subscription leak** | Low | Low | Manager unsubscribes completion handler in `Stop()`. Each pipeline phase creates/tears down its own Manager. |
| **Cross-phase interference** | Very Low | Medium | Each phase gets a fresh Manager with its own subscriptions. No shared mutable state between phase Managers. |

## Files Changed

### New (10 files)
- `internal/pipeline/doc.go` — Package docs
- `internal/pipeline/types.go` — PipelinePhase, PipelineConfig, DecomposeConfig, DecomposeResult
- `internal/pipeline/types_test.go` — Phase validation, config tests
- `internal/pipeline/decompose.go` — Union-find plan decomposer
- `internal/pipeline/decompose_test.go` — Decomposer edge cases
- `internal/pipeline/pipeline.go` — Multi-phase pipeline orchestration
- `internal/pipeline/pipeline_test.go` — Pipeline lifecycle tests
- `internal/pipeline/options.go` — Functional options
- `internal/pipeline/AGENTS.md` — Agent guidelines
- `internal/pipeline/CLAUDE.md` — Symlink to AGENTS.md

### Modified (11 files)
- `internal/event/types.go` — 3 new event types + section header fix
- `internal/team/manager.go` — `AddTeamDynamic`, `buildAndRegisterTeamLocked`, failed-dep fix, budget cleanup
- `internal/team/manager_test.go` — Dynamic team tests, failed-dep test, code cleanup
- `internal/team/budget.go` — Simplified start/stop (removed no-op subscription)
- `internal/team/budget_test.go` — Updated for simplified budget tracker
- `internal/team/router.go` — Accurate best-effort delivery comment
- `internal/team/types_test.go` — Replaced custom helpers with `strings.Contains`
- `internal/team/AGENTS.md` — New pitfalls (failed deps, budget cleanup, AddTeamDynamic)
- `internal/pipeline/AGENTS.md` — New pitfalls (state-before-event, WaitGroup, fail phasesRun)
- `AGENTS.md` (root) — New pitfalls and patterns (event bus re-entrancy, decorator chain, one-Manager-per-phase)
- `CHANGELOG.md` — Added entry