### PR TITLE
Add bridge execution layer connecting teams to Claude Code instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Bridge Execution Layer** - Bridge package (`internal/bridge/`) and adapter wiring (`internal/orchestrator/bridgewire/`) that connect team Hubs to real Claude Code instances. Each Bridge claims tasks from a team's queue, spawns worktree + tmux instances, monitors for completion via sentinel files, and reports outcomes back to the queue. PipelineExecutor subscribes to pipeline phase transitions and attaches Bridges to execution-phase teams automatically. (#647)
+
 - **Pipeline Orchestration** - Plan decomposer and multi-phase pipeline (`internal/pipeline/`) for team-based execution. Groups tasks by file affinity using union-find, then orchestrates sequential phases (planning → execution → review → consolidation). Each phase runs its own Manager with scoped teams. Adds pipeline lifecycle events and dynamic team addition to the team Manager. (Phase 3 of Orchestrator of Orchestrators, #637)
 
 - **Multi-Team Execution** - Multi-team orchestration layer (`internal/team/`) that runs multiple teams in parallel, each with its own Coordination Hub. Supports inter-team dependency ordering, per-team budget tracking with exhaustion detection, and inter-team message routing via existing mailbox infrastructure. Adds team lifecycle events (created, phase changed, completed, budget exhausted) and inter-team message events to the event bus. (#637)

--- a/internal/bridge/AGENTS.md
+++ b/internal/bridge/AGENTS.md
@@ -1,0 +1,55 @@
+# bridge — Agent Guidelines
+
+> **Living document.** Update this file when you learn something specific to this package.
+> Same rules as the root `AGENTS.md` — see its Self-Improvement Protocol.
+
+See `doc.go` for package overview and API usage.
+
+## Architecture
+
+The bridge package connects team Hubs (Orchestration 2.0's task pipeline) to real Claude Code instances (worktrees + tmux). Each Bridge is scoped to one team and runs independently.
+
+**Core Flow:**
+```
+Gate.ClaimNext() → InstanceFactory.CreateInstance() → StartInstance()
+    → monitor loop (poll CompletionChecker)
+    → Gate.Complete/Fail() + SessionRecorder
+```
+
+**Interfaces (Ports):**
+- `InstanceFactory` — Creates and starts Claude Code instances
+- `CompletionChecker` — Detects sentinel files and verifies work
+- `SessionRecorder` — Records session state changes (task assignments, completions, failures)
+- `Instance` — Read-only handle to a created instance (ID, WorktreePath, Branch)
+
+These interfaces are implemented by adapters in `internal/orchestrator/bridgewire/`.
+
+**Concurrency Model:**
+- One claim-loop goroutine per Bridge
+- One monitor goroutine per active task
+- All goroutines tracked via `sync.WaitGroup` for clean shutdown
+- Running map (`taskID → instanceID`) protected by `sync.RWMutex`
+
+## Pitfalls
+
+- **Import cycle with ultraplan** — The `bridge` package must NOT import `ultraplan` or `orchestrator`. The chain `bridge → team → coordination → ... → ultraplan → orchestrator` creates a cycle if `orchestrator` imports `bridge`. Use simple types (strings, slices) rather than concrete domain types in the bridge API. The `BuildTaskPrompt` function accepts `(title, description string, files []string)` instead of `ultraplan.PlannedTask` for this reason.
+- **Event-driven wake pattern** — The claim loop subscribes to `queue.depth_changed` events and blocks on a buffered channel. Don't replace this with polling — the event-driven approach is more efficient and responsive.
+- **Gate.IsComplete exit condition** — The claim loop exits when there are no tasks and `gate.IsComplete()` returns true (all tasks terminal). Without this check, the loop would block forever waiting for new tasks that will never arrive.
+- **Publish events outside the lock** — `BridgeTaskStartedEvent` and `BridgeTaskCompletedEvent` are published outside the mutex to avoid deadlock with synchronous event handlers that might call back into the bridge.
+- **Clean running map before callbacks** — The monitor cleans up the `running` map before calling `RecordCompletion`/`RecordFailure` or publishing events. This ensures observers see consistent state when their callbacks fire.
+- **Stop() lifecycle: cancel → drain → mark stopped** — `Stop()` cancels the context, releases the lock, calls `wg.Wait()`, then re-acquires the lock to set `started=false`. Setting `started=false` before `wg.Wait()` would allow a premature `Start()` that corrupts the WaitGroup.
+- **Nil interface arguments panic immediately** — The `New()` constructor panics on nil arguments rather than deferring the nil-pointer dereference to runtime. This surfaces wiring bugs at construction time.
+- **Retry limit on completion check errors** — The monitor gives up after `maxCheckErrors` (10) consecutive `CheckCompletion` failures and fails the task. Without this, a bad worktree path would cause indefinite retries.
+- **TaskQueue retry interacts with bridge claim loop** — `TaskQueue.Fail()` has retry logic (`defaultMaxRetries=2`). When the bridge monitor calls `gate.Fail()`, the task may return to `TaskPending` (not permanently failed), and the claim loop re-claims it. Tests that assert on `Running()` after failure must either disable retries via `SetMaxRetries(taskID, 0)` or account for the re-claim cycle.
+- **Always log gate.Fail errors** — `gate.Fail()` can fail if the task has already transitioned. Always check and log the return error rather than discarding with `_ =`.
+
+## Testing
+
+- Use `newTestTeam` helper (in `bridge_test.go`) which creates a `team.Manager` → `AddTeam` → `Start` flow to get a real `*team.Team` with a functioning Hub.
+- Always use `coordination.WithRebalanceInterval(-1)` to disable the adaptive lead's rebalance loop.
+- Use `WithPollInterval(10*time.Millisecond)` for fast tests.
+- Event assertions use `waitForEvent` with channel + timeout, not `time.Sleep`.
+- For error-path tests where the task becomes terminal (e.g., `CreateInstanceError`), use `stopWithTimeout` — the claim loop exits via `IsComplete()` once the task fails, so `Stop()` returns without needing a separate event.
+- For tests that need to observe side effects before stopping (e.g., recorder signals), use a `signalingRecorder` that sends on a channel. Don't call `Stop()` before the signal — `Stop()` cancels the context, which races with the monitor.
+- **Wait for team completion before cleanup** — When a task reaches terminal state, the team Manager's `monitorTeamCompletion` goroutine publishes `TeamCompletedEvent` inline (which calls `onTeamCompleted`, acquiring `Manager.mu`). If `Manager.Stop()` runs during test cleanup before this finishes, it deadlocks (Stop holds `m.mu` through `wg.Wait()`). Subscribe to `team.completed` early and wait on it before the test ends. See `TestBridge_MaxCheckErrorsFailsTask` for the pattern.
+- Always run with `-race` — the bridge has concurrent goroutines.

--- a/internal/bridge/CLAUDE.md
+++ b/internal/bridge/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -1,0 +1,359 @@
+package bridge
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/event"
+	"github.com/Iron-Ham/claudio/internal/logging"
+	"github.com/Iron-Ham/claudio/internal/team"
+)
+
+// Bridge connects a single team's Hub to real Claude Code instances.
+//
+// It claims tasks from the team's Gate, creates instances via the
+// InstanceFactory, monitors them for completion, and reports outcomes
+// back through the Gate and SessionRecorder.
+type Bridge struct {
+	team     *team.Team
+	factory  InstanceFactory
+	checker  CompletionChecker
+	recorder SessionRecorder
+	bus      *event.Bus
+	logger   *logging.Logger
+
+	pollInterval time.Duration
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	mu      sync.RWMutex
+	running map[string]string // taskID → instanceID
+	started bool
+}
+
+// New creates a Bridge for the given team.
+//
+// All interface arguments (factory, checker, recorder) and the bus must be
+// non-nil. Passing nil will panic early to surface wiring bugs immediately.
+func New(t *team.Team, factory InstanceFactory, checker CompletionChecker, recorder SessionRecorder, bus *event.Bus, opts ...Option) *Bridge {
+	if t == nil {
+		panic("bridge: team must not be nil")
+	}
+	if factory == nil {
+		panic("bridge: InstanceFactory must not be nil")
+	}
+	if checker == nil {
+		panic("bridge: CompletionChecker must not be nil")
+	}
+	if recorder == nil {
+		panic("bridge: SessionRecorder must not be nil")
+	}
+	if bus == nil {
+		panic("bridge: event.Bus must not be nil")
+	}
+
+	cfg := &config{
+		pollInterval: defaultPollInterval,
+		logger:       logging.NopLogger(),
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	if cfg.pollInterval <= 0 {
+		cfg.pollInterval = defaultPollInterval
+	}
+	if cfg.logger == nil {
+		cfg.logger = logging.NopLogger()
+	}
+
+	return &Bridge{
+		team:         t,
+		factory:      factory,
+		checker:      checker,
+		recorder:     recorder,
+		bus:          bus,
+		logger:       cfg.logger,
+		pollInterval: cfg.pollInterval,
+		running:      make(map[string]string),
+	}
+}
+
+// Start begins the claim loop. It returns immediately; the loop runs in
+// a background goroutine. Call Stop to shut down.
+func (b *Bridge) Start(ctx context.Context) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.started {
+		return fmt.Errorf("bridge: already started")
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	b.ctx = ctx
+	b.cancel = cancel
+	b.started = true
+
+	b.wg.Add(1)
+	go func() {
+		defer b.wg.Done()
+		b.claimLoop()
+	}()
+
+	return nil
+}
+
+// Stop cancels the context and waits for all goroutines to finish.
+// It is safe to call multiple times.
+func (b *Bridge) Stop() {
+	b.mu.Lock()
+	if !b.started {
+		b.mu.Unlock()
+		return
+	}
+	b.cancel()
+	b.mu.Unlock()
+
+	b.wg.Wait()
+
+	b.mu.Lock()
+	b.started = false
+	b.mu.Unlock()
+}
+
+// Running returns the current mapping of taskID → instanceID for active tasks.
+func (b *Bridge) Running() map[string]string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	out := make(map[string]string, len(b.running))
+	for k, v := range b.running {
+		out[k] = v
+	}
+	return out
+}
+
+// claimLoop continuously claims tasks from the team's Gate and spawns
+// monitor goroutines for each one. It exits when the context is cancelled.
+func (b *Bridge) claimLoop() {
+	// Subscribe to queue depth changes so we can wake up when new tasks appear.
+	wake := make(chan struct{}, 1)
+	subID := b.bus.Subscribe("queue.depth_changed", func(_ event.Event) {
+		select {
+		case wake <- struct{}{}:
+		default:
+		}
+	})
+	defer b.bus.Unsubscribe(subID)
+
+	for {
+		if err := b.ctx.Err(); err != nil {
+			return
+		}
+
+		gate := b.team.Hub().Gate()
+
+		// Use the team ID as a claim identifier for traceability.
+		// The real instance ID is recorded after CreateInstance.
+		claimID := fmt.Sprintf("bridge-%s", b.team.Spec().ID)
+
+		task, err := gate.ClaimNext(claimID)
+		if err != nil {
+			b.logger.Error("bridge claim failed", "team", b.team.Spec().ID, "error", err)
+			b.waitForWake(wake)
+			continue
+		}
+
+		if task == nil {
+			if gate.IsComplete() {
+				return
+			}
+			b.waitForWake(wake)
+			continue
+		}
+
+		// Build a prompt and create an instance.
+		prompt := BuildTaskPrompt(task.Title, task.Description, task.Files)
+		inst, err := b.factory.CreateInstance(prompt)
+		if err != nil {
+			b.logger.Error("bridge: failed to create instance",
+				"team", b.team.Spec().ID, "task", task.ID, "error", err)
+			if failErr := gate.Fail(task.ID, fmt.Sprintf("create instance: %v", err)); failErr != nil {
+				b.logger.Error("bridge: gate.Fail also failed",
+					"task", task.ID, "error", failErr)
+			}
+			continue
+		}
+
+		if err := b.factory.StartInstance(inst); err != nil {
+			b.logger.Error("bridge: failed to start instance",
+				"team", b.team.Spec().ID, "task", task.ID, "error", err)
+			if failErr := gate.Fail(task.ID, fmt.Sprintf("start instance: %v", err)); failErr != nil {
+				b.logger.Error("bridge: gate.Fail also failed",
+					"task", task.ID, "error", failErr)
+			}
+			continue
+		}
+
+		// Transition the task to running.
+		if err := gate.MarkRunning(task.ID); err != nil {
+			b.logger.Error("bridge: failed to mark running",
+				"team", b.team.Spec().ID, "task", task.ID, "error", err)
+			if failErr := gate.Fail(task.ID, fmt.Sprintf("mark running: %v", err)); failErr != nil {
+				b.logger.Error("bridge: gate.Fail also failed",
+					"task", task.ID, "error", failErr)
+			}
+			continue
+		}
+
+		// Record assignment and publish event.
+		b.recorder.AssignTask(task.ID, inst.ID())
+
+		b.mu.Lock()
+		b.running[task.ID] = inst.ID()
+		b.mu.Unlock()
+
+		b.bus.Publish(event.NewBridgeTaskStartedEvent(
+			b.team.Spec().ID, task.ID, inst.ID(),
+		))
+
+		// Spawn a monitor goroutine for this task.
+		b.wg.Add(1)
+		go func(taskID string, inst Instance) {
+			defer b.wg.Done()
+			b.monitorInstance(taskID, inst)
+		}(task.ID, inst)
+	}
+}
+
+// waitForWake blocks until either the wake channel fires or the context is cancelled.
+func (b *Bridge) waitForWake(wake <-chan struct{}) {
+	select {
+	case <-b.ctx.Done():
+	case <-wake:
+	}
+}
+
+// maxCheckErrors is the number of consecutive completion check failures before
+// the bridge gives up and fails the task. This prevents indefinite retries
+// when the worktree path is invalid or the filesystem is unhealthy.
+const maxCheckErrors = 10
+
+// monitorInstance polls for instance completion and reports the result.
+func (b *Bridge) monitorInstance(taskID string, inst Instance) {
+	ticker := time.NewTicker(b.pollInterval)
+	defer ticker.Stop()
+
+	consecutiveErrors := 0
+
+	for {
+		select {
+		case <-b.ctx.Done():
+			b.logger.Info("bridge: monitor cancelled, cleaning up",
+				"task", taskID)
+			b.mu.Lock()
+			delete(b.running, taskID)
+			b.mu.Unlock()
+			return
+		case <-ticker.C:
+		}
+
+		done, err := b.checker.CheckCompletion(inst.WorktreePath())
+		if err != nil {
+			consecutiveErrors++
+			b.logger.Warn("bridge: completion check error",
+				"task", taskID, "error", err,
+				"consecutive", consecutiveErrors)
+			if consecutiveErrors >= maxCheckErrors {
+				b.logger.Error("bridge: max check errors reached, failing task",
+					"task", taskID, "limit", maxCheckErrors)
+				gate := b.team.Hub().Gate()
+				reason := fmt.Sprintf("completion check failed %d times: %v", maxCheckErrors, err)
+				if failErr := gate.Fail(taskID, reason); failErr != nil {
+					b.logger.Error("bridge: gate.Fail failed after check errors",
+						"task", taskID, "error", failErr)
+				}
+				// Clean up running map before recording, so observers see
+				// a consistent state when the recorder callback fires.
+				b.mu.Lock()
+				delete(b.running, taskID)
+				b.mu.Unlock()
+				b.recorder.RecordFailure(taskID, reason)
+				return
+			}
+			continue
+		}
+		consecutiveErrors = 0
+
+		if !done {
+			continue
+		}
+
+		// Instance wrote its sentinel file. Verify the work.
+		success, commitCount, verifyErr := b.checker.VerifyWork(
+			taskID, inst.ID(), inst.WorktreePath(), inst.Branch(),
+		)
+
+		gate := b.team.Hub().Gate()
+		teamID := b.team.Spec().ID
+
+		// Clean up running map before recording/publishing so observers see
+		// consistent state when callbacks or event handlers fire.
+		b.mu.Lock()
+		delete(b.running, taskID)
+		b.mu.Unlock()
+
+		if success {
+			if _, completeErr := gate.Complete(taskID); completeErr != nil {
+				b.logger.Error("bridge: failed to complete task",
+					"task", taskID, "error", completeErr)
+			}
+			b.recorder.RecordCompletion(taskID, commitCount)
+			b.bus.Publish(event.NewBridgeTaskCompletedEvent(
+				teamID, taskID, inst.ID(), true, commitCount, "",
+			))
+		} else {
+			reason := "verification failed"
+			if verifyErr != nil {
+				reason = verifyErr.Error()
+			}
+			if failErr := gate.Fail(taskID, reason); failErr != nil {
+				b.logger.Error("bridge: failed to fail task",
+					"task", taskID, "error", failErr)
+			}
+			b.recorder.RecordFailure(taskID, reason)
+			b.bus.Publish(event.NewBridgeTaskCompletedEvent(
+				teamID, taskID, inst.ID(), false, commitCount, reason,
+			))
+		}
+
+		return
+	}
+}
+
+// BuildTaskPrompt formats task fields into a prompt string for a Claude Code instance.
+// Accepts basic fields rather than a concrete type to avoid import cycles.
+// The coordinator adapters may use the orchestrator's prompt.TaskBuilder for
+// richer formatting; this is the bridge-level default.
+func BuildTaskPrompt(title, description string, files []string) string {
+	var sb strings.Builder
+	sb.WriteString("# Task: ")
+	sb.WriteString(title)
+	sb.WriteString("\n\n")
+	sb.WriteString(description)
+
+	if len(files) > 0 {
+		sb.WriteString("\n\n## Files\n")
+		for _, f := range files {
+			sb.WriteString("- ")
+			sb.WriteString(f)
+			sb.WriteString("\n")
+		}
+	}
+
+	return sb.String()
+}

--- a/internal/bridge/bridge_test.go
+++ b/internal/bridge/bridge_test.go
@@ -1,0 +1,906 @@
+package bridge_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/bridge"
+	"github.com/Iron-Ham/claudio/internal/coordination"
+	"github.com/Iron-Ham/claudio/internal/event"
+	"github.com/Iron-Ham/claudio/internal/logging"
+	"github.com/Iron-Ham/claudio/internal/team"
+	"github.com/Iron-Ham/claudio/internal/ultraplan"
+)
+
+// --- Mock implementations ------------------------------------------------
+
+type mockInstance struct {
+	id           string
+	worktreePath string
+	branch       string
+}
+
+func (m *mockInstance) ID() string           { return m.id }
+func (m *mockInstance) WorktreePath() string { return m.worktreePath }
+func (m *mockInstance) Branch() string       { return m.branch }
+
+type mockFactory struct {
+	mu        sync.Mutex
+	created   []string // prompts
+	instances map[string]*mockInstance
+	createErr error
+	startErr  error
+}
+
+func newMockFactory() *mockFactory {
+	return &mockFactory{
+		instances: make(map[string]*mockInstance),
+	}
+}
+
+func (f *mockFactory) CreateInstance(prompt string) (bridge.Instance, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+
+	id := prompt[:min(8, len(prompt))]
+	inst := &mockInstance{
+		id:           "inst-" + id,
+		worktreePath: "/tmp/wt-" + id,
+		branch:       "branch-" + id,
+	}
+	f.created = append(f.created, prompt)
+	f.instances[inst.id] = inst
+	return inst, nil
+}
+
+func (f *mockFactory) StartInstance(inst bridge.Instance) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.startErr
+}
+
+func (f *mockFactory) Created() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.created))
+	copy(out, f.created)
+	return out
+}
+
+type mockChecker struct {
+	mu          sync.Mutex
+	completions map[string]bool // worktreePath → done
+	verifyOK    bool
+	commitCount int
+	verifyErr   error
+}
+
+func newMockChecker() *mockChecker {
+	return &mockChecker{
+		completions: make(map[string]bool),
+		verifyOK:    true,
+		commitCount: 1,
+	}
+}
+
+func (c *mockChecker) CheckCompletion(worktreePath string) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.completions[worktreePath], nil
+}
+
+func (c *mockChecker) VerifyWork(_, _, _, _ string) (bool, int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.verifyOK, c.commitCount, c.verifyErr
+}
+
+func (c *mockChecker) MarkComplete(worktreePath string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.completions[worktreePath] = true
+}
+
+type mockRecorder struct {
+	mu        sync.Mutex
+	assigned  map[string]string // taskID → instanceID
+	completed map[string]int    // taskID → commitCount
+	failed    map[string]string // taskID → reason
+}
+
+func newMockRecorder() *mockRecorder {
+	return &mockRecorder{
+		assigned:  make(map[string]string),
+		completed: make(map[string]int),
+		failed:    make(map[string]string),
+	}
+}
+
+func (r *mockRecorder) AssignTask(taskID, instanceID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.assigned[taskID] = instanceID
+}
+
+func (r *mockRecorder) RecordCompletion(taskID string, commitCount int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.completed[taskID] = commitCount
+}
+
+func (r *mockRecorder) RecordFailure(taskID, reason string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.failed[taskID] = reason
+}
+
+func (r *mockRecorder) Assigned() map[string]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make(map[string]string, len(r.assigned))
+	for k, v := range r.assigned {
+		out[k] = v
+	}
+	return out
+}
+
+func (r *mockRecorder) Completed() map[string]int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make(map[string]int, len(r.completed))
+	for k, v := range r.completed {
+		out[k] = v
+	}
+	return out
+}
+
+func (r *mockRecorder) Failed() map[string]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make(map[string]string, len(r.failed))
+	for k, v := range r.failed {
+		out[k] = v
+	}
+	return out
+}
+
+// --- Helpers -------------------------------------------------------------
+
+// newTestTeam creates a team.Manager with one team, starts it, and returns the Team pointer.
+func newTestTeam(t *testing.T, bus *event.Bus, tasks []ultraplan.PlannedTask) *team.Team {
+	t.Helper()
+
+	mgr, err := team.NewManager(team.ManagerConfig{
+		Bus:     bus,
+		BaseDir: t.TempDir(),
+	}, team.WithHubOptions(coordination.WithRebalanceInterval(-1)))
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	spec := team.Spec{
+		ID:       "test-team",
+		Name:     "Test Team",
+		Role:     team.RoleExecution,
+		Tasks:    tasks,
+		TeamSize: 1,
+	}
+	if err := mgr.AddTeam(spec); err != nil {
+		t.Fatalf("AddTeam: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	if err := mgr.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.Stop() })
+
+	tt := mgr.Team("test-team")
+	if tt == nil {
+		t.Fatal("team not found after AddTeam + Start")
+	}
+	return tt
+}
+
+func waitForEvent(t *testing.T, bus *event.Bus, eventType string, timeout time.Duration) event.Event {
+	t.Helper()
+	ch := make(chan event.Event, 1)
+	subID := bus.Subscribe(eventType, func(e event.Event) {
+		select {
+		case ch <- e:
+		default:
+		}
+	})
+	defer bus.Unsubscribe(subID)
+
+	select {
+	case e := <-ch:
+		return e
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for %q event", eventType)
+		return nil
+	}
+}
+
+// stopWithTimeout calls b.Stop() and fails the test if it doesn't return
+// within the deadline. This replaces time.Sleep for error-path tests where
+// the claim loop exits via IsComplete after a terminal task failure.
+func stopWithTimeout(t *testing.T, b *bridge.Bridge, timeout time.Duration) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		b.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatal("bridge.Stop() did not return within timeout")
+	}
+}
+
+// --- Tests ---------------------------------------------------------------
+
+func TestBridge_ClaimAndComplete(t *testing.T) {
+	bus := event.NewBus()
+	tasks := []ultraplan.PlannedTask{
+		{ID: "t1", Title: "Task 1", Description: "Do thing 1", Files: []string{"a.go"}},
+	}
+	tt := newTestTeam(t, bus, tasks)
+
+	factory := newMockFactory()
+	checker := newMockChecker()
+	recorder := newMockRecorder()
+
+	b := bridge.New(tt, factory, checker, recorder, bus,
+		bridge.WithPollInterval(10*time.Millisecond),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := b.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer b.Stop()
+
+	// Wait for the bridge to claim and start the task.
+	e := waitForEvent(t, bus, "bridge.task_started", 2*time.Second)
+	started := e.(event.BridgeTaskStartedEvent)
+	if started.TaskID != "t1" {
+		t.Errorf("started.TaskID = %q, want %q", started.TaskID, "t1")
+	}
+	if started.TeamID != "test-team" {
+		t.Errorf("started.TeamID = %q, want %q", started.TeamID, "test-team")
+	}
+
+	// Verify the factory was called.
+	created := factory.Created()
+	if len(created) != 1 {
+		t.Fatalf("factory.Created() = %d prompts, want 1", len(created))
+	}
+
+	// Verify the recorder was called.
+	assigned := recorder.Assigned()
+	if _, ok := assigned["t1"]; !ok {
+		t.Error("recorder.AssignTask not called for t1")
+	}
+
+	// Verify the task is in the running map.
+	running := b.Running()
+	if _, ok := running["t1"]; !ok {
+		t.Error("Running() should contain t1")
+	}
+
+	// Now signal completion via the mock checker.
+	factory.mu.Lock()
+	var worktreePath string
+	for _, inst := range factory.instances {
+		worktreePath = inst.worktreePath
+		break
+	}
+	factory.mu.Unlock()
+
+	checker.MarkComplete(worktreePath)
+
+	// Wait for the bridge to complete the task.
+	ce := waitForEvent(t, bus, "bridge.task_completed", 2*time.Second)
+	completed := ce.(event.BridgeTaskCompletedEvent)
+	if completed.TaskID != "t1" {
+		t.Errorf("completed.TaskID = %q, want %q", completed.TaskID, "t1")
+	}
+	if !completed.Success {
+		t.Error("completed.Success = false, want true")
+	}
+	if completed.CommitCount != 1 {
+		t.Errorf("completed.CommitCount = %d, want 1", completed.CommitCount)
+	}
+
+	// Verify recorder got the completion.
+	completedTasks := recorder.Completed()
+	if count, ok := completedTasks["t1"]; !ok || count != 1 {
+		t.Errorf("recorder.Completed[t1] = %d, want 1", count)
+	}
+
+	// Verify the running map is cleared.
+	running = b.Running()
+	if len(running) != 0 {
+		t.Errorf("Running() = %v, want empty", running)
+	}
+}
+
+func TestBridge_VerificationFailure(t *testing.T) {
+	bus := event.NewBus()
+	tasks := []ultraplan.PlannedTask{
+		{ID: "t1", Title: "Task 1", Description: "Do thing 1"},
+	}
+	tt := newTestTeam(t, bus, tasks)
+
+	factory := newMockFactory()
+	checker := newMockChecker()
+	checker.verifyOK = false
+	checker.verifyErr = errors.New("no commits")
+	recorder := newMockRecorder()
+
+	b := bridge.New(tt, factory, checker, recorder, bus,
+		bridge.WithPollInterval(10*time.Millisecond),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := b.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer b.Stop()
+
+	// Wait for task to start.
+	waitForEvent(t, bus, "bridge.task_started", 2*time.Second)
+
+	// Get worktree path and mark complete so monitor picks it up.
+	factory.mu.Lock()
+	var wtp string
+	for _, inst := range factory.instances {
+		wtp = inst.worktreePath
+		break
+	}
+	factory.mu.Unlock()
+	checker.MarkComplete(wtp)
+
+	// Wait for bridge to report failure.
+	ce := waitForEvent(t, bus, "bridge.task_completed", 2*time.Second)
+	completed := ce.(event.BridgeTaskCompletedEvent)
+	if completed.Success {
+		t.Error("completed.Success = true, want false")
+	}
+	if completed.Error != "no commits" {
+		t.Errorf("completed.Error = %q, want %q", completed.Error, "no commits")
+	}
+
+	// Verify recorder got the failure.
+	failed := recorder.Failed()
+	if reason, ok := failed["t1"]; !ok || reason != "no commits" {
+		t.Errorf("recorder.Failed[t1] = %q, want %q", reason, "no commits")
+	}
+}
+
+func TestBridge_CreateInstanceError(t *testing.T) {
+	bus := event.NewBus()
+	tasks := []ultraplan.PlannedTask{
+		{ID: "t1", Title: "Task 1", Description: "Do thing 1"},
+	}
+	tt := newTestTeam(t, bus, tasks)
+
+	factory := newMockFactory()
+	factory.createErr = errors.New("out of resources")
+	checker := newMockChecker()
+	recorder := newMockRecorder()
+
+	b := bridge.New(tt, factory, checker, recorder, bus,
+		bridge.WithPollInterval(10*time.Millisecond),
+	)
+
+	if err := b.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// When CreateInstance fails, the bridge calls gate.Fail() making the task
+	// terminal. The claim loop then sees IsComplete → exits. Stop blocks until
+	// the claim loop goroutine finishes, so it returns once the error is processed.
+	stopWithTimeout(t, b, 3*time.Second)
+
+	// The task should not be in the running map.
+	running := b.Running()
+	if len(running) != 0 {
+		t.Errorf("Running() = %v, want empty", running)
+	}
+}
+
+func TestBridge_StartInstanceError(t *testing.T) {
+	bus := event.NewBus()
+	tasks := []ultraplan.PlannedTask{
+		{ID: "t1", Title: "Task 1", Description: "Do thing 1"},
+	}
+	tt := newTestTeam(t, bus, tasks)
+
+	factory := newMockFactory()
+	factory.startErr = errors.New("tmux unavailable")
+	checker := newMockChecker()
+	recorder := newMockRecorder()
+
+	b := bridge.New(tt, factory, checker, recorder, bus,
+		bridge.WithPollInterval(10*time.Millisecond),
+	)
+
+	if err := b.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Same pattern as CreateInstanceError: the task becomes terminal via
+	// gate.Fail(), so Stop returns once the claim loop exits.
+	stopWithTimeout(t, b, 3*time.Second)
+
+	running := b.Running()
+	if len(running) != 0 {
+		t.Errorf("Running() = %v, want empty", running)
+	}
+}
+
+func TestBridge_DoubleStart(t *testing.T) {
+	bus := event.NewBus()
+	tasks := []ultraplan.PlannedTask{
+		{ID: "t1", Title: "Task 1", Description: "Do thing 1"},
+	}
+	tt := newTestTeam(t, bus, tasks)
+
+	factory := newMockFactory()
+	checker := newMockChecker()
+	recorder := newMockRecorder()
+
+	b := bridge.New(tt, factory, checker, recorder, bus)
+
+	ctx := context.Background()
+	if err := b.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer b.Stop()
+
+	if err := b.Start(ctx); err == nil {
+		t.Error("second Start should return error")
+	}
+}
+
+func TestBridge_StopBeforeStart(t *testing.T) {
+	bus := event.NewBus()
+	tasks := []ultraplan.PlannedTask{
+		{ID: "t1", Title: "Task 1", Description: "Do thing 1"},
+	}
+	tt := newTestTeam(t, bus, tasks)
+
+	factory := newMockFactory()
+	checker := newMockChecker()
+	recorder := newMockRecorder()
+
+	b := bridge.New(tt, factory, checker, recorder, bus)
+	// Should not panic.
+	b.Stop()
+	_ = tt
+}
+
+func TestBridge_ContextCancellation(t *testing.T) {
+	bus := event.NewBus()
+	tasks := []ultraplan.PlannedTask{
+		{ID: "t1", Title: "Task 1", Description: "Do thing 1"},
+	}
+	tt := newTestTeam(t, bus, tasks)
+
+	factory := newMockFactory()
+	checker := newMockChecker()
+	recorder := newMockRecorder()
+
+	b := bridge.New(tt, factory, checker, recorder, bus,
+		bridge.WithPollInterval(10*time.Millisecond),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := b.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait for the task to start so the monitor goroutine is running.
+	waitForEvent(t, bus, "bridge.task_started", 2*time.Second)
+
+	// Cancel the context — the bridge should stop gracefully.
+	cancel()
+	b.Stop() // Should return quickly without hanging.
+}
+
+func TestBridge_MultipleTasks(t *testing.T) {
+	bus := event.NewBus()
+	tasks := []ultraplan.PlannedTask{
+		{ID: "t1", Title: "Task 1", Description: "First"},
+		{ID: "t2", Title: "Task 2", Description: "Second"},
+	}
+	tt := newTestTeam(t, bus, tasks)
+
+	factory := newMockFactory()
+	checker := newMockChecker()
+	recorder := newMockRecorder()
+
+	b := bridge.New(tt, factory, checker, recorder, bus,
+		bridge.WithPollInterval(10*time.Millisecond),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := b.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer b.Stop()
+
+	// Collect two started events.
+	started := make(chan event.Event, 2)
+	subID := bus.Subscribe("bridge.task_started", func(e event.Event) {
+		started <- e
+	})
+	defer bus.Unsubscribe(subID)
+
+	// Wait for both tasks to be claimed and started.
+	deadline := time.After(3 * time.Second)
+	count := 0
+	for count < 2 {
+		select {
+		case <-started:
+			count++
+		case <-deadline:
+			t.Fatalf("only got %d/2 task_started events", count)
+		}
+	}
+
+	// Both tasks should be running.
+	running := b.Running()
+	if len(running) != 2 {
+		t.Errorf("Running() has %d entries, want 2", len(running))
+	}
+
+	// Complete both tasks.
+	factory.mu.Lock()
+	for _, inst := range factory.instances {
+		checker.MarkComplete(inst.worktreePath)
+	}
+	factory.mu.Unlock()
+
+	// Collect two completed events.
+	completed := make(chan event.Event, 2)
+	subID2 := bus.Subscribe("bridge.task_completed", func(e event.Event) {
+		completed <- e
+	})
+	defer bus.Unsubscribe(subID2)
+
+	deadline = time.After(3 * time.Second)
+	count = 0
+	for count < 2 {
+		select {
+		case <-completed:
+			count++
+		case <-deadline:
+			t.Fatalf("only got %d/2 task_completed events", count)
+		}
+	}
+
+	// Running map should be clear.
+	running = b.Running()
+	if len(running) != 0 {
+		t.Errorf("Running() = %v, want empty", running)
+	}
+}
+
+func TestBridge_WithLogger(t *testing.T) {
+	bus := event.NewBus()
+	tasks := []ultraplan.PlannedTask{
+		{ID: "t1", Title: "Task 1", Description: "Do thing 1"},
+	}
+	tt := newTestTeam(t, bus, tasks)
+
+	factory := newMockFactory()
+	checker := newMockChecker()
+	recorder := newMockRecorder()
+
+	logger := logging.NopLogger()
+	b := bridge.New(tt, factory, checker, recorder, bus,
+		bridge.WithPollInterval(10*time.Millisecond),
+		bridge.WithLogger(logger),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := b.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait for task to start, then complete it.
+	waitForEvent(t, bus, "bridge.task_started", 2*time.Second)
+
+	factory.mu.Lock()
+	for _, inst := range factory.instances {
+		checker.MarkComplete(inst.worktreePath)
+	}
+	factory.mu.Unlock()
+
+	waitForEvent(t, bus, "bridge.task_completed", 2*time.Second)
+	b.Stop()
+}
+
+func TestBridge_IsCompleteExit(t *testing.T) {
+	bus := event.NewBus()
+	// Single task — once it completes, IsComplete should be true
+	// and the claim loop should exit on its own.
+	tasks := []ultraplan.PlannedTask{
+		{ID: "t1", Title: "Task 1", Description: "Do thing 1"},
+	}
+	tt := newTestTeam(t, bus, tasks)
+
+	factory := newMockFactory()
+	checker := newMockChecker()
+	recorder := newMockRecorder()
+
+	b := bridge.New(tt, factory, checker, recorder, bus,
+		bridge.WithPollInterval(10*time.Millisecond),
+	)
+
+	if err := b.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait for task to start.
+	waitForEvent(t, bus, "bridge.task_started", 2*time.Second)
+
+	// Complete the task.
+	factory.mu.Lock()
+	for _, inst := range factory.instances {
+		checker.MarkComplete(inst.worktreePath)
+	}
+	factory.mu.Unlock()
+
+	// Wait for completion event.
+	waitForEvent(t, bus, "bridge.task_completed", 2*time.Second)
+
+	// The claim loop should exit on its own via IsComplete(). Stop
+	// should return quickly without needing context cancellation.
+	done := make(chan struct{})
+	go func() {
+		b.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// good — bridge stopped via IsComplete exit
+	case <-time.After(3 * time.Second):
+		t.Error("bridge.Stop() did not return within timeout; IsComplete exit may not be working")
+	}
+}
+
+func TestBridge_NilConstructorPanics(t *testing.T) {
+	bus := event.NewBus()
+	tasks := []ultraplan.PlannedTask{
+		{ID: "t1", Title: "Task 1", Description: "Do thing 1"},
+	}
+	tt := newTestTeam(t, bus, tasks)
+
+	factory := newMockFactory()
+	checker := newMockChecker()
+	recorder := newMockRecorder()
+
+	tests := []struct {
+		name  string
+		build func()
+	}{
+		{"nil team", func() { bridge.New(nil, factory, checker, recorder, bus) }},
+		{"nil factory", func() { bridge.New(tt, nil, checker, recorder, bus) }},
+		{"nil checker", func() { bridge.New(tt, factory, nil, recorder, bus) }},
+		{"nil recorder", func() { bridge.New(tt, factory, checker, nil, bus) }},
+		{"nil bus", func() { bridge.New(tt, factory, checker, recorder, nil) }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Error("expected panic for nil argument")
+				}
+			}()
+			tc.build()
+		})
+	}
+}
+
+func TestBridge_WithLoggerNil(t *testing.T) {
+	bus := event.NewBus()
+	tasks := []ultraplan.PlannedTask{
+		{ID: "t1", Title: "Task 1", Description: "Do thing 1"},
+	}
+	tt := newTestTeam(t, bus, tasks)
+
+	factory := newMockFactory()
+	checker := newMockChecker()
+	recorder := newMockRecorder()
+
+	// WithLogger(nil) should not cause a nil-pointer panic.
+	b := bridge.New(tt, factory, checker, recorder, bus,
+		bridge.WithPollInterval(10*time.Millisecond),
+		bridge.WithLogger(nil),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := b.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait for task to start, then complete it.
+	waitForEvent(t, bus, "bridge.task_started", 2*time.Second)
+
+	factory.mu.Lock()
+	for _, inst := range factory.instances {
+		checker.MarkComplete(inst.worktreePath)
+	}
+	factory.mu.Unlock()
+
+	waitForEvent(t, bus, "bridge.task_completed", 2*time.Second)
+	b.Stop()
+}
+
+func TestBridge_MaxCheckErrorsFailsTask(t *testing.T) {
+	bus := event.NewBus()
+	tasks := []ultraplan.PlannedTask{
+		{ID: "t1", Title: "Task 1", Description: "Do thing 1"},
+	}
+	tt := newTestTeam(t, bus, tasks)
+
+	// Disable retries so the first gate.Fail() makes the task permanently
+	// failed. Without this, the retry logic returns the task to pending and
+	// the claim loop re-claims it, racing with the monitor's cleanup.
+	if err := tt.Hub().TaskQueue().SetMaxRetries("t1", 0); err != nil {
+		t.Fatalf("SetMaxRetries: %v", err)
+	}
+
+	// Subscribe to team completion early. When the task permanently fails,
+	// monitorTeamCompletion publishes TeamCompletedEvent inline (which calls
+	// onTeamCompleted, acquiring Manager.mu). We must wait for that to finish
+	// before Manager.Stop runs during cleanup, since Stop holds Manager.mu
+	// through wg.Wait — creating a deadlock if the monitor hasn't exited yet.
+	teamDone := make(chan struct{}, 1)
+	teamDoneSub := bus.Subscribe("team.completed", func(_ event.Event) {
+		select {
+		case teamDone <- struct{}{}:
+		default:
+		}
+	})
+	defer bus.Unsubscribe(teamDoneSub)
+
+	factory := newMockFactory()
+
+	// Use a signaling recorder so we can wait for RecordFailure before stopping.
+	failureCh := make(chan string, 1)
+	recorder := &signalingRecorder{
+		inner:     newMockRecorder(),
+		failureCh: failureCh,
+	}
+
+	// Use a checker that always errors on CheckCompletion.
+	errChecker := &errorChecker{err: errors.New("disk I/O error")}
+
+	b := bridge.New(tt, factory, errChecker, recorder, bus,
+		bridge.WithPollInterval(time.Millisecond),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := b.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer b.Stop()
+
+	// Wait for the recorder to receive the failure signal.
+	select {
+	case taskID := <-failureCh:
+		if taskID != "t1" {
+			t.Errorf("failed task = %q, want %q", taskID, "t1")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for recorder failure")
+	}
+
+	// Wait for team completion so monitorTeamCompletion finishes before cleanup.
+	select {
+	case <-teamDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for team completion")
+	}
+
+	// Running map should be empty.
+	running := b.Running()
+	if len(running) != 0 {
+		t.Errorf("Running() = %v, want empty", running)
+	}
+}
+
+// errorChecker is a CompletionChecker whose CheckCompletion always returns
+// an error. The factory still succeeds, so the bridge starts the monitor.
+type errorChecker struct {
+	err error
+}
+
+func (c *errorChecker) CheckCompletion(_ string) (bool, error) {
+	return false, c.err
+}
+
+func (c *errorChecker) VerifyWork(_, _, _, _ string) (bool, int, error) {
+	return false, 0, c.err
+}
+
+// signalingRecorder wraps a mockRecorder and sends the task ID on a channel
+// when RecordFailure is called. Used to synchronize tests without time.Sleep.
+type signalingRecorder struct {
+	inner     *mockRecorder
+	failureCh chan<- string
+}
+
+func (r *signalingRecorder) AssignTask(taskID, instanceID string) {
+	r.inner.AssignTask(taskID, instanceID)
+}
+
+func (r *signalingRecorder) RecordCompletion(taskID string, commitCount int) {
+	r.inner.RecordCompletion(taskID, commitCount)
+}
+
+func (r *signalingRecorder) RecordFailure(taskID, reason string) {
+	r.inner.RecordFailure(taskID, reason)
+	select {
+	case r.failureCh <- taskID:
+	default:
+	}
+}
+
+func TestBuildTaskPrompt(t *testing.T) {
+	prompt := bridge.BuildTaskPrompt(
+		"Add auth middleware",
+		"Implement JWT validation in the API gateway.",
+		[]string{"api/middleware.go", "api/auth.go"},
+	)
+
+	if !strings.Contains(prompt, "Add auth middleware") {
+		t.Error("prompt missing title")
+	}
+	if !strings.Contains(prompt, "Implement JWT validation") {
+		t.Error("prompt missing description")
+	}
+	if !strings.Contains(prompt, "api/middleware.go") {
+		t.Error("prompt missing file list")
+	}
+}
+
+func TestBuildTaskPrompt_NoFiles(t *testing.T) {
+	prompt := bridge.BuildTaskPrompt("Review", "Review all changes.", nil)
+
+	if !strings.Contains(prompt, "Review") {
+		t.Error("prompt missing title")
+	}
+	if strings.Contains(prompt, "## Files") {
+		t.Error("prompt should not contain Files section when no files specified")
+	}
+}

--- a/internal/bridge/doc.go
+++ b/internal/bridge/doc.go
@@ -1,0 +1,22 @@
+// Package bridge connects team Hubs to real Claude Code instance infrastructure.
+//
+// A Bridge claims tasks from a team's approval gate as they become ready,
+// creates a Claude Code instance (worktree + tmux) for each task, monitors
+// the instance for completion (sentinel file polling), and reports the
+// outcome back to the team's task queue.
+//
+// One Bridge is created per team. Each Bridge runs independently, claiming
+// from its own team's queue. The [bridgewire.PipelineExecutor] attaches
+// Bridges to teams when the pipeline transitions to an execution phase.
+//
+// The Bridge uses narrow interfaces ([InstanceFactory], [CompletionChecker],
+// [SessionRecorder]) so that the concrete orchestrator types remain
+// encapsulated. Tests can substitute mock implementations.
+//
+// Lifecycle:
+//
+//	b := bridge.New(team, factory, checker, recorder, bus)
+//	b.Start(ctx)    // spawns claim loop + per-task monitors
+//	// ... tasks execute ...
+//	b.Stop()         // cancels context, waits for all goroutines
+package bridge

--- a/internal/bridge/options.go
+++ b/internal/bridge/options.go
@@ -1,0 +1,33 @@
+package bridge
+
+import (
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/logging"
+)
+
+// defaultPollInterval is how often the monitor checks for instance completion.
+const defaultPollInterval = time.Second
+
+// Option configures a Bridge.
+type Option func(*config)
+
+type config struct {
+	pollInterval time.Duration
+	logger       *logging.Logger
+}
+
+// WithPollInterval sets the polling interval for completion checking.
+// A zero or negative value is replaced with the default (1s).
+func WithPollInterval(d time.Duration) Option {
+	return func(c *config) {
+		c.pollInterval = d
+	}
+}
+
+// WithLogger sets the logger for the bridge.
+func WithLogger(logger *logging.Logger) Option {
+	return func(c *config) {
+		c.logger = logger
+	}
+}

--- a/internal/bridge/types.go
+++ b/internal/bridge/types.go
@@ -1,0 +1,44 @@
+package bridge
+
+// InstanceFactory creates and starts Claude Code instances.
+type InstanceFactory interface {
+	// CreateInstance creates a new instance (worktree + branch) for the given task prompt.
+	// Returns a handle that can be started and queried.
+	CreateInstance(taskPrompt string) (Instance, error)
+
+	// StartInstance launches the Claude Code backend for an instance.
+	StartInstance(inst Instance) error
+}
+
+// Instance represents a running (or created) Claude Code backend.
+type Instance interface {
+	// ID returns the unique instance identifier.
+	ID() string
+
+	// WorktreePath returns the path to the instance's git worktree.
+	WorktreePath() string
+
+	// Branch returns the git branch name for this instance's work.
+	Branch() string
+}
+
+// CompletionChecker detects whether an instance has finished its task.
+type CompletionChecker interface {
+	// CheckCompletion returns true if the instance has written its sentinel file.
+	CheckCompletion(worktreePath string) (done bool, err error)
+
+	// VerifyWork validates task output (commit presence and verification result).
+	VerifyWork(taskID, instanceID, worktreePath, baseBranch string) (success bool, commitCount int, err error)
+}
+
+// SessionRecorder keeps session state in sync with bridge operations.
+type SessionRecorder interface {
+	// AssignTask records that a task has been assigned to an instance.
+	AssignTask(taskID, instanceID string)
+
+	// RecordCompletion records successful task completion.
+	RecordCompletion(taskID string, commitCount int)
+
+	// RecordFailure records a task failure with the given reason.
+	RecordFailure(taskID, reason string)
+}

--- a/internal/event/types.go
+++ b/internal/event/types.go
@@ -785,6 +785,54 @@ func NewPipelineCompletedEvent(pipelineID string, success bool, phasesRun int) P
 }
 
 // -----------------------------------------------------------------------------
+// Bridge Events (Pipeline → Instance Execution)
+// -----------------------------------------------------------------------------
+
+// BridgeTaskStartedEvent is emitted when a bridge starts executing a task
+// by spawning a Claude Code instance.
+type BridgeTaskStartedEvent struct {
+	baseEvent
+	TeamID     string // Team the task belongs to
+	TaskID     string // Task being executed
+	InstanceID string // Instance created for the task
+}
+
+// NewBridgeTaskStartedEvent creates a BridgeTaskStartedEvent.
+func NewBridgeTaskStartedEvent(teamID, taskID, instanceID string) BridgeTaskStartedEvent {
+	return BridgeTaskStartedEvent{
+		baseEvent:  newBaseEvent("bridge.task_started"),
+		TeamID:     teamID,
+		TaskID:     taskID,
+		InstanceID: instanceID,
+	}
+}
+
+// BridgeTaskCompletedEvent is emitted when a bridge-managed task finishes
+// (either successfully or with failure).
+type BridgeTaskCompletedEvent struct {
+	baseEvent
+	TeamID      string // Team the task belongs to
+	TaskID      string // Task that completed
+	InstanceID  string // Instance that executed the task
+	Success     bool   // Whether the task completed successfully
+	CommitCount int    // Number of commits produced (0 if failed)
+	Error       string // Error description (empty on success)
+}
+
+// NewBridgeTaskCompletedEvent creates a BridgeTaskCompletedEvent.
+func NewBridgeTaskCompletedEvent(teamID, taskID, instanceID string, success bool, commitCount int, errMsg string) BridgeTaskCompletedEvent {
+	return BridgeTaskCompletedEvent{
+		baseEvent:   newBaseEvent("bridge.task_completed"),
+		TeamID:      teamID,
+		TaskID:      taskID,
+		InstanceID:  instanceID,
+		Success:     success,
+		CommitCount: commitCount,
+		Error:       errMsg,
+	}
+}
+
+// -----------------------------------------------------------------------------
 // Inter-Team Communication Events
 // -----------------------------------------------------------------------------
 

--- a/internal/orchestrator/bridgewire/AGENTS.md
+++ b/internal/orchestrator/bridgewire/AGENTS.md
@@ -1,0 +1,41 @@
+# bridgewire — Agent Guidelines
+
+> **Living document.** Update this file when you learn something specific to this package.
+> Same rules as the root `AGENTS.md` — see its Self-Improvement Protocol.
+
+See `doc.go` for package overview and API usage.
+
+## Architecture
+
+The bridgewire package provides adapter types that connect the orchestrator's concrete infrastructure (worktrees, tmux, verification) to the bridge package's narrow interfaces. It exists specifically to break the import cycle: `bridge` cannot import `orchestrator` (which would create `bridge → team → ... → orchestrator → bridge`), so this sub-package inside `orchestrator/` imports both and bridges the gap.
+
+**Key Types:**
+- `PipelineExecutor` — Subscribes to `pipeline.phase_changed` events; when the execution phase starts, creates a Bridge per execution-role team
+- `instanceFactory` — Adapts `*orchestrator.Orchestrator` to `bridge.InstanceFactory`
+- `completionChecker` — Adapts `orchestrator.Verifier` to `bridge.CompletionChecker`
+- `sessionRecorder` — Callback-based `bridge.SessionRecorder` using `SessionRecorderDeps`
+
+**Data Flow:**
+```
+Pipeline fires PipelinePhaseChangedEvent
+  → PipelineExecutor.attachBridges() (dispatched via goroutine)
+    → creates adapters (factory, checker)
+    → creates Bridge per execution team
+    → Bridge.Start(ctx)
+```
+
+## Pitfalls
+
+- **Import direction is critical** — This package imports both `orchestrator` and `bridge`. The `bridge` package must NOT import this package or `orchestrator`. If you add new types here, ensure they don't leak orchestrator types into bridge's API.
+- **Goroutine dispatch in event handler** — The `PipelineExecutor` dispatches `attachBridges` via `go` from the event handler. This is required because `event.Bus.Publish` runs handlers inline, and `attachBridges` acquires `pe.mu`. Calling it inline would deadlock if the publisher holds a conflicting lock.
+- **Stop() releases lock before blocking** — `PipelineExecutor.Stop()` copies the bridge slice and releases `pe.mu` before calling `bridge.Stop()` on each bridge. Holding the lock through `Stop()` (which calls `wg.Wait()`) would deadlock goroutines that need `pe.mu`.
+- **PipelineExecutor.started = false before wg.Wait** — Unlike `Bridge.Stop()` which sets `started=false` after `wg.Wait()`, `PipelineExecutor.Stop()` sets it before because the executor doesn't own the bridge goroutines — it only owns the event subscription. The bridges manage their own WaitGroups.
+- **Nil-safe defaults** — `NewPipelineExecutor` defaults nil `Logger` to `NopLogger()` and nil `Recorder` to a no-op `SessionRecorder`. This matches the pattern in bridge's `New()` constructor.
+- **Coverage exceptions** — `CreateInstance`, `StartInstance`, and `attachBridges` require real orchestrator infrastructure (worktrees, tmux) and are tested via integration tests. Each has a `// Coverage:` comment explaining this.
+
+## Testing
+
+- Adapter tests (`adapters_test.go`) verify interface satisfaction and basic wiring with mock orchestrator types.
+- `PipelineExecutor` tests (`executor_test.go`) cover the Start/Stop lifecycle and config validation.
+- `attachBridges` is not unit-tested (requires real Pipeline with active teams); this is documented with a `// Coverage:` comment.
+- Always run with `-race` — the executor has concurrent event handlers.

--- a/internal/orchestrator/bridgewire/CLAUDE.md
+++ b/internal/orchestrator/bridgewire/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/internal/orchestrator/bridgewire/adapters.go
+++ b/internal/orchestrator/bridgewire/adapters.go
@@ -1,0 +1,119 @@
+package bridgewire
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Iron-Ham/claudio/internal/bridge"
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/orchestrator/verify"
+)
+
+// --- InstanceFactory adapter ---
+
+// instanceFactory adapts an Orchestrator to bridge.InstanceFactory.
+type instanceFactory struct {
+	orch    *orchestrator.Orchestrator
+	session *orchestrator.Session
+}
+
+// NewInstanceFactory creates a bridge.InstanceFactory backed by the given Orchestrator.
+func NewInstanceFactory(orch *orchestrator.Orchestrator, session *orchestrator.Session) bridge.InstanceFactory {
+	return &instanceFactory{orch: orch, session: session}
+}
+
+// Coverage: CreateInstance and StartInstance wrap *orchestrator.Orchestrator which
+// requires full session/worktree infrastructure; tested via integration tests.
+func (f *instanceFactory) CreateInstance(taskPrompt string) (bridge.Instance, error) {
+	inst, err := f.orch.AddInstance(f.session, taskPrompt)
+	if err != nil {
+		return nil, fmt.Errorf("create instance: %w", err)
+	}
+	return &orchInstance{inst: inst}, nil
+}
+
+func (f *instanceFactory) StartInstance(inst bridge.Instance) error {
+	orchInst := f.orch.GetInstance(inst.ID())
+	if orchInst == nil {
+		return fmt.Errorf("start instance: %q not found", inst.ID())
+	}
+	if err := f.orch.StartInstance(orchInst); err != nil {
+		return fmt.Errorf("start instance %q: %w", inst.ID(), err)
+	}
+	return nil
+}
+
+// orchInstance adapts an orchestrator.Instance to bridge.Instance.
+type orchInstance struct {
+	inst *orchestrator.Instance
+}
+
+func (oi *orchInstance) ID() string           { return oi.inst.ID }
+func (oi *orchInstance) WorktreePath() string { return oi.inst.WorktreePath }
+func (oi *orchInstance) Branch() string       { return oi.inst.Branch }
+
+// --- CompletionChecker adapter ---
+
+// completionChecker adapts an orchestrator.Verifier to bridge.CompletionChecker.
+type completionChecker struct {
+	verifier orchestrator.Verifier
+}
+
+// NewCompletionChecker creates a bridge.CompletionChecker backed by the given Verifier.
+func NewCompletionChecker(v orchestrator.Verifier) bridge.CompletionChecker {
+	return &completionChecker{verifier: v}
+}
+
+func (c *completionChecker) CheckCompletion(worktreePath string) (bool, error) {
+	return c.verifier.CheckCompletionFile(worktreePath)
+}
+
+func (c *completionChecker) VerifyWork(taskID, instanceID, worktreePath, baseBranch string) (bool, int, error) {
+	result := c.verifier.VerifyTaskWork(taskID, instanceID, worktreePath, baseBranch, &verify.TaskVerifyOptions{})
+	if result.Error != "" {
+		return result.Success, result.CommitCount, errors.New(result.Error)
+	}
+	return result.Success, result.CommitCount, nil
+}
+
+// --- SessionRecorder adapter ---
+
+// SessionRecorderDeps defines the coordinator operations needed by the session recorder.
+type SessionRecorderDeps struct {
+	// OnAssign is called when a task is assigned to an instance.
+	OnAssign func(taskID, instanceID string)
+
+	// OnComplete is called when a task completes successfully.
+	OnComplete func(taskID string, commitCount int)
+
+	// OnFailure is called when a task fails.
+	OnFailure func(taskID, reason string)
+}
+
+// sessionRecorder delegates to caller-provided callbacks.
+type sessionRecorder struct {
+	deps SessionRecorderDeps
+}
+
+// NewSessionRecorder creates a bridge.SessionRecorder backed by the given callbacks.
+func NewSessionRecorder(deps SessionRecorderDeps) bridge.SessionRecorder {
+	return &sessionRecorder{deps: deps}
+}
+
+func (r *sessionRecorder) AssignTask(taskID, instanceID string) {
+	if r.deps.OnAssign != nil {
+		r.deps.OnAssign(taskID, instanceID)
+	}
+}
+
+func (r *sessionRecorder) RecordCompletion(taskID string, commitCount int) {
+	if r.deps.OnComplete != nil {
+		r.deps.OnComplete(taskID, commitCount)
+	}
+}
+
+func (r *sessionRecorder) RecordFailure(taskID, reason string) {
+	if r.deps.OnFailure != nil {
+		r.deps.OnFailure(taskID, reason)
+	}
+}

--- a/internal/orchestrator/bridgewire/adapters_test.go
+++ b/internal/orchestrator/bridgewire/adapters_test.go
@@ -1,0 +1,163 @@
+package bridgewire
+
+import (
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/bridge"
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/orchestrator/verify"
+)
+
+// --- Mock Verifier ---
+
+type mockVerifier struct {
+	completionResult bool
+	completionErr    error
+	verifyResult     verify.TaskCompletionResult
+}
+
+func (v *mockVerifier) CheckCompletionFile(worktreePath string) (bool, error) {
+	return v.completionResult, v.completionErr
+}
+
+func (v *mockVerifier) VerifyTaskWork(taskID, instanceID, worktreePath, baseBranch string, opts *verify.TaskVerifyOptions) verify.TaskCompletionResult {
+	return v.verifyResult
+}
+
+// --- Tests ---
+
+func TestNewCompletionChecker_CheckCompletion(t *testing.T) {
+	v := &mockVerifier{completionResult: true}
+	checker := NewCompletionChecker(v)
+
+	done, err := checker.CheckCompletion("/tmp/wt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !done {
+		t.Error("expected done=true")
+	}
+}
+
+func TestNewCompletionChecker_VerifyWorkSuccess(t *testing.T) {
+	v := &mockVerifier{
+		verifyResult: verify.TaskCompletionResult{
+			Success:     true,
+			CommitCount: 3,
+		},
+	}
+	checker := NewCompletionChecker(v)
+
+	success, commits, err := checker.VerifyWork("t1", "inst-1", "/tmp/wt", "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !success {
+		t.Error("expected success=true")
+	}
+	if commits != 3 {
+		t.Errorf("commits = %d, want 3", commits)
+	}
+}
+
+func TestNewCompletionChecker_VerifyWorkFailure(t *testing.T) {
+	v := &mockVerifier{
+		verifyResult: verify.TaskCompletionResult{
+			Success:     false,
+			CommitCount: 0,
+			Error:       "no commits produced",
+		},
+	}
+	checker := NewCompletionChecker(v)
+
+	success, commits, err := checker.VerifyWork("t1", "inst-1", "/tmp/wt", "main")
+	if success {
+		t.Error("expected success=false")
+	}
+	if commits != 0 {
+		t.Errorf("commits = %d, want 0", commits)
+	}
+	if err == nil {
+		t.Error("expected error for failed verification")
+	}
+}
+
+func TestNewSessionRecorder(t *testing.T) {
+	var assignedTask, assignedInst string
+	var completedTask string
+	var completedCommits int
+	var failedTask, failedReason string
+
+	recorder := NewSessionRecorder(SessionRecorderDeps{
+		OnAssign: func(taskID, instanceID string) {
+			assignedTask = taskID
+			assignedInst = instanceID
+		},
+		OnComplete: func(taskID string, commitCount int) {
+			completedTask = taskID
+			completedCommits = commitCount
+		},
+		OnFailure: func(taskID, reason string) {
+			failedTask = taskID
+			failedReason = reason
+		},
+	})
+
+	recorder.AssignTask("t1", "inst-1")
+	if assignedTask != "t1" || assignedInst != "inst-1" {
+		t.Errorf("AssignTask: got (%q, %q), want (%q, %q)", assignedTask, assignedInst, "t1", "inst-1")
+	}
+
+	recorder.RecordCompletion("t2", 5)
+	if completedTask != "t2" || completedCommits != 5 {
+		t.Errorf("RecordCompletion: got (%q, %d), want (%q, %d)", completedTask, completedCommits, "t2", 5)
+	}
+
+	recorder.RecordFailure("t3", "timeout")
+	if failedTask != "t3" || failedReason != "timeout" {
+		t.Errorf("RecordFailure: got (%q, %q), want (%q, %q)", failedTask, failedReason, "t3", "timeout")
+	}
+}
+
+func TestNewSessionRecorder_NilCallbacks(t *testing.T) {
+	recorder := NewSessionRecorder(SessionRecorderDeps{})
+
+	// Should not panic with nil callbacks.
+	recorder.AssignTask("t1", "inst-1")
+	recorder.RecordCompletion("t1", 1)
+	recorder.RecordFailure("t1", "reason")
+}
+
+func TestNewInstanceFactory(t *testing.T) {
+	orch := &orchestrator.Orchestrator{}
+	sess := &orchestrator.Session{}
+	f := NewInstanceFactory(orch, sess)
+	if f == nil {
+		t.Fatal("NewInstanceFactory returned nil")
+	}
+}
+
+func TestOrchInstance_Methods(t *testing.T) {
+	inst := &orchInstance{inst: &orchestrator.Instance{
+		ID:           "test-id",
+		WorktreePath: "/tmp/wt",
+		Branch:       "feature-branch",
+	}}
+	if inst.ID() != "test-id" {
+		t.Errorf("ID() = %q, want %q", inst.ID(), "test-id")
+	}
+	if inst.WorktreePath() != "/tmp/wt" {
+		t.Errorf("WorktreePath() = %q, want %q", inst.WorktreePath(), "/tmp/wt")
+	}
+	if inst.Branch() != "feature-branch" {
+		t.Errorf("Branch() = %q, want %q", inst.Branch(), "feature-branch")
+	}
+}
+
+// Verify interface compliance at compile time.
+var (
+	_ bridge.CompletionChecker = (*completionChecker)(nil)
+	_ bridge.SessionRecorder   = (*sessionRecorder)(nil)
+	_ bridge.InstanceFactory   = (*instanceFactory)(nil)
+	_ bridge.Instance          = (*orchInstance)(nil)
+)

--- a/internal/orchestrator/bridgewire/doc.go
+++ b/internal/orchestrator/bridgewire/doc.go
@@ -1,0 +1,17 @@
+// Package bridgewire creates bridge adapters that connect the orchestrator
+// infrastructure (worktrees, tmux, verification) to the bridge interfaces.
+//
+// This package exists as a separate package to break the import cycle between
+// the orchestrator and bridge packages. It imports both and provides adapter
+// types that translate between their APIs.
+//
+// Usage:
+//
+//	factory := bridgewire.NewInstanceFactory(orch, session)
+//	checker := bridgewire.NewCompletionChecker(verifier)
+//	recorder := bridgewire.NewSessionRecorder(bridgewire.SessionRecorderDeps{
+//		OnAssign:   func(taskID, instanceID string) { /* ... */ },
+//		OnComplete: func(taskID string, commitCount int) { /* ... */ },
+//		OnFailure:  func(taskID, reason string) { /* ... */ },
+//	})
+package bridgewire

--- a/internal/orchestrator/bridgewire/executor.go
+++ b/internal/orchestrator/bridgewire/executor.go
@@ -1,0 +1,190 @@
+package bridgewire
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/Iron-Ham/claudio/internal/bridge"
+	"github.com/Iron-Ham/claudio/internal/event"
+	"github.com/Iron-Ham/claudio/internal/logging"
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/pipeline"
+	"github.com/Iron-Ham/claudio/internal/team"
+)
+
+// PipelineExecutor wires a Pipeline's execution-phase teams to real Claude Code
+// instances via Bridges. It subscribes to pipeline phase change events and
+// creates a Bridge for each team when the execution phase starts.
+type PipelineExecutor struct {
+	orch     *orchestrator.Orchestrator
+	session  *orchestrator.Session
+	verifier orchestrator.Verifier
+	bus      *event.Bus
+	logger   *logging.Logger
+	recorder bridge.SessionRecorder
+
+	pipe    *pipeline.Pipeline
+	ctx     context.Context
+	cancel  context.CancelFunc
+	mu      sync.Mutex
+	bridges []*bridge.Bridge
+	started bool
+	subID   string
+}
+
+// PipelineExecutorConfig holds required dependencies.
+type PipelineExecutorConfig struct {
+	Orchestrator *orchestrator.Orchestrator
+	Session      *orchestrator.Session
+	Verifier     orchestrator.Verifier
+	Bus          *event.Bus
+	Pipeline     *pipeline.Pipeline
+	Recorder     bridge.SessionRecorder
+	Logger       *logging.Logger
+}
+
+// NewPipelineExecutor creates a PipelineExecutor that will attach bridges
+// to execution-phase teams when they start.
+func NewPipelineExecutor(cfg PipelineExecutorConfig) (*PipelineExecutor, error) {
+	if cfg.Orchestrator == nil {
+		return nil, fmt.Errorf("bridgewire: Orchestrator is required")
+	}
+	if cfg.Session == nil {
+		return nil, fmt.Errorf("bridgewire: Session is required")
+	}
+	if cfg.Verifier == nil {
+		return nil, fmt.Errorf("bridgewire: Verifier is required")
+	}
+	if cfg.Bus == nil {
+		return nil, fmt.Errorf("bridgewire: Bus is required")
+	}
+	if cfg.Pipeline == nil {
+		return nil, fmt.Errorf("bridgewire: Pipeline is required")
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = logging.NopLogger()
+	}
+	if cfg.Recorder == nil {
+		cfg.Recorder = NewSessionRecorder(SessionRecorderDeps{})
+	}
+
+	return &PipelineExecutor{
+		orch:     cfg.Orchestrator,
+		session:  cfg.Session,
+		verifier: cfg.Verifier,
+		bus:      cfg.Bus,
+		pipe:     cfg.Pipeline,
+		recorder: cfg.Recorder,
+		logger:   cfg.Logger,
+	}, nil
+}
+
+// Start subscribes to pipeline phase change events and begins attaching
+// bridges when the execution phase starts.
+func (pe *PipelineExecutor) Start(ctx context.Context) error {
+	pe.mu.Lock()
+	defer pe.mu.Unlock()
+
+	if pe.started {
+		return fmt.Errorf("bridgewire: executor already started")
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	pe.ctx = ctx
+	pe.cancel = cancel
+	pe.started = true
+
+	// Dispatch to a goroutine to avoid deadlock: event.Bus.Publish runs
+	// handlers inline, and attachBridges acquires pe.mu. If the publisher
+	// already holds a conflicting lock, an inline call would deadlock.
+	pe.subID = pe.bus.Subscribe("pipeline.phase_changed", func(e event.Event) {
+		pce, ok := e.(event.PipelinePhaseChangedEvent)
+		if !ok {
+			return
+		}
+		if pce.CurrentPhase == string(pipeline.PhaseExecution) {
+			go pe.attachBridges()
+		}
+	})
+
+	return nil
+}
+
+// Stop cancels all bridges and cleans up subscriptions.
+func (pe *PipelineExecutor) Stop() {
+	pe.mu.Lock()
+	if !pe.started {
+		pe.mu.Unlock()
+		return
+	}
+	pe.started = false
+
+	pe.bus.Unsubscribe(pe.subID)
+	pe.cancel()
+
+	// Copy the slice so we can release the lock before blocking on bridge.Stop().
+	bridges := make([]*bridge.Bridge, len(pe.bridges))
+	copy(bridges, pe.bridges)
+	pe.bridges = nil
+	pe.mu.Unlock()
+
+	for _, b := range bridges {
+		b.Stop()
+	}
+}
+
+// Coverage: attachBridges requires a real Pipeline with active teams; tested via integration.
+// attachBridges creates a Bridge for each team in the current execution phase.
+func (pe *PipelineExecutor) attachBridges() {
+	pe.mu.Lock()
+	defer pe.mu.Unlock()
+
+	if !pe.started {
+		return
+	}
+
+	mgr := pe.pipe.Manager(pipeline.PhaseExecution)
+	if mgr == nil {
+		pe.logger.Warn("bridgewire: execution phase manager not yet available")
+		return
+	}
+
+	factory := NewInstanceFactory(pe.orch, pe.session)
+	checker := NewCompletionChecker(pe.verifier)
+
+	statuses := mgr.AllStatuses()
+	for _, status := range statuses {
+		if status.Role != team.RoleExecution {
+			continue
+		}
+
+		t := mgr.Team(status.ID)
+		if t == nil {
+			pe.logger.Warn("bridgewire: team not found", "team", status.ID)
+			continue
+		}
+
+		b := bridge.New(t, factory, checker, pe.recorder, pe.bus,
+			bridge.WithLogger(pe.logger),
+		)
+		if err := b.Start(pe.ctx); err != nil {
+			pe.logger.Error("bridgewire: failed to start bridge",
+				"team", status.ID, "error", err)
+			continue
+		}
+
+		pe.bridges = append(pe.bridges, b)
+		pe.logger.Info("bridgewire: attached bridge to team", "team", status.ID)
+	}
+}
+
+// Bridges returns the current bridges for testing/inspection.
+func (pe *PipelineExecutor) Bridges() []*bridge.Bridge {
+	pe.mu.Lock()
+	defer pe.mu.Unlock()
+
+	out := make([]*bridge.Bridge, len(pe.bridges))
+	copy(out, pe.bridges)
+	return out
+}

--- a/internal/orchestrator/bridgewire/executor_test.go
+++ b/internal/orchestrator/bridgewire/executor_test.go
@@ -1,0 +1,129 @@
+package bridgewire
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Iron-Ham/claudio/internal/event"
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/pipeline"
+)
+
+func TestNewPipelineExecutor_Validation(t *testing.T) {
+	bus := event.NewBus()
+
+	tests := []struct {
+		name    string
+		cfg     PipelineExecutorConfig
+		wantErr string
+	}{
+		{
+			name:    "missing orchestrator",
+			cfg:     PipelineExecutorConfig{},
+			wantErr: "Orchestrator is required",
+		},
+		{
+			name: "missing session",
+			cfg: PipelineExecutorConfig{
+				Orchestrator: &orchestrator.Orchestrator{},
+			},
+			wantErr: "Session is required",
+		},
+		{
+			name: "missing verifier",
+			cfg: PipelineExecutorConfig{
+				Orchestrator: &orchestrator.Orchestrator{},
+				Session:      &orchestrator.Session{},
+			},
+			wantErr: "Verifier is required",
+		},
+		{
+			name: "missing bus",
+			cfg: PipelineExecutorConfig{
+				Orchestrator: &orchestrator.Orchestrator{},
+				Session:      &orchestrator.Session{},
+				Verifier:     &mockVerifier{},
+			},
+			wantErr: "Bus is required",
+		},
+		{
+			name: "missing pipeline",
+			cfg: PipelineExecutorConfig{
+				Orchestrator: &orchestrator.Orchestrator{},
+				Session:      &orchestrator.Session{},
+				Verifier:     &mockVerifier{},
+				Bus:          bus,
+			},
+			wantErr: "Pipeline is required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewPipelineExecutor(tt.cfg)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want containing %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPipelineExecutor_DoubleStart(t *testing.T) {
+	bus := event.NewBus()
+	pe, err := NewPipelineExecutor(PipelineExecutorConfig{
+		Orchestrator: &orchestrator.Orchestrator{},
+		Session:      &orchestrator.Session{},
+		Verifier:     &mockVerifier{},
+		Bus:          bus,
+		Pipeline:     &pipeline.Pipeline{},
+	})
+	if err != nil {
+		t.Fatalf("NewPipelineExecutor: %v", err)
+	}
+
+	ctx := t.Context()
+	if err := pe.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer pe.Stop()
+
+	if err := pe.Start(ctx); err == nil {
+		t.Error("second Start should return error")
+	}
+}
+
+func TestPipelineExecutor_StopBeforeStart(t *testing.T) {
+	bus := event.NewBus()
+	pe, err := NewPipelineExecutor(PipelineExecutorConfig{
+		Orchestrator: &orchestrator.Orchestrator{},
+		Session:      &orchestrator.Session{},
+		Verifier:     &mockVerifier{},
+		Bus:          bus,
+		Pipeline:     &pipeline.Pipeline{},
+	})
+	if err != nil {
+		t.Fatalf("NewPipelineExecutor: %v", err)
+	}
+	pe.Stop() // should not panic
+}
+
+func TestPipelineExecutor_BridgesEmpty(t *testing.T) {
+	bus := event.NewBus()
+	pe, err := NewPipelineExecutor(PipelineExecutorConfig{
+		Orchestrator: &orchestrator.Orchestrator{},
+		Session:      &orchestrator.Session{},
+		Verifier:     &mockVerifier{},
+		Bus:          bus,
+		Pipeline:     &pipeline.Pipeline{},
+	})
+	if err != nil {
+		t.Fatalf("NewPipelineExecutor: %v", err)
+	}
+
+	bridges := pe.Bridges()
+	if len(bridges) != 0 {
+		t.Errorf("Bridges() = %d, want 0 before start", len(bridges))
+	}
+}

--- a/internal/taskqueue/AGENTS.md
+++ b/internal/taskqueue/AGENTS.md
@@ -10,6 +10,7 @@ See `doc.go` for package overview and API usage.
 - **Wrapper type mutex access** — `EventQueue` wraps `TaskQueue` to publish events. Never access `TaskQueue`'s internal mutex from `EventQueue`. If `EventQueue` needs new synchronized behavior, add a public method on `TaskQueue` and call it from the wrapper.
 - **Copy-on-return semantics** — `ClaimNext()` and `GetTask()` return value copies of internal structs, not pointers. This prevents callers from mutating queue state through the returned value. Maintain this pattern when adding new accessor methods.
 - **Persistence locking** — State persistence uses temp file + `os.Rename` with `flock` for crash safety. The flock is process-level; multiple goroutines within the same process coordinate via the `TaskQueue` mutex, not the flock.
+- **Default retry count** — `NewFromPlan` sets `MaxRetries=2` on every task. `Fail()` returns tasks to `TaskPending` until retries are exhausted, which means a single `Fail()` call does NOT make a task permanently failed. Use `SetMaxRetries(taskID, 0)` in tests that need immediate permanent failure.
 
 ## EventQueue Decorator
 

--- a/internal/team/AGENTS.md
+++ b/internal/team/AGENTS.md
@@ -33,6 +33,7 @@ Manager.Start(ctx)
 - **Manager holds write lock during startTeamLocked** — The `onTeamCompleted` handler acquires `m.mu` write lock. Since it's called from an event handler (which runs synchronously on the bus), avoid publishing events that would re-enter `onTeamCompleted` from within the lock.
 - **Failed dependencies do NOT unblock dependents** — `allDepsSatisfiedLocked` requires `PhaseDone`, not just any terminal phase. A failed dependency keeps dependent teams blocked forever. This is intentional — partial results from a failed team should not feed into dependent teams.
 - **Budget cleanup on Hub start failure** — `startTeamLocked` calls `t.budget.Stop()` if `t.hub.Start(ctx)` fails. Without this, the budget tracker leaks its "active" sentinel and appears started despite the team being in `PhaseFailed`.
+- **Manager.Stop() holds lock through wg.Wait()** — `Stop()` acquires `m.mu` and holds it through `m.wg.Wait()`. If `monitorTeamCompletion` is publishing `TeamCompletedEvent` (which calls `onTeamCompleted` inline, acquiring `m.mu`), this deadlocks. Callers that trigger queue completion must ensure `monitorTeamCompletion` finishes before `Stop()` runs. In tests, subscribe to `team.completed` early and wait on it before cleanup. This is a known issue; a proper fix would release `m.mu` before `wg.Wait()` (similar to `PipelineExecutor.Stop()`).
 
 ## Testing
 


### PR DESCRIPTION
## Summary

- **Bridge package** (`internal/bridge/`) — Claims tasks from team queues, spawns worktree + tmux instances via narrow interfaces (InstanceFactory, CompletionChecker, SessionRecorder), monitors for completion via sentinel file polling, and reports outcomes back through the Gate
- **Adapter wiring** (`internal/orchestrator/bridgewire/`) — Thin adapters that wrap `*orchestrator.Orchestrator` and `Verifier` to implement bridge interfaces; PipelineExecutor subscribes to pipeline phase transitions and attaches Bridges to execution-phase teams automatically
- **Bridge events** — `BridgeTaskStartedEvent` and `BridgeTaskCompletedEvent` added to `internal/event/types.go` for observability

### Design Decisions

- **Narrow interfaces** — Bridge defines 4 small interfaces (InstanceFactory, CompletionChecker, SessionRecorder, Instance) so the orchestrator types stay encapsulated and tests can substitute mocks
- **Import cycle prevention** — Bridge package accepts `(title, description string, files []string)` instead of `ultraplan.PlannedTask` to avoid the `bridge → team → ... → ultraplan → orchestrator` cycle. Adapters live in a sub-package of orchestrator
- **Event-driven claim loop** — Subscribes to `queue.depth_changed` events via buffered channel; no polling
- **Goroutine dispatch from event handlers** — PipelineExecutor dispatches `attachBridges()` to a goroutine from the event handler to avoid deadlock with the synchronous event bus
- **Retry limit** — Monitor gives up after 10 consecutive `CheckCompletion` failures and fails the task
- **Nil-safe construction** — Constructor panics on nil arguments to surface wiring bugs immediately

Closes #647

## Test plan

- [x] `go test -race -count=1 ./internal/bridge/...` — 17 tests pass with race detector (claim/complete, verification failure, create/start errors, context cancellation, multiple tasks, nil panics, logger nil-safety, max check errors, prompt building)
- [x] `go test -race -count=1 ./internal/orchestrator/bridgewire/...` — 7 tests pass (validation, double start, stop before start, bridges empty, completion checker, session recorder, interface compliance)
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run` — 0 issues
- [x] `gofmt -d .` — no diffs
- [x] Full `go test -race ./...` — all packages pass