### PR TITLE
Add team-based TripleShot coordinator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,7 @@ This is not exhaustive — update it when you add or discover undocumented packa
 - `internal/team/` — Multi-team orchestration with dependency ordering, budget tracking, and inter-team routing *(has `AGENTS.md`)*
 - `internal/bridge/` — Connects team Hubs to real Claude Code instances (worktree + tmux) *(has `AGENTS.md`)*
 - `internal/orchestrator/bridgewire/` — Adapter types that wire orchestrator infrastructure to bridge interfaces *(has `AGENTS.md`)*
+- `internal/orchestrator/workflows/tripleshot/teamwire/` — Adapts TripleShot to Orchestration 2.0 teams via `TeamCoordinator` + bridge adapters *(has `AGENTS.md`)*
 - `internal/pipeline/` — Plan decomposer and multi-phase team pipeline *(has `AGENTS.md`)*
 - `internal/tui/` — Bubble Tea terminal UI components *(has `AGENTS.md`)*
 - `internal/worktree/` — Git worktree creation and management

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Team-Based TripleShot** - New `TeamCoordinator` (`internal/orchestrator/workflows/tripleshot/teamwire/`) adapts the TripleShot workflow to the Orchestration 2.0 team infrastructure. Each attempt becomes a self-coordinating team with Bridge execution, and the judge is dynamically added via `team.Manager.AddTeamDynamic` after all attempts complete. Includes adapter types connecting tripleshot interfaces to bridge interfaces and two new event types (`TripleShotAttemptCompletedEvent`, `TripleShotJudgeCompletedEvent`). (#645)
+
 - **Bridge Execution Layer** - Bridge package (`internal/bridge/`) and adapter wiring (`internal/orchestrator/bridgewire/`) that connect team Hubs to real Claude Code instances. Each Bridge claims tasks from a team's queue, spawns worktree + tmux instances, monitors for completion via sentinel files, and reports outcomes back to the queue. PipelineExecutor subscribes to pipeline phase transitions and attaches Bridges to execution-phase teams automatically. (#647)
 
 - **Pipeline Orchestration** - Plan decomposer and multi-phase pipeline (`internal/pipeline/`) for team-based execution. Groups tasks by file affinity using union-find, then orchestrates sequential phases (planning → execution → review → consolidation). Each phase runs its own Manager with scoped teams. Adds pipeline lifecycle events and dynamic team addition to the team Manager. (Phase 3 of Orchestrator of Orchestrators, #637)

--- a/internal/event/types.go
+++ b/internal/event/types.go
@@ -857,3 +857,43 @@ func NewInterTeamMessageEvent(fromTeam, toTeam, messageType, content, priority s
 		Priority:    priority,
 	}
 }
+
+// -----------------------------------------------------------------------------
+// TripleShot Team Events
+// -----------------------------------------------------------------------------
+
+// TripleShotAttemptCompletedEvent is emitted when a tripleshot attempt finishes
+// (either successfully or with failure) in the team-based coordinator.
+type TripleShotAttemptCompletedEvent struct {
+	baseEvent
+	AttemptIndex int    // 0, 1, or 2
+	TeamID       string // Team that ran this attempt
+	Success      bool   // Whether the attempt completed successfully
+}
+
+// NewTripleShotAttemptCompletedEvent creates a TripleShotAttemptCompletedEvent.
+func NewTripleShotAttemptCompletedEvent(attemptIndex int, teamID string, success bool) TripleShotAttemptCompletedEvent {
+	return TripleShotAttemptCompletedEvent{
+		baseEvent:    newBaseEvent("tripleshot.attempt_completed"),
+		AttemptIndex: attemptIndex,
+		TeamID:       teamID,
+		Success:      success,
+	}
+}
+
+// TripleShotJudgeCompletedEvent is emitted when the tripleshot judge finishes
+// its evaluation in the team-based coordinator.
+type TripleShotJudgeCompletedEvent struct {
+	baseEvent
+	TeamID  string // Team that ran the judge
+	Success bool   // Whether the evaluation completed successfully
+}
+
+// NewTripleShotJudgeCompletedEvent creates a TripleShotJudgeCompletedEvent.
+func NewTripleShotJudgeCompletedEvent(teamID string, success bool) TripleShotJudgeCompletedEvent {
+	return TripleShotJudgeCompletedEvent{
+		baseEvent: newBaseEvent("tripleshot.judge_completed"),
+		TeamID:    teamID,
+		Success:   success,
+	}
+}

--- a/internal/orchestrator/workflows/tripleshot/teamwire/AGENTS.md
+++ b/internal/orchestrator/workflows/tripleshot/teamwire/AGENTS.md
@@ -1,0 +1,43 @@
+# teamwire — Agent Guidelines
+
+> **Living document.** Update this file when you learn something specific to this package.
+> Same rules as the root `AGENTS.md` — see its Self-Improvement Protocol.
+
+## Purpose
+
+This package connects the TripleShot workflow to the Orchestration 2.0 team infrastructure. It exists as a separate subpackage to break an import cycle: `tripleshot → bridge → team → coordination → ... → ultraplan → orchestrator → tripleshot`.
+
+## Architecture
+
+```
+TeamCoordinator
+  ├── team.Manager
+  │   ├── Team "attempt-0" (execution, 1 task)  ──→ Bridge ──→ Instance
+  │   ├── Team "attempt-1" (execution, 1 task)  ──→ Bridge ──→ Instance
+  │   ├── Team "attempt-2" (execution, 1 task)  ──→ Bridge ──→ Instance
+  │   └── Team "judge" (review, 1 task, depends_on=[attempt-*])  ──→ Bridge ──→ Instance
+  └── Adapters
+      ├── attemptFactory   → bridge.InstanceFactory
+      ├── attemptInstance   → bridge.Instance
+      ├── attemptCompletionChecker → bridge.CompletionChecker
+      ├── judgeCompletionChecker   → bridge.CompletionChecker
+      └── sessionRecorder  → bridge.SessionRecorder
+```
+
+**Uses Manager directly, not Pipeline.** The Pipeline's rigid phase model (planning → execution → review → consolidation) doesn't fit — the judge team needs completion data from all 3 attempts to construct its prompt, so it's added dynamically via `AddTeamDynamic`.
+
+## Pitfalls
+
+- **Import cycle** — The `tripleshot` package cannot import `bridge`, `team`, or `coordination` due to the dependency chain. All team/bridge wiring lives here in `teamwire`. If you need to reference a tripleshot type from bridge code, use the `ts` import alias for the parent package.
+- **Two-phase Start** — `Start()` must not hold `tc.mu` when calling `Bridge.Start()`. The bridge's claim loop publishes `BridgeTaskStartedEvent` synchronously, and the handler `onBridgeTaskStarted` acquires `tc.mu`. Holding the lock through `Start()` → bridge claim → event publish → handler → lock = deadlock. The fix: `registerStart()` holds/releases the lock, then `Start()` creates bridges outside it.
+- **Event subscription timing** — Subscriptions must happen before `Bridge.Start()` launches the claim loop. Currently done in `registerStart()` (Phase 1, under lock, before Phase 2 bridge creation) — this is the safe window. Don't move subscriptions after Phase 2 begins. For test assertions where you need events, subscribe before calling `Start()`. For production callbacks, use `SetCallbacks` before `Start`.
+- **`onTeamCompleted` dispatches to goroutine** — The handler for `team.completed` dispatches `startJudge()` via `go` to avoid deadlock. The synchronous event bus would block if `startJudge` tried to publish events while the bus's `Publish` goroutine holds a lock.
+- **Bridge retry vs. completion file status** — When `VerifyWork` returns `success=false` (e.g., completion file has `"failed"` status), the bridge calls `gate.Fail()`. Due to TaskQueue retry logic (`defaultMaxRetries=2`), the task returns to Pending and gets re-claimed by the bridge. Each re-claim creates a new instance with a new empty worktree. Tests that depend on failure being final must account for this retry cycle or test handler methods directly.
+- **Every `onJudgeCompleted` failure path must publish `TripleShotJudgeCompletedEvent`** — Use the `failJudge()` helper, which sets session error, transitions to `PhaseFailed`, fires callbacks, and publishes the event. Forgetting the event on one path breaks downstream listeners.
+- **Session mutation lock discipline** — `tsManager.Session()` returns a raw `*Session` pointer; the `tsManager.mu` RLock only protects the pointer swap, not field access. All session field mutations (`JudgeID`, `CompletedAt`, `Error`, `Attempts[i].*`) must hold `tc.mu`. `GetWinningBranch()` also holds `tc.mu` for reads. The lock order `tc.mu → tsManager.mu` is safe (no reverse path exists). Functions like `failJudge` and `startJudge` error paths acquire `tc.mu` for mutations, then release before `notifyCallbacks`/`bus.Publish` to avoid deadlock.
+
+## Testing
+
+- Handler-level tests (`onBridgeTaskCompleted`, `onJudgeCompleted`, `startJudge`) set `tc.started = true` and `tc.attemptTeamIDs` manually to bypass the full `Start()` lifecycle. This makes failure-path tests deterministic.
+- Full lifecycle tests (`TestTeamCoordinator_FullLifecycle`) use callbacks, not bus event subscriptions, to avoid the timing window described above.
+- Always use `coordination.WithRebalanceInterval(-1)` and `bridge.WithPollInterval(10 * time.Millisecond)` for fast, deterministic tests.

--- a/internal/orchestrator/workflows/tripleshot/teamwire/CLAUDE.md
+++ b/internal/orchestrator/workflows/tripleshot/teamwire/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/internal/orchestrator/workflows/tripleshot/teamwire/adapters.go
+++ b/internal/orchestrator/workflows/tripleshot/teamwire/adapters.go
@@ -1,0 +1,135 @@
+package teamwire
+
+import (
+	"fmt"
+
+	"github.com/Iron-Ham/claudio/internal/bridge"
+	ts "github.com/Iron-Ham/claudio/internal/orchestrator/workflows/tripleshot"
+)
+
+// Compile-time interface compliance checks.
+var (
+	_ bridge.InstanceFactory   = (*attemptFactory)(nil)
+	_ bridge.Instance          = (*attemptInstance)(nil)
+	_ bridge.CompletionChecker = (*attemptCompletionChecker)(nil)
+	_ bridge.CompletionChecker = (*judgeCompletionChecker)(nil)
+	_ bridge.SessionRecorder   = (*sessionRecorder)(nil)
+)
+
+// --- InstanceFactory adapter ---
+
+// attemptFactory adapts the tripleshot OrchestratorInterface to bridge.InstanceFactory.
+type attemptFactory struct {
+	orch    ts.OrchestratorInterface
+	session ts.SessionInterface
+}
+
+func newAttemptFactory(orch ts.OrchestratorInterface, session ts.SessionInterface) bridge.InstanceFactory {
+	return &attemptFactory{orch: orch, session: session}
+}
+
+func (f *attemptFactory) CreateInstance(taskPrompt string) (bridge.Instance, error) {
+	inst, err := f.orch.AddInstance(f.session, taskPrompt)
+	if err != nil {
+		return nil, fmt.Errorf("create instance: %w", err)
+	}
+	return &attemptInstance{inst: inst}, nil
+}
+
+func (f *attemptFactory) StartInstance(inst bridge.Instance) error {
+	realInst := f.session.GetInstance(inst.ID())
+	if realInst == nil {
+		return fmt.Errorf("start instance: %q not found", inst.ID())
+	}
+	if err := f.orch.StartInstance(realInst); err != nil {
+		return fmt.Errorf("start instance %q: %w", inst.ID(), err)
+	}
+	return nil
+}
+
+// --- Instance adapter ---
+
+// attemptInstance adapts the tripleshot InstanceInterface to bridge.Instance.
+type attemptInstance struct {
+	inst ts.InstanceInterface
+}
+
+func (a *attemptInstance) ID() string           { return a.inst.GetID() }
+func (a *attemptInstance) WorktreePath() string { return a.inst.GetWorktreePath() }
+func (a *attemptInstance) Branch() string       { return a.inst.GetBranch() }
+
+// --- CompletionChecker adapters ---
+
+// attemptCompletionChecker checks for the tripleshot attempt completion sentinel file.
+type attemptCompletionChecker struct{}
+
+func newAttemptCompletionChecker() bridge.CompletionChecker {
+	return &attemptCompletionChecker{}
+}
+
+func (c *attemptCompletionChecker) CheckCompletion(worktreePath string) (bool, error) {
+	return ts.CompletionFileExists(worktreePath), nil
+}
+
+func (c *attemptCompletionChecker) VerifyWork(_, _, worktreePath, _ string) (bool, int, error) {
+	completion, err := ts.ParseCompletionFile(worktreePath)
+	if err != nil {
+		return false, 0, fmt.Errorf("parse completion file: %w", err)
+	}
+	return completion.Status == "complete", 0, nil
+}
+
+// judgeCompletionChecker checks for the tripleshot evaluation sentinel file.
+type judgeCompletionChecker struct{}
+
+func newJudgeCompletionChecker() bridge.CompletionChecker {
+	return &judgeCompletionChecker{}
+}
+
+func (c *judgeCompletionChecker) CheckCompletion(worktreePath string) (bool, error) {
+	return ts.EvaluationFileExists(worktreePath), nil
+}
+
+func (c *judgeCompletionChecker) VerifyWork(_, _, worktreePath, _ string) (bool, int, error) {
+	_, err := ts.ParseEvaluationFile(worktreePath)
+	if err != nil {
+		return false, 0, fmt.Errorf("parse evaluation file: %w", err)
+	}
+	return true, 0, nil
+}
+
+// --- SessionRecorder adapter ---
+
+// sessionRecorderDeps defines the callbacks for the session recorder.
+type sessionRecorderDeps struct {
+	OnAssign   func(taskID, instanceID string)
+	OnComplete func(taskID string, commitCount int)
+	OnFailure  func(taskID, reason string)
+}
+
+// sessionRecorder delegates to caller-provided callbacks.
+type sessionRecorder struct {
+	deps sessionRecorderDeps
+}
+
+func newSessionRecorder(deps sessionRecorderDeps) bridge.SessionRecorder {
+	return &sessionRecorder{deps: deps}
+}
+
+func (r *sessionRecorder) AssignTask(taskID, instanceID string) {
+	if r.deps.OnAssign != nil {
+		r.deps.OnAssign(taskID, instanceID)
+	}
+}
+
+func (r *sessionRecorder) RecordCompletion(taskID string, commitCount int) {
+	if r.deps.OnComplete != nil {
+		r.deps.OnComplete(taskID, commitCount)
+	}
+}
+
+func (r *sessionRecorder) RecordFailure(taskID, reason string) {
+	if r.deps.OnFailure != nil {
+		r.deps.OnFailure(taskID, reason)
+	}
+}

--- a/internal/orchestrator/workflows/tripleshot/teamwire/adapters_test.go
+++ b/internal/orchestrator/workflows/tripleshot/teamwire/adapters_test.go
@@ -1,0 +1,337 @@
+package teamwire
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	ts "github.com/Iron-Ham/claudio/internal/orchestrator/workflows/tripleshot"
+)
+
+// --- Mock implementations for adapter tests ---
+
+type mockInstance struct {
+	id           string
+	worktreePath string
+	branch       string
+}
+
+func (m *mockInstance) GetID() string           { return m.id }
+func (m *mockInstance) GetWorktreePath() string { return m.worktreePath }
+func (m *mockInstance) GetBranch() string       { return m.branch }
+
+type mockOrch struct {
+	addErr   error
+	startErr error
+	inst     *mockInstance
+}
+
+func (m *mockOrch) AddInstance(_ ts.SessionInterface, _ string) (ts.InstanceInterface, error) {
+	if m.addErr != nil {
+		return nil, m.addErr
+	}
+	return m.inst, nil
+}
+
+func (m *mockOrch) AddInstanceToWorktree(_ ts.SessionInterface, _, _, _ string) (ts.InstanceInterface, error) {
+	return m.inst, nil
+}
+
+func (m *mockOrch) StartInstance(_ ts.InstanceInterface) error {
+	return m.startErr
+}
+
+func (m *mockOrch) SaveSession() error { return nil }
+
+func (m *mockOrch) AddInstanceStub(_ ts.SessionInterface, _ string) (ts.InstanceInterface, error) {
+	return m.inst, nil
+}
+
+func (m *mockOrch) CompleteInstanceSetupByID(_ ts.SessionInterface, _ string) error {
+	return nil
+}
+
+type mockSession struct {
+	instances map[string]*mockInstance
+}
+
+func (m *mockSession) GetGroup(_ string) ts.GroupInterface              { return nil }
+func (m *mockSession) GetGroupBySessionType(_ string) ts.GroupInterface { return nil }
+func (m *mockSession) GetInstance(id string) ts.InstanceInterface {
+	inst := m.instances[id]
+	if inst == nil {
+		return nil
+	}
+	return inst
+}
+
+// --- attemptFactory tests ---
+
+func TestAttemptFactory_CreateInstance(t *testing.T) {
+	inst := &mockInstance{id: "inst-1", worktreePath: "/tmp/wt-1", branch: "branch-1"}
+	orch := &mockOrch{inst: inst}
+	session := &mockSession{}
+
+	factory := newAttemptFactory(orch, session)
+	result, err := factory.CreateInstance("test prompt")
+	if err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+	if result.ID() != "inst-1" {
+		t.Errorf("ID = %q, want %q", result.ID(), "inst-1")
+	}
+	if result.WorktreePath() != "/tmp/wt-1" {
+		t.Errorf("WorktreePath = %q, want %q", result.WorktreePath(), "/tmp/wt-1")
+	}
+	if result.Branch() != "branch-1" {
+		t.Errorf("Branch = %q, want %q", result.Branch(), "branch-1")
+	}
+}
+
+func TestAttemptFactory_CreateInstance_Error(t *testing.T) {
+	orch := &mockOrch{addErr: errors.New("disk full")}
+	session := &mockSession{}
+
+	factory := newAttemptFactory(orch, session)
+	_, err := factory.CreateInstance("test prompt")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, orch.addErr) {
+		t.Errorf("error = %v, want wrapped %v", err, orch.addErr)
+	}
+}
+
+func TestAttemptFactory_StartInstance(t *testing.T) {
+	inst := &mockInstance{id: "inst-1"}
+	orch := &mockOrch{inst: inst}
+	session := &mockSession{
+		instances: map[string]*mockInstance{"inst-1": inst},
+	}
+
+	factory := newAttemptFactory(orch, session)
+	ai := &attemptInstance{inst: inst}
+	if err := factory.StartInstance(ai); err != nil {
+		t.Fatalf("StartInstance: %v", err)
+	}
+}
+
+func TestAttemptFactory_StartInstance_NotFound(t *testing.T) {
+	orch := &mockOrch{}
+	session := &mockSession{instances: map[string]*mockInstance{}}
+
+	factory := newAttemptFactory(orch, session)
+	ai := &attemptInstance{inst: &mockInstance{id: "missing"}}
+	err := factory.StartInstance(ai)
+	if err == nil {
+		t.Fatal("expected error for missing instance")
+	}
+}
+
+func TestAttemptFactory_StartInstance_Error(t *testing.T) {
+	inst := &mockInstance{id: "inst-1"}
+	orch := &mockOrch{startErr: errors.New("tmux failure"), inst: inst}
+	session := &mockSession{
+		instances: map[string]*mockInstance{"inst-1": inst},
+	}
+
+	factory := newAttemptFactory(orch, session)
+	ai := &attemptInstance{inst: inst}
+	err := factory.StartInstance(ai)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// --- attemptCompletionChecker tests ---
+
+func TestAttemptCompletionChecker_NoFile(t *testing.T) {
+	checker := newAttemptCompletionChecker()
+	done, err := checker.CheckCompletion(t.TempDir())
+	if err != nil {
+		t.Fatalf("CheckCompletion: %v", err)
+	}
+	if done {
+		t.Error("expected done=false for missing file")
+	}
+}
+
+func TestAttemptCompletionChecker_WithFile(t *testing.T) {
+	dir := t.TempDir()
+	completion := ts.CompletionFile{
+		AttemptIndex:  0,
+		Status:        "complete",
+		Summary:       "done",
+		FilesModified: []string{"a.go"},
+		Approach:      "direct",
+	}
+	data, _ := json.Marshal(completion)
+	if err := os.WriteFile(filepath.Join(dir, ts.CompletionFileName), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	checker := newAttemptCompletionChecker()
+	done, err := checker.CheckCompletion(dir)
+	if err != nil {
+		t.Fatalf("CheckCompletion: %v", err)
+	}
+	if !done {
+		t.Error("expected done=true for existing file")
+	}
+}
+
+func TestAttemptCompletionChecker_VerifyWork(t *testing.T) {
+	dir := t.TempDir()
+	completion := ts.CompletionFile{
+		AttemptIndex:  0,
+		Status:        "complete",
+		Summary:       "implemented feature",
+		FilesModified: []string{"main.go"},
+		Approach:      "test-driven",
+	}
+	data, _ := json.Marshal(completion)
+	if err := os.WriteFile(filepath.Join(dir, ts.CompletionFileName), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	checker := newAttemptCompletionChecker()
+	success, commitCount, err := checker.VerifyWork("t1", "i1", dir, "main")
+	if err != nil {
+		t.Fatalf("VerifyWork: %v", err)
+	}
+	if !success {
+		t.Error("expected success=true for complete status")
+	}
+	if commitCount != 0 {
+		t.Errorf("commitCount = %d, want 0", commitCount)
+	}
+}
+
+func TestAttemptCompletionChecker_VerifyWork_FailedStatus(t *testing.T) {
+	dir := t.TempDir()
+	completion := ts.CompletionFile{Status: "failed"}
+	data, _ := json.Marshal(completion)
+	if err := os.WriteFile(filepath.Join(dir, ts.CompletionFileName), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	checker := newAttemptCompletionChecker()
+	success, _, err := checker.VerifyWork("t1", "i1", dir, "main")
+	if err != nil {
+		t.Fatalf("VerifyWork: %v", err)
+	}
+	if success {
+		t.Error("expected success=false for failed status")
+	}
+}
+
+func TestAttemptCompletionChecker_VerifyWork_NoFile(t *testing.T) {
+	checker := newAttemptCompletionChecker()
+	_, _, err := checker.VerifyWork("t1", "i1", t.TempDir(), "main")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+// --- judgeCompletionChecker tests ---
+
+func TestJudgeCompletionChecker_NoFile(t *testing.T) {
+	checker := newJudgeCompletionChecker()
+	done, err := checker.CheckCompletion(t.TempDir())
+	if err != nil {
+		t.Fatalf("CheckCompletion: %v", err)
+	}
+	if done {
+		t.Error("expected done=false for missing file")
+	}
+}
+
+func TestJudgeCompletionChecker_WithFile(t *testing.T) {
+	dir := t.TempDir()
+	evaluation := ts.Evaluation{
+		WinnerIndex:   1,
+		MergeStrategy: ts.MergeStrategySelect,
+		Reasoning:     "best solution",
+	}
+	data, _ := json.Marshal(evaluation)
+	if err := os.WriteFile(filepath.Join(dir, ts.EvaluationFileName), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	checker := newJudgeCompletionChecker()
+	done, err := checker.CheckCompletion(dir)
+	if err != nil {
+		t.Fatalf("CheckCompletion: %v", err)
+	}
+	if !done {
+		t.Error("expected done=true for existing file")
+	}
+}
+
+func TestJudgeCompletionChecker_VerifyWork(t *testing.T) {
+	dir := t.TempDir()
+	evaluation := ts.Evaluation{
+		WinnerIndex:   0,
+		MergeStrategy: ts.MergeStrategySelect,
+		Reasoning:     "solid",
+	}
+	data, _ := json.Marshal(evaluation)
+	if err := os.WriteFile(filepath.Join(dir, ts.EvaluationFileName), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	checker := newJudgeCompletionChecker()
+	success, _, err := checker.VerifyWork("j1", "ji1", dir, "main")
+	if err != nil {
+		t.Fatalf("VerifyWork: %v", err)
+	}
+	if !success {
+		t.Error("expected success=true")
+	}
+}
+
+func TestJudgeCompletionChecker_VerifyWork_NoFile(t *testing.T) {
+	checker := newJudgeCompletionChecker()
+	_, _, err := checker.VerifyWork("j1", "ji1", t.TempDir(), "main")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+// --- sessionRecorder tests ---
+
+func TestSessionRecorder_AllCallbacks(t *testing.T) {
+	var assigned, completed, failed bool
+
+	recorder := newSessionRecorder(sessionRecorderDeps{
+		OnAssign:   func(_, _ string) { assigned = true },
+		OnComplete: func(_ string, _ int) { completed = true },
+		OnFailure:  func(_, _ string) { failed = true },
+	})
+
+	recorder.AssignTask("t1", "i1")
+	if !assigned {
+		t.Error("OnAssign not called")
+	}
+
+	recorder.RecordCompletion("t1", 1)
+	if !completed {
+		t.Error("OnComplete not called")
+	}
+
+	recorder.RecordFailure("t1", "reason")
+	if !failed {
+		t.Error("OnFailure not called")
+	}
+}
+
+func TestSessionRecorder_NilCallbacks(t *testing.T) {
+	recorder := newSessionRecorder(sessionRecorderDeps{})
+
+	// Should not panic with nil callbacks.
+	recorder.AssignTask("t1", "i1")
+	recorder.RecordCompletion("t1", 1)
+	recorder.RecordFailure("t1", "reason")
+}

--- a/internal/orchestrator/workflows/tripleshot/teamwire/teamcoordinator_test.go
+++ b/internal/orchestrator/workflows/tripleshot/teamwire/teamcoordinator_test.go
@@ -1,0 +1,995 @@
+package teamwire
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/bridge"
+	"github.com/Iron-Ham/claudio/internal/coordination"
+	"github.com/Iron-Ham/claudio/internal/event"
+	ts "github.com/Iron-Ham/claudio/internal/orchestrator/workflows/tripleshot"
+)
+
+// --- Test helpers and mocks ---
+
+// testOrch provides a controllable OrchestratorInterface for tests.
+// It creates mock instances and tracks calls.
+type testOrch struct {
+	mu        sync.Mutex
+	instances map[string]*mockInstance
+	nextID    int
+	createErr error
+	startErr  error
+	tempDirFn func() string // injected from test via t.TempDir for auto-cleanup
+}
+
+func newTestOrch(t *testing.T) *testOrch {
+	return &testOrch{instances: make(map[string]*mockInstance), tempDirFn: t.TempDir}
+}
+
+func (o *testOrch) AddInstance(session ts.SessionInterface, _ string) (ts.InstanceInterface, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if o.createErr != nil {
+		return nil, o.createErr
+	}
+
+	id := o.nextInstanceID()
+	dir := o.tempDirFn()
+	inst := &mockInstance{
+		id:           id,
+		worktreePath: dir,
+		branch:       "branch-" + id,
+	}
+	o.instances[id] = inst
+
+	// Also register in session for lookup.
+	if ts, ok := session.(*testSession); ok {
+		ts.mu.Lock()
+		ts.instances[id] = inst
+		ts.mu.Unlock()
+	}
+
+	return inst, nil
+}
+
+func (o *testOrch) AddInstanceToWorktree(_ ts.SessionInterface, _, _, _ string) (ts.InstanceInterface, error) {
+	return nil, nil
+}
+
+func (o *testOrch) StartInstance(_ ts.InstanceInterface) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.startErr
+}
+
+func (o *testOrch) SaveSession() error { return nil }
+
+func (o *testOrch) AddInstanceStub(_ ts.SessionInterface, _ string) (ts.InstanceInterface, error) {
+	return nil, nil
+}
+
+func (o *testOrch) CompleteInstanceSetupByID(_ ts.SessionInterface, _ string) error {
+	return nil
+}
+
+func (o *testOrch) nextInstanceID() string {
+	o.nextID++
+	return "inst-" + string(rune('a'+o.nextID-1))
+}
+
+func (o *testOrch) getInstances() map[string]*mockInstance {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	out := make(map[string]*mockInstance, len(o.instances))
+	for k, v := range o.instances {
+		out[k] = v
+	}
+	return out
+}
+
+// testSession provides a thread-safe SessionInterface for tests.
+type testSession struct {
+	mu        sync.Mutex
+	instances map[string]*mockInstance
+}
+
+func newTestSession() *testSession {
+	return &testSession{instances: make(map[string]*mockInstance)}
+}
+
+func (s *testSession) GetGroup(_ string) ts.GroupInterface              { return nil }
+func (s *testSession) GetGroupBySessionType(_ string) ts.GroupInterface { return nil }
+func (s *testSession) GetInstance(id string) ts.InstanceInterface {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	inst := s.instances[id]
+	if inst == nil {
+		return nil
+	}
+	return inst
+}
+
+// writeCompletionFile writes a tripleshot completion sentinel file.
+func writeCompletionFile(t *testing.T, dir string, status string) {
+	t.Helper()
+	completion := ts.CompletionFile{
+		Status:        status,
+		Summary:       "test summary",
+		Approach:      "test approach",
+		FilesModified: []string{"test.go"},
+	}
+	data, _ := json.Marshal(completion)
+	if err := os.WriteFile(filepath.Join(dir, ts.CompletionFileName), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeEvaluationFile writes a tripleshot evaluation sentinel file.
+func writeEvaluationFile(t *testing.T, dir string, winner int) {
+	t.Helper()
+	evaluation := ts.Evaluation{
+		WinnerIndex:   winner,
+		MergeStrategy: ts.MergeStrategySelect,
+		Reasoning:     "test reasoning",
+	}
+	data, _ := json.Marshal(evaluation)
+	if err := os.WriteFile(filepath.Join(dir, ts.EvaluationFileName), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// --- Constructor validation tests ---
+
+func TestNewTeamCoordinator_Validation(t *testing.T) {
+	bus := event.NewBus()
+	orch := newTestOrch(t)
+	session := newTestSession()
+
+	tests := []struct {
+		name string
+		cfg  TeamCoordinatorConfig
+		want string
+	}{
+		{
+			name: "missing orchestrator",
+			cfg:  TeamCoordinatorConfig{Bus: bus, BaseSession: session, BaseDir: "/tmp", Task: "test"},
+			want: "Orchestrator is required",
+		},
+		{
+			name: "missing base session",
+			cfg:  TeamCoordinatorConfig{Orchestrator: orch, Bus: bus, BaseDir: "/tmp", Task: "test"},
+			want: "BaseSession is required",
+		},
+		{
+			name: "missing bus",
+			cfg:  TeamCoordinatorConfig{Orchestrator: orch, BaseSession: session, BaseDir: "/tmp", Task: "test"},
+			want: "Bus is required",
+		},
+		{
+			name: "missing base dir",
+			cfg:  TeamCoordinatorConfig{Orchestrator: orch, BaseSession: session, Bus: bus, Task: "test"},
+			want: "BaseDir is required",
+		},
+		{
+			name: "missing task",
+			cfg:  TeamCoordinatorConfig{Orchestrator: orch, BaseSession: session, Bus: bus, BaseDir: "/tmp"},
+			want: "Task is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewTeamCoordinator(tt.cfg)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if got := err.Error(); !strings.Contains(got, tt.want) {
+				t.Errorf("error = %q, want containing %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewTeamCoordinator_Valid(t *testing.T) {
+	bus := event.NewBus()
+	orch := newTestOrch(t)
+	session := newTestSession()
+
+	tc, err := NewTeamCoordinator(TeamCoordinatorConfig{
+		Orchestrator: orch,
+		BaseSession:  session,
+		Bus:          bus,
+		BaseDir:      t.TempDir(),
+		Task:         "implement feature",
+	})
+	if err != nil {
+		t.Fatalf("NewTeamCoordinator: %v", err)
+	}
+
+	s := tc.Session()
+	if s.Task != "implement feature" {
+		t.Errorf("Session.Task = %q, want %q", s.Task, "implement feature")
+	}
+	if s.Phase != ts.PhaseWorking {
+		t.Errorf("Session.Phase = %q, want %q", s.Phase, ts.PhaseWorking)
+	}
+}
+
+// --- Start/Stop lifecycle tests ---
+
+func TestTeamCoordinator_DoubleStart(t *testing.T) {
+	bus := event.NewBus()
+	orch := newTestOrch(t)
+	session := newTestSession()
+
+	tc, _ := NewTeamCoordinator(TeamCoordinatorConfig{
+		Orchestrator:  orch,
+		BaseSession:   session,
+		Bus:           bus,
+		BaseDir:       t.TempDir(),
+		Task:          "test task",
+		HubOptions:    []coordination.Option{coordination.WithRebalanceInterval(-1)},
+		BridgeOptions: []bridge.Option{bridge.WithPollInterval(10 * time.Millisecond)},
+	})
+
+	ctx := context.Background()
+	if err := tc.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer tc.Stop()
+
+	err := tc.Start(ctx)
+	if err == nil {
+		t.Fatal("expected error on double start")
+	}
+}
+
+func TestTeamCoordinator_StopIdempotent(t *testing.T) {
+	bus := event.NewBus()
+	orch := newTestOrch(t)
+	session := newTestSession()
+
+	tc, _ := NewTeamCoordinator(TeamCoordinatorConfig{
+		Orchestrator:  orch,
+		BaseSession:   session,
+		Bus:           bus,
+		BaseDir:       t.TempDir(),
+		Task:          "test task",
+		HubOptions:    []coordination.Option{coordination.WithRebalanceInterval(-1)},
+		BridgeOptions: []bridge.Option{bridge.WithPollInterval(10 * time.Millisecond)},
+	})
+
+	ctx := context.Background()
+	if err := tc.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Stop multiple times — should not panic.
+	tc.Stop()
+	tc.Stop()
+}
+
+func TestTeamCoordinator_StopBeforeStart(t *testing.T) {
+	bus := event.NewBus()
+	orch := newTestOrch(t)
+	session := newTestSession()
+
+	tc, _ := NewTeamCoordinator(TeamCoordinatorConfig{
+		Orchestrator: orch,
+		BaseSession:  session,
+		Bus:          bus,
+		BaseDir:      t.TempDir(),
+		Task:         "test task",
+	})
+
+	// Should not panic.
+	tc.Stop()
+}
+
+// --- Callback tests ---
+
+func TestTeamCoordinator_SetCallbacks(t *testing.T) {
+	bus := event.NewBus()
+	orch := newTestOrch(t)
+	session := newTestSession()
+
+	tc, _ := NewTeamCoordinator(TeamCoordinatorConfig{
+		Orchestrator:  orch,
+		BaseSession:   session,
+		Bus:           bus,
+		BaseDir:       t.TempDir(),
+		Task:          "test task",
+		HubOptions:    []coordination.Option{coordination.WithRebalanceInterval(-1)},
+		BridgeOptions: []bridge.Option{bridge.WithPollInterval(10 * time.Millisecond)},
+	})
+
+	phaseChanges := make(chan ts.Phase, 10)
+	tc.SetCallbacks(&ts.CoordinatorCallbacks{
+		OnPhaseChange: func(phase ts.Phase) {
+			phaseChanges <- phase
+		},
+	})
+
+	ctx := context.Background()
+	if err := tc.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer tc.Stop()
+
+	// Should receive working phase change from Start.
+	select {
+	case phase := <-phaseChanges:
+		if phase != ts.PhaseWorking {
+			t.Errorf("expected PhaseWorking, got %v", phase)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for phase change")
+	}
+}
+
+// --- Attempt lifecycle tests ---
+
+func TestTeamCoordinator_AttemptStartCallbacks(t *testing.T) {
+	bus := event.NewBus()
+	orch := newTestOrch(t)
+	session := newTestSession()
+
+	tc, _ := NewTeamCoordinator(TeamCoordinatorConfig{
+		Orchestrator:  orch,
+		BaseSession:   session,
+		Bus:           bus,
+		BaseDir:       t.TempDir(),
+		Task:          "implement feature",
+		HubOptions:    []coordination.Option{coordination.WithRebalanceInterval(-1)},
+		BridgeOptions: []bridge.Option{bridge.WithPollInterval(10 * time.Millisecond)},
+	})
+
+	starts := make(chan int, 3)
+	tc.SetCallbacks(&ts.CoordinatorCallbacks{
+		OnPhaseChange:  func(_ ts.Phase) {},
+		OnAttemptStart: func(idx int, _ string) { starts <- idx },
+	})
+
+	ctx := context.Background()
+	if err := tc.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer tc.Stop()
+
+	// Wait for all 3 attempts to start.
+	started := make(map[int]bool)
+	timeout := time.After(5 * time.Second)
+	for len(started) < 3 {
+		select {
+		case idx := <-starts:
+			started[idx] = true
+		case <-timeout:
+			t.Fatalf("timed out waiting for attempt starts, got %d", len(started))
+		}
+	}
+}
+
+// --- Full lifecycle test (attempts + judge) ---
+
+func TestTeamCoordinator_FullLifecycle(t *testing.T) {
+	bus := event.NewBus()
+	orch := newTestOrch(t)
+	session := newTestSession()
+
+	tc, _ := NewTeamCoordinator(TeamCoordinatorConfig{
+		Orchestrator:  orch,
+		BaseSession:   session,
+		Bus:           bus,
+		BaseDir:       t.TempDir(),
+		Task:          "implement feature",
+		HubOptions:    []coordination.Option{coordination.WithRebalanceInterval(-1)},
+		BridgeOptions: []bridge.Option{bridge.WithPollInterval(10 * time.Millisecond)},
+	})
+
+	completeCh := make(chan string, 1)
+	phaseCh := make(chan ts.Phase, 10)
+	evalCh := make(chan *ts.Evaluation, 1)
+	attemptStarts := make(chan startInfo, 3)
+	judgeStarts := make(chan string, 1)
+
+	tc.SetCallbacks(&ts.CoordinatorCallbacks{
+		OnPhaseChange: func(p ts.Phase) { phaseCh <- p },
+		OnAttemptStart: func(idx int, instanceID string) {
+			attemptStarts <- startInfo{idx: idx, instanceID: instanceID}
+		},
+		OnAttemptComplete: func(_ int) {},
+		OnAttemptFailed:   func(_ int, _ string) {},
+		OnJudgeStart:      func(instanceID string) { judgeStarts <- instanceID },
+		OnEvaluationReady: func(eval *ts.Evaluation) { evalCh <- eval },
+		OnComplete: func(success bool, summary string) {
+			if success {
+				completeCh <- summary
+			} else {
+				completeCh <- "FAILED: " + summary
+			}
+		},
+	})
+
+	ctx := context.Background()
+	if err := tc.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer tc.Stop()
+
+	// Wait for all 3 attempt starts via callbacks (not bus events, since
+	// events may fire before we can subscribe).
+	instanceIDs := make([]string, 0, 3)
+	timeout := time.After(5 * time.Second)
+	for range 3 {
+		select {
+		case info := <-attemptStarts:
+			instanceIDs = append(instanceIDs, info.instanceID)
+		case <-timeout:
+			t.Fatalf("timed out waiting for attempt starts, got %d", len(instanceIDs))
+		}
+	}
+
+	// Write completion files for all 3 attempts.
+	instances := orch.getInstances()
+	for _, id := range instanceIDs {
+		inst := instances[id]
+		if inst == nil {
+			t.Fatalf("instance %q not found in orch", id)
+		}
+		writeCompletionFile(t, inst.worktreePath, "complete")
+	}
+
+	// Wait for evaluating phase.
+	waitForPhase(t, phaseCh, ts.PhaseEvaluating, 10*time.Second)
+
+	// Wait for judge start via callback.
+	var judgeInstanceID string
+	select {
+	case judgeInstanceID = <-judgeStarts:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for judge start")
+	}
+
+	judgeInstances := orch.getInstances()
+	judgeInst := judgeInstances[judgeInstanceID]
+	if judgeInst == nil {
+		t.Fatal("judge instance not found")
+	}
+
+	writeEvaluationFile(t, judgeInst.worktreePath, 1)
+
+	// Wait for completion.
+	select {
+	case summary := <-completeCh:
+		if strings.Contains(summary, "FAILED") {
+			t.Fatalf("expected success, got: %s", summary)
+		}
+		t.Logf("completed: %s", summary)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for completion")
+	}
+
+	// Verify evaluation was received.
+	select {
+	case eval := <-evalCh:
+		if eval.WinnerIndex != 1 {
+			t.Errorf("WinnerIndex = %d, want 1", eval.WinnerIndex)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for evaluation")
+	}
+
+	// Verify session state.
+	s := tc.Session()
+	if s.Phase != ts.PhaseComplete {
+		t.Errorf("Session.Phase = %q, want %q", s.Phase, ts.PhaseComplete)
+	}
+	if s.Evaluation == nil {
+		t.Error("Session.Evaluation is nil")
+	}
+	if s.CompletedAt == nil {
+		t.Error("Session.CompletedAt is nil")
+	}
+}
+
+// --- Tripleshot-specific event tests ---
+
+func TestTeamCoordinator_TripleShotAttemptEvents(t *testing.T) {
+	bus := event.NewBus()
+	orch := newTestOrch(t)
+	session := newTestSession()
+
+	tc, _ := NewTeamCoordinator(TeamCoordinatorConfig{
+		Orchestrator:  orch,
+		BaseSession:   session,
+		Bus:           bus,
+		BaseDir:       t.TempDir(),
+		Task:          "test task",
+		HubOptions:    []coordination.Option{coordination.WithRebalanceInterval(-1)},
+		BridgeOptions: []bridge.Option{bridge.WithPollInterval(10 * time.Millisecond)},
+	})
+
+	// Collect tripleshot attempt completed events — subscribe BEFORE Start
+	// so we don't miss any events from the synchronous bus.
+	attemptEvents := make(chan event.TripleShotAttemptCompletedEvent, 3)
+	bus.Subscribe("tripleshot.attempt_completed", func(e event.Event) {
+		if ace, ok := e.(event.TripleShotAttemptCompletedEvent); ok {
+			attemptEvents <- ace
+		}
+	})
+
+	// Use callbacks (set before Start) to learn when attempts start.
+	attemptStartIDs := make(chan string, 3)
+	tc.SetCallbacks(&ts.CoordinatorCallbacks{
+		OnPhaseChange:     func(_ ts.Phase) {},
+		OnAttemptStart:    func(_ int, id string) { attemptStartIDs <- id },
+		OnAttemptComplete: func(_ int) {},
+	})
+
+	ctx := context.Background()
+	if err := tc.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer tc.Stop()
+
+	// Wait for attempts to start via callbacks, then write completion files.
+	timeout := time.After(5 * time.Second)
+	for range 3 {
+		var instanceID string
+		select {
+		case instanceID = <-attemptStartIDs:
+		case <-timeout:
+			t.Fatal("timed out waiting for attempt starts")
+		}
+		instances := orch.getInstances()
+		inst := instances[instanceID]
+		writeCompletionFile(t, inst.worktreePath, "complete")
+	}
+
+	// Wait for all 3 tripleshot attempt events.
+	received := 0
+	timeout2 := time.After(10 * time.Second)
+	for received < 3 {
+		select {
+		case ace := <-attemptEvents:
+			if !ace.Success {
+				t.Errorf("attempt %d not marked as success", ace.AttemptIndex)
+			}
+			received++
+		case <-timeout2:
+			t.Fatalf("timed out waiting for attempt events, got %d", received)
+		}
+	}
+}
+
+// --- GetWinningBranch tests ---
+
+func TestTeamCoordinator_GetWinningBranch(t *testing.T) {
+	bus := event.NewBus()
+	orch := newTestOrch(t)
+	session := newTestSession()
+
+	tc, _ := NewTeamCoordinator(TeamCoordinatorConfig{
+		Orchestrator: orch,
+		BaseSession:  session,
+		Bus:          bus,
+		BaseDir:      t.TempDir(),
+		Task:         "test",
+	})
+
+	// No evaluation yet.
+	if b := tc.GetWinningBranch(); b != "" {
+		t.Errorf("expected empty branch, got %q", b)
+	}
+
+	// Set up evaluation.
+	s := tc.Session()
+	s.Attempts[1].Branch = "winner-branch"
+	s.Evaluation = &ts.Evaluation{
+		WinnerIndex:   1,
+		MergeStrategy: ts.MergeStrategySelect,
+	}
+	if b := tc.GetWinningBranch(); b != "winner-branch" {
+		t.Errorf("expected %q, got %q", "winner-branch", b)
+	}
+
+	// Merge strategy should return empty.
+	s.Evaluation.MergeStrategy = ts.MergeStrategyMerge
+	if b := tc.GetWinningBranch(); b != "" {
+		t.Errorf("expected empty for merge strategy, got %q", b)
+	}
+
+	// Out-of-range winner index.
+	s.Evaluation.MergeStrategy = ts.MergeStrategySelect
+	s.Evaluation.WinnerIndex = 5
+	if b := tc.GetWinningBranch(); b != "" {
+		t.Errorf("expected empty for invalid index, got %q", b)
+	}
+
+	// Negative winner index.
+	s.Evaluation.WinnerIndex = -1
+	if b := tc.GetWinningBranch(); b != "" {
+		t.Errorf("expected empty for negative index, got %q", b)
+	}
+}
+
+// --- Attempt failure tests ---
+
+// --- Handler-level tests for failure paths ---
+
+func TestTeamCoordinator_OnBridgeTaskCompleted_AttemptFailed(t *testing.T) {
+	bus := event.NewBus()
+	orch := newTestOrch(t)
+	session := newTestSession()
+
+	tc, _ := NewTeamCoordinator(TeamCoordinatorConfig{
+		Orchestrator: orch,
+		BaseSession:  session,
+		Bus:          bus,
+		BaseDir:      t.TempDir(),
+		Task:         "test task",
+	})
+
+	failedCh := make(chan string, 1)
+	tc.SetCallbacks(&ts.CoordinatorCallbacks{
+		OnAttemptFailed: func(idx int, reason string) {
+			failedCh <- fmt.Sprintf("%d:%s", idx, reason)
+		},
+	})
+
+	// Manually set started=true and attemptTeamIDs so handlers work.
+	tc.mu.Lock()
+	tc.started = true
+	tc.attemptTeamIDs = [3]string{"attempt-0", "attempt-1", "attempt-2"}
+	tc.mu.Unlock()
+
+	// Simulate bridge task_completed for attempt-1 with failure.
+	bce := event.NewBridgeTaskCompletedEvent("attempt-1", "task-1", "inst-1", false, 0, "verification failed")
+	tc.onBridgeTaskCompleted(bce)
+
+	select {
+	case result := <-failedCh:
+		if !strings.Contains(result, "1:") || !strings.Contains(result, "verification failed") {
+			t.Errorf("unexpected failure callback: %s", result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for failure callback")
+	}
+
+	// Verify session state.
+	s := tc.Session()
+	if s.Attempts[1].Status != ts.AttemptStatusFailed {
+		t.Errorf("Attempts[1].Status = %q, want %q", s.Attempts[1].Status, ts.AttemptStatusFailed)
+	}
+}
+
+func TestTeamCoordinator_OnJudgeCompleted_Failure(t *testing.T) {
+	bus := event.NewBus()
+	orch := newTestOrch(t)
+	session := newTestSession()
+
+	tc, _ := NewTeamCoordinator(TeamCoordinatorConfig{
+		Orchestrator: orch,
+		BaseSession:  session,
+		Bus:          bus,
+		BaseDir:      t.TempDir(),
+		Task:         "test task",
+	})
+
+	doneCh := make(chan string, 1)
+	phaseCh := make(chan ts.Phase, 5)
+	tc.SetCallbacks(&ts.CoordinatorCallbacks{
+		OnPhaseChange: func(p ts.Phase) { phaseCh <- p },
+		OnComplete:    func(success bool, summary string) { doneCh <- fmt.Sprintf("%v:%s", success, summary) },
+	})
+
+	// Set started=true and ensure event not treated as attempt.
+	tc.mu.Lock()
+	tc.started = true
+	tc.mu.Unlock()
+
+	// Collect tripleshot judge event.
+	judgeEvents := make(chan event.TripleShotJudgeCompletedEvent, 1)
+	bus.Subscribe("tripleshot.judge_completed", func(e event.Event) {
+		if jce, ok := e.(event.TripleShotJudgeCompletedEvent); ok {
+			judgeEvents <- jce
+		}
+	})
+
+	// Simulate judge bridge failure (not an attempt team, falls through to onJudgeCompleted).
+	bce := event.NewBridgeTaskCompletedEvent("judge", "judge-task", "judge-inst", false, 0, "judge crashed")
+	tc.onBridgeTaskCompleted(bce)
+
+	select {
+	case result := <-doneCh:
+		if !strings.Contains(result, "false") {
+			t.Errorf("expected failure, got: %s", result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for judge failure callback")
+	}
+
+	// Verify the TripleShotJudgeCompletedEvent was published.
+	select {
+	case jce := <-judgeEvents:
+		if jce.Success {
+			t.Error("expected Success=false")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for judge completed event")
+	}
+
+	s := tc.Session()
+	if s.Phase != ts.PhaseFailed {
+		t.Errorf("Session.Phase = %q, want %q", s.Phase, ts.PhaseFailed)
+	}
+}
+
+func TestTeamCoordinator_OnJudgeCompleted_InstanceNotFound(t *testing.T) {
+	bus := event.NewBus()
+	orch := newTestOrch(t)
+	session := newTestSession()
+
+	tc, _ := NewTeamCoordinator(TeamCoordinatorConfig{
+		Orchestrator: orch,
+		BaseSession:  session,
+		Bus:          bus,
+		BaseDir:      t.TempDir(),
+		Task:         "test task",
+	})
+
+	doneCh := make(chan string, 1)
+	tc.SetCallbacks(&ts.CoordinatorCallbacks{
+		OnPhaseChange: func(_ ts.Phase) {},
+		OnComplete:    func(success bool, _ string) { doneCh <- fmt.Sprintf("%v", success) },
+	})
+
+	tc.mu.Lock()
+	tc.started = true
+	tc.mu.Unlock()
+
+	// Collect tripleshot judge event.
+	judgeEvents := make(chan event.TripleShotJudgeCompletedEvent, 1)
+	bus.Subscribe("tripleshot.judge_completed", func(e event.Event) {
+		if jce, ok := e.(event.TripleShotJudgeCompletedEvent); ok {
+			judgeEvents <- jce
+		}
+	})
+
+	// Simulate successful judge completion, but instance not found in session.
+	bce := event.NewBridgeTaskCompletedEvent("judge", "judge-task", "nonexistent-inst", true, 0, "")
+	tc.onBridgeTaskCompleted(bce)
+
+	select {
+	case result := <-doneCh:
+		if !strings.Contains(result, "false") {
+			t.Errorf("expected failure, got: %s", result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for completion callback")
+	}
+
+	// Verify the TripleShotJudgeCompletedEvent was published.
+	select {
+	case jce := <-judgeEvents:
+		if jce.Success {
+			t.Error("expected Success=false")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for judge completed event")
+	}
+
+	s := tc.Session()
+	if s.Phase != ts.PhaseFailed {
+		t.Errorf("Session.Phase = %q, want %q", s.Phase, ts.PhaseFailed)
+	}
+}
+
+func TestTeamCoordinator_OnJudgeCompleted_BadEvaluation(t *testing.T) {
+	bus := event.NewBus()
+	orch := newTestOrch(t)
+	session := newTestSession()
+
+	tc, _ := NewTeamCoordinator(TeamCoordinatorConfig{
+		Orchestrator: orch,
+		BaseSession:  session,
+		Bus:          bus,
+		BaseDir:      t.TempDir(),
+		Task:         "test task",
+	})
+
+	doneCh := make(chan string, 1)
+	tc.SetCallbacks(&ts.CoordinatorCallbacks{
+		OnPhaseChange: func(_ ts.Phase) {},
+		OnComplete:    func(success bool, summary string) { doneCh <- fmt.Sprintf("%v:%s", success, summary) },
+	})
+
+	tc.mu.Lock()
+	tc.started = true
+	tc.mu.Unlock()
+
+	// Collect tripleshot judge event.
+	judgeEvents := make(chan event.TripleShotJudgeCompletedEvent, 1)
+	bus.Subscribe("tripleshot.judge_completed", func(e event.Event) {
+		if jce, ok := e.(event.TripleShotJudgeCompletedEvent); ok {
+			judgeEvents <- jce
+		}
+	})
+
+	// Create a mock instance in session (so GetInstance works) but with
+	// no evaluation file (so ParseEvaluationFile fails).
+	instDir := t.TempDir()
+	inst := &mockInstance{id: "judge-inst", worktreePath: instDir, branch: "judge-branch"}
+	session.mu.Lock()
+	session.instances["judge-inst"] = inst
+	session.mu.Unlock()
+
+	bce := event.NewBridgeTaskCompletedEvent("judge", "judge-task", "judge-inst", true, 0, "")
+	tc.onBridgeTaskCompleted(bce)
+
+	select {
+	case result := <-doneCh:
+		if !strings.Contains(result, "false") {
+			t.Errorf("expected failure, got: %s", result)
+		}
+		if !strings.Contains(result, "parse evaluation") {
+			t.Errorf("expected parse error in result, got: %s", result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for completion callback")
+	}
+
+	// Verify the TripleShotJudgeCompletedEvent was published.
+	select {
+	case jce := <-judgeEvents:
+		if jce.Success {
+			t.Error("expected Success=false")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for judge completed event")
+	}
+
+	s := tc.Session()
+	if s.Phase != ts.PhaseFailed {
+		t.Errorf("Session.Phase = %q, want %q", s.Phase, ts.PhaseFailed)
+	}
+}
+
+func TestTeamCoordinator_StartJudge_TooFewSuccesses(t *testing.T) {
+	bus := event.NewBus()
+	orch := newTestOrch(t)
+	session := newTestSession()
+
+	tc, _ := NewTeamCoordinator(TeamCoordinatorConfig{
+		Orchestrator: orch,
+		BaseSession:  session,
+		Bus:          bus,
+		BaseDir:      t.TempDir(),
+		Task:         "test task",
+	})
+
+	doneCh := make(chan string, 1)
+	phaseCh := make(chan ts.Phase, 5)
+	tc.SetCallbacks(&ts.CoordinatorCallbacks{
+		OnPhaseChange: func(p ts.Phase) { phaseCh <- p },
+		OnComplete: func(success bool, summary string) {
+			doneCh <- fmt.Sprintf("%v:%s", success, summary)
+		},
+	})
+
+	tc.mu.Lock()
+	tc.started = true
+	tc.mu.Unlock()
+
+	// Manually set session: only 1 out of 3 completed.
+	s := tc.Session()
+	s.Attempts[0].Status = ts.AttemptStatusCompleted
+	s.Attempts[1].Status = ts.AttemptStatusFailed
+	s.Attempts[2].Status = ts.AttemptStatusFailed
+
+	// Call startJudge directly — it should detect <2 successes and fail.
+	tc.startJudge()
+
+	select {
+	case result := <-doneCh:
+		if !strings.Contains(result, "false") {
+			t.Errorf("expected failure, got: %s", result)
+		}
+		if !strings.Contains(result, "fewer than 2") {
+			t.Errorf("expected 'fewer than 2' in result, got: %s", result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for failure callback")
+	}
+
+	if s.Phase != ts.PhaseFailed {
+		t.Errorf("Session.Phase = %q, want %q", s.Phase, ts.PhaseFailed)
+	}
+}
+
+func TestTeamCoordinator_OnTeamCompleted_NotStarted(t *testing.T) {
+	bus := event.NewBus()
+	orch := newTestOrch(t)
+	session := newTestSession()
+
+	tc, _ := NewTeamCoordinator(TeamCoordinatorConfig{
+		Orchestrator: orch,
+		BaseSession:  session,
+		Bus:          bus,
+		BaseDir:      t.TempDir(),
+		Task:         "test task",
+	})
+
+	// Not started — handler should return immediately without panicking.
+	tce := event.NewTeamCompletedEvent("attempt-0", "Attempt 1", true, 1, 0)
+	tc.onTeamCompleted(tce)
+
+	// Verify no attempt was counted.
+	tc.mu.Lock()
+	count := tc.completedAttempts
+	tc.mu.Unlock()
+	if count != 0 {
+		t.Errorf("completedAttempts = %d, want 0", count)
+	}
+}
+
+func TestTeamCoordinator_OnTeamCompleted_UnknownTeam(t *testing.T) {
+	bus := event.NewBus()
+	orch := newTestOrch(t)
+	session := newTestSession()
+
+	tc, _ := NewTeamCoordinator(TeamCoordinatorConfig{
+		Orchestrator: orch,
+		BaseSession:  session,
+		Bus:          bus,
+		BaseDir:      t.TempDir(),
+		Task:         "test task",
+	})
+
+	tc.mu.Lock()
+	tc.started = true
+	tc.mu.Unlock()
+
+	// Unknown team ID — should be ignored.
+	tce := event.NewTeamCompletedEvent("unknown-team", "Unknown", true, 1, 0)
+	tc.onTeamCompleted(tce)
+
+	tc.mu.Lock()
+	count := tc.completedAttempts
+	tc.mu.Unlock()
+	if count != 0 {
+		t.Errorf("completedAttempts = %d, want 0", count)
+	}
+}
+
+// startInfo captures an attempt start event for test assertions.
+type startInfo struct {
+	idx        int
+	instanceID string
+}
+
+// --- Helpers ---
+
+func waitForPhase(t *testing.T, ch <-chan ts.Phase, want ts.Phase, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case got := <-ch:
+			if got == want {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for phase %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Introduces `teamwire` subpackage (`internal/orchestrator/workflows/tripleshot/teamwire/`) that connects the TripleShot workflow to Orchestration 2.0 team infrastructure
- `TeamCoordinator` orchestrates 3 parallel attempt teams + 1 dynamically-added judge team using `team.Manager` directly (not Pipeline, since the judge needs completion data from all attempts to construct its prompt)
- Adapter types (`attemptFactory`, `attemptCompletionChecker`, `judgeCompletionChecker`, `sessionRecorder`) implement bridge interfaces wrapping tripleshot's existing `OrchestratorInterface` and sentinel file helpers
- Two new event types: `TripleShotAttemptCompletedEvent` and `TripleShotJudgeCompletedEvent`
- Subpackage exists to break the import cycle: `tripleshot → bridge → team → coordination → ... → orchestrator → tripleshot`

## Design decisions

- **Manager over Pipeline**: Pipeline enforces sequential phases where all execution teams share one Manager. TripleShot needs the judge in the SAME Manager to use `DependsOn`, and the judge prompt requires data that isn't available until all 3 attempts finish. `AddTeamDynamic` is the right tool.
- **Two-phase Start**: `registerStart()` holds/releases the lock, then `Start()` creates bridges outside it — prevents deadlock with the synchronous event bus.
- **`failJudge` helper**: All `onJudgeCompleted` failure paths are consolidated into one method that sets session error, transitions phase, fires callbacks, and publishes the judge completed event.

## Test plan

- [x] 32 tests covering constructor validation, Start/Stop lifecycle, callbacks, attempt lifecycle, full lifecycle (attempts + judge), tripleshot-specific events, GetWinningBranch, and handler-level failure paths
- [x] Race detector: `go test -race ./internal/orchestrator/workflows/tripleshot/teamwire/...` — passes
- [x] golangci-lint: 0 issues
- [x] gofmt: clean
- [x] Coverage: 82.1% — uncovered lines are documented with `// Coverage:` comments (defensive guards for unreachable paths)

Closes #645