### PR TITLE
Make Orchestration 2.0 the default execution path

### DIFF
--- a/internal/cmd/session/pipeline_wire.go
+++ b/internal/cmd/session/pipeline_wire.go
@@ -1,0 +1,27 @@
+package session
+
+import (
+	"github.com/Iron-Ham/claudio/internal/logging"
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/orchestrator/bridgewire"
+)
+
+// registerPipelineFactory registers a PipelineRunnerFactory on the given
+// Coordinator so that the Pipeline-based execution backend can be created
+// lazily when UsePipeline is enabled. See tui/pipeline_wire.go for the
+// equivalent TUI-side registration.
+func registerPipelineFactory(coordinator *orchestrator.Coordinator, orch *orchestrator.Orchestrator, logger *logging.Logger) {
+	coordinator.SetPipelineFactory(func(deps orchestrator.PipelineRunnerDeps) (orchestrator.ExecutionRunner, error) {
+		recorder := bridgewire.NewSessionRecorder(bridgewire.SessionRecorderDeps{})
+		return bridgewire.NewPipelineRunner(bridgewire.PipelineRunnerConfig{
+			Orch:        deps.Orch,
+			Session:     deps.Session,
+			Verifier:    deps.Verifier,
+			Plan:        deps.Plan,
+			Bus:         orch.EventBus(),
+			Logger:      logger,
+			Recorder:    recorder,
+			MaxParallel: deps.MaxParallel,
+		})
+	})
+}

--- a/internal/cmd/session/start.go
+++ b/internal/cmd/session/start.go
@@ -511,6 +511,9 @@ func resumeUltraplanSession(orch *orchestrator.Orchestrator, sess *orchestrator.
 	// Create coordinator from the loaded session state
 	coordinator := orchestrator.NewCoordinator(orch, sess, ultraSession, logger)
 
+	// Register pipeline factory for lazy PipelineRunner creation
+	registerPipelineFactory(coordinator, orch, logger)
+
 	// Resume based on current phase
 	switch ultraSession.Phase {
 	case orchestrator.PhasePlanning:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,6 +226,8 @@ type TripleshotConfig struct {
 	AutoApprove bool `mapstructure:"auto_approve"`
 	// Adversarial enables adversarial review mode where each implementer must pass review before completion (default: false)
 	Adversarial bool `mapstructure:"adversarial"`
+	// UseLegacy forces the legacy polling-based coordinator instead of team-based Orch 2.0 (default: false)
+	UseLegacy bool `mapstructure:"use_legacy"`
 }
 
 // AdversarialConfig controls adversarial review mode behavior.
@@ -471,6 +473,7 @@ func Default() *Config {
 		Tripleshot: TripleshotConfig{
 			AutoApprove: false,
 			Adversarial: false,
+			UseLegacy:   false,
 		},
 		Adversarial: AdversarialConfig{
 			MaxIterations:   10, // Reasonable default to prevent infinite loops
@@ -598,6 +601,7 @@ func SetDefaults() {
 	// Tripleshot defaults
 	viper.SetDefault("tripleshot.auto_approve", defaults.Tripleshot.AutoApprove)
 	viper.SetDefault("tripleshot.adversarial", defaults.Tripleshot.Adversarial)
+	viper.SetDefault("tripleshot.use_legacy", defaults.Tripleshot.UseLegacy)
 
 	// Adversarial defaults
 	viper.SetDefault("adversarial.max_iterations", defaults.Adversarial.MaxIterations)

--- a/internal/orchestrator/bridgewire/runner.go
+++ b/internal/orchestrator/bridgewire/runner.go
@@ -1,0 +1,193 @@
+package bridgewire
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Iron-Ham/claudio/internal/bridge"
+	"github.com/Iron-Ham/claudio/internal/event"
+	"github.com/Iron-Ham/claudio/internal/logging"
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/pipeline"
+	"github.com/Iron-Ham/claudio/internal/ultraplan"
+)
+
+// PipelineRunnerConfig holds the dependencies for constructing a PipelineRunner.
+type PipelineRunnerConfig struct {
+	Orch     *orchestrator.Orchestrator
+	Session  *orchestrator.Session
+	Verifier orchestrator.Verifier
+	Plan     *orchestrator.PlanSpec // orchestrator's PlanSpec (converted internally)
+	Bus      *event.Bus
+	Logger   *logging.Logger
+	Recorder bridge.SessionRecorder
+	BaseDir  string // Base directory for pipeline state files (defaults to Session.BaseRepo)
+
+	MaxParallel int // from UltraPlanConfig.MaxParallel
+}
+
+// PipelineRunner implements orchestrator.ExecutionRunner using the
+// Pipeline-based execution backend (Orchestration 2.0).
+//
+// It encapsulates the full lifecycle: plan conversion, pipeline creation,
+// decomposition, and PipelineExecutor wiring.
+type PipelineRunner struct {
+	pipe *pipeline.Pipeline
+	exec *PipelineExecutor
+}
+
+// NewPipelineRunner creates a PipelineRunner from the given config.
+// It converts the orchestrator PlanSpec to ultraplan.PlanSpec, creates the
+// Pipeline, decomposes the plan into teams, and wires a PipelineExecutor.
+func NewPipelineRunner(cfg PipelineRunnerConfig) (*PipelineRunner, error) {
+	if cfg.Plan == nil {
+		return nil, fmt.Errorf("bridgewire: PipelineRunner requires a non-nil Plan")
+	}
+	if cfg.Bus == nil {
+		return nil, fmt.Errorf("bridgewire: PipelineRunner requires a non-nil Bus")
+	}
+	if cfg.Orch == nil {
+		return nil, fmt.Errorf("bridgewire: PipelineRunner requires a non-nil Orch")
+	}
+	if cfg.Session == nil {
+		return nil, fmt.Errorf("bridgewire: PipelineRunner requires a non-nil Session")
+	}
+
+	// Convert orchestrator.PlanSpec → ultraplan.PlanSpec
+	uplan := convertPlan(cfg.Plan)
+
+	// Use explicit BaseDir if provided, otherwise fall back to Session.BaseRepo
+	baseDir := cfg.BaseDir
+	if baseDir == "" {
+		baseDir = cfg.Session.BaseRepo
+	}
+
+	// Create the pipeline
+	pipe, err := pipeline.NewPipeline(pipeline.PipelineConfig{
+		Bus:     cfg.Bus,
+		BaseDir: baseDir,
+		Plan:    uplan,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("bridgewire: create pipeline: %w", err)
+	}
+
+	// Decompose the plan into execution teams only (no planning/review/consolidation
+	// phases — those are handled by the Coordinator's existing methods).
+	maxPar := cfg.MaxParallel
+	if maxPar < 1 {
+		maxPar = 3
+	}
+
+	_, err = pipe.Decompose(pipeline.DecomposeConfig{
+		DefaultTeamSize:  maxPar,
+		MinTeamInstances: 1,
+		MaxTeamInstances: maxPar,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("bridgewire: decompose plan: %w", err)
+	}
+
+	// Create the PipelineExecutor
+	logger := cfg.Logger
+	if logger == nil {
+		logger = logging.NopLogger()
+	}
+
+	exec, err := NewPipelineExecutorFromOrch(
+		cfg.Orch, cfg.Session, cfg.Verifier,
+		cfg.Bus, pipe, cfg.Recorder, logger,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("bridgewire: create executor: %w", err)
+	}
+
+	return &PipelineRunner{
+		pipe: pipe,
+		exec: exec,
+	}, nil
+}
+
+// Start begins execution: starts the executor (which subscribes to pipeline
+// phase events and creates bridges) then starts the pipeline itself.
+func (r *PipelineRunner) Start(ctx context.Context) error {
+	if err := r.exec.Start(ctx); err != nil {
+		return fmt.Errorf("bridgewire: start executor: %w", err)
+	}
+	if err := r.pipe.Start(ctx); err != nil {
+		r.exec.Stop()
+		return fmt.Errorf("bridgewire: start pipeline: %w", err)
+	}
+	return nil
+}
+
+// Stop tears down both the executor and pipeline.
+func (r *PipelineRunner) Stop() {
+	r.exec.Stop()
+	_ = r.pipe.Stop()
+}
+
+// convertPlan converts an orchestrator.PlanSpec to an ultraplan.PlanSpec.
+// The two types have identical shapes (by design) so this is a field-by-field copy.
+func convertPlan(src *orchestrator.PlanSpec) *ultraplan.PlanSpec {
+	tasks := make([]ultraplan.PlannedTask, len(src.Tasks))
+	for i, t := range src.Tasks {
+		var files []string
+		if len(t.Files) > 0 {
+			files = make([]string, len(t.Files))
+			copy(files, t.Files)
+		}
+		var deps []string
+		if len(t.DependsOn) > 0 {
+			deps = make([]string, len(t.DependsOn))
+			copy(deps, t.DependsOn)
+		}
+		tasks[i] = ultraplan.PlannedTask{
+			ID:            t.ID,
+			Title:         t.Title,
+			Description:   t.Description,
+			Files:         files,
+			DependsOn:     deps,
+			Priority:      t.Priority,
+			EstComplexity: ultraplan.TaskComplexity(t.EstComplexity),
+			IssueURL:      t.IssueURL,
+			NoCode:        t.NoCode,
+		}
+	}
+
+	depGraph := make(map[string][]string, len(src.DependencyGraph))
+	for k, v := range src.DependencyGraph {
+		cp := make([]string, len(v))
+		copy(cp, v)
+		depGraph[k] = cp
+	}
+
+	execOrder := make([][]string, len(src.ExecutionOrder))
+	for i, group := range src.ExecutionOrder {
+		execOrder[i] = make([]string, len(group))
+		copy(execOrder[i], group)
+	}
+
+	var insights []string
+	if len(src.Insights) > 0 {
+		insights = make([]string, len(src.Insights))
+		copy(insights, src.Insights)
+	}
+	var constraints []string
+	if len(src.Constraints) > 0 {
+		constraints = make([]string, len(src.Constraints))
+		copy(constraints, src.Constraints)
+	}
+
+	return &ultraplan.PlanSpec{
+		ID:              src.ID,
+		Objective:       src.Objective,
+		Summary:         src.Summary,
+		Tasks:           tasks,
+		DependencyGraph: depGraph,
+		ExecutionOrder:  execOrder,
+		Insights:        insights,
+		Constraints:     constraints,
+		CreatedAt:       src.CreatedAt,
+	}
+}

--- a/internal/orchestrator/bridgewire/runner_test.go
+++ b/internal/orchestrator/bridgewire/runner_test.go
@@ -1,0 +1,324 @@
+package bridgewire
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Iron-Ham/claudio/internal/event"
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/ultraplan"
+)
+
+func TestConvertPlan(t *testing.T) {
+	t.Run("converts all fields", func(t *testing.T) {
+		src := &orchestrator.PlanSpec{
+			ID:        "plan-1",
+			Objective: "build feature X",
+			Summary:   "three tasks",
+			Tasks: []orchestrator.PlannedTask{
+				{
+					ID:            "t1",
+					Title:         "task one",
+					Description:   "do thing one",
+					Files:         []string{"a.go", "b.go"},
+					DependsOn:     nil,
+					Priority:      1,
+					EstComplexity: orchestrator.ComplexityLow,
+					IssueURL:      "https://example.com/1",
+					NoCode:        false,
+				},
+				{
+					ID:            "t2",
+					Title:         "task two",
+					Description:   "do thing two",
+					Files:         []string{"c.go"},
+					DependsOn:     []string{"t1"},
+					Priority:      2,
+					EstComplexity: orchestrator.ComplexityHigh,
+					NoCode:        true,
+				},
+			},
+			DependencyGraph: map[string][]string{
+				"t2": {"t1"},
+			},
+			ExecutionOrder: [][]string{{"t1"}, {"t2"}},
+			Insights:       []string{"insight 1"},
+			Constraints:    []string{"constraint 1"},
+			CreatedAt:      time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		}
+
+		got := convertPlan(src)
+
+		if got.ID != "plan-1" {
+			t.Errorf("ID = %q, want %q", got.ID, "plan-1")
+		}
+		if got.Objective != "build feature X" {
+			t.Errorf("Objective = %q, want %q", got.Objective, "build feature X")
+		}
+		if got.Summary != "three tasks" {
+			t.Errorf("Summary = %q, want %q", got.Summary, "three tasks")
+		}
+		if len(got.Tasks) != 2 {
+			t.Fatalf("Tasks len = %d, want 2", len(got.Tasks))
+		}
+
+		task1 := got.Tasks[0]
+		if task1.ID != "t1" {
+			t.Errorf("Tasks[0].ID = %q, want %q", task1.ID, "t1")
+		}
+		if task1.Title != "task one" {
+			t.Errorf("Tasks[0].Title = %q, want %q", task1.Title, "task one")
+		}
+		if task1.EstComplexity != ultraplan.TaskComplexity("low") {
+			t.Errorf("Tasks[0].EstComplexity = %q, want %q", task1.EstComplexity, "low")
+		}
+		if task1.IssueURL != "https://example.com/1" {
+			t.Errorf("Tasks[0].IssueURL = %q, want %q", task1.IssueURL, "https://example.com/1")
+		}
+		if task1.NoCode {
+			t.Error("Tasks[0].NoCode = true, want false")
+		}
+		if len(task1.Files) != 2 {
+			t.Errorf("Tasks[0].Files len = %d, want 2", len(task1.Files))
+		}
+
+		task2 := got.Tasks[1]
+		if task2.ID != "t2" {
+			t.Errorf("Tasks[1].ID = %q, want %q", task2.ID, "t2")
+		}
+		if !task2.NoCode {
+			t.Error("Tasks[1].NoCode = false, want true")
+		}
+		if len(task2.DependsOn) != 1 || task2.DependsOn[0] != "t1" {
+			t.Errorf("Tasks[1].DependsOn = %v, want [t1]", task2.DependsOn)
+		}
+
+		// Dependency graph
+		if deps, ok := got.DependencyGraph["t2"]; !ok || len(deps) != 1 || deps[0] != "t1" {
+			t.Errorf("DependencyGraph[t2] = %v, want [t1]", got.DependencyGraph["t2"])
+		}
+
+		// Execution order
+		if len(got.ExecutionOrder) != 2 {
+			t.Fatalf("ExecutionOrder len = %d, want 2", len(got.ExecutionOrder))
+		}
+		if len(got.ExecutionOrder[0]) != 1 || got.ExecutionOrder[0][0] != "t1" {
+			t.Errorf("ExecutionOrder[0] = %v, want [t1]", got.ExecutionOrder[0])
+		}
+
+		if len(got.Insights) != 1 || got.Insights[0] != "insight 1" {
+			t.Errorf("Insights = %v, want [insight 1]", got.Insights)
+		}
+		if len(got.Constraints) != 1 || got.Constraints[0] != "constraint 1" {
+			t.Errorf("Constraints = %v, want [constraint 1]", got.Constraints)
+		}
+		if !got.CreatedAt.Equal(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)) {
+			t.Errorf("CreatedAt = %v, want 2025-01-01", got.CreatedAt)
+		}
+	})
+
+	t.Run("handles empty plan", func(t *testing.T) {
+		src := &orchestrator.PlanSpec{
+			ID: "empty",
+		}
+		got := convertPlan(src)
+		if got.ID != "empty" {
+			t.Errorf("ID = %q, want %q", got.ID, "empty")
+		}
+		if len(got.Tasks) != 0 {
+			t.Errorf("Tasks len = %d, want 0", len(got.Tasks))
+		}
+	})
+
+	t.Run("deep copies slices", func(t *testing.T) {
+		src := &orchestrator.PlanSpec{
+			ID:             "copy-test",
+			ExecutionOrder: [][]string{{"t1", "t2"}},
+			Tasks: []orchestrator.PlannedTask{
+				{ID: "t1", Files: []string{"a.go"}},
+			},
+		}
+		got := convertPlan(src)
+
+		// Mutating source should not affect converted plan
+		src.ExecutionOrder[0][0] = "mutated"
+		if got.ExecutionOrder[0][0] != "t1" {
+			t.Error("convertPlan did not deep copy ExecutionOrder")
+		}
+
+		src.Tasks[0].Files[0] = "mutated.go"
+		if got.Tasks[0].Files[0] != "a.go" {
+			t.Error("convertPlan did not deep copy Files")
+		}
+	})
+}
+
+func TestNewPipelineRunner_Validation(t *testing.T) {
+	t.Run("nil plan", func(t *testing.T) {
+		_, err := NewPipelineRunner(PipelineRunnerConfig{
+			Orch:    &orchestrator.Orchestrator{},
+			Session: &orchestrator.Session{},
+			Bus:     event.NewBus(),
+		})
+		if err == nil {
+			t.Fatal("expected error for nil Plan")
+		}
+	})
+
+	t.Run("nil bus", func(t *testing.T) {
+		_, err := NewPipelineRunner(PipelineRunnerConfig{
+			Orch:    &orchestrator.Orchestrator{},
+			Session: &orchestrator.Session{},
+			Plan:    &orchestrator.PlanSpec{ID: "p1"},
+		})
+		if err == nil {
+			t.Fatal("expected error for nil Bus")
+		}
+	})
+
+	t.Run("nil orch", func(t *testing.T) {
+		_, err := NewPipelineRunner(PipelineRunnerConfig{
+			Session: &orchestrator.Session{},
+			Plan:    &orchestrator.PlanSpec{ID: "p1"},
+			Bus:     event.NewBus(),
+		})
+		if err == nil {
+			t.Fatal("expected error for nil Orch")
+		}
+	})
+
+	t.Run("nil session", func(t *testing.T) {
+		_, err := NewPipelineRunner(PipelineRunnerConfig{
+			Orch: &orchestrator.Orchestrator{},
+			Plan: &orchestrator.PlanSpec{ID: "p1"},
+			Bus:  event.NewBus(),
+		})
+		if err == nil {
+			t.Fatal("expected error for nil Session")
+		}
+	})
+}
+
+func TestNewPipelineRunner_CreatesSuccessfully(t *testing.T) {
+	bus := event.NewBus()
+	plan := &orchestrator.PlanSpec{
+		ID:        "plan-1",
+		Objective: "test",
+		Tasks: []orchestrator.PlannedTask{
+			{ID: "t1", Title: "task one", Description: "do it"},
+		},
+		ExecutionOrder: [][]string{{"t1"}},
+	}
+
+	runner, err := NewPipelineRunner(PipelineRunnerConfig{
+		Orch:        &orchestrator.Orchestrator{},
+		Session:     &orchestrator.Session{BaseRepo: t.TempDir()},
+		Plan:        plan,
+		Bus:         bus,
+		MaxParallel: 2,
+	})
+	if err != nil {
+		t.Fatalf("NewPipelineRunner() error = %v", err)
+	}
+	if runner == nil {
+		t.Fatal("NewPipelineRunner() returned nil")
+	}
+	if runner.pipe == nil {
+		t.Fatal("runner.pipe is nil")
+	}
+	if runner.exec == nil {
+		t.Fatal("runner.exec is nil")
+	}
+}
+
+func TestPipelineRunner_StopBeforeStart(t *testing.T) {
+	bus := event.NewBus()
+	plan := &orchestrator.PlanSpec{
+		ID:             "plan-1",
+		Tasks:          []orchestrator.PlannedTask{{ID: "t1", Title: "task", Description: "d"}},
+		ExecutionOrder: [][]string{{"t1"}},
+	}
+	runner, err := NewPipelineRunner(PipelineRunnerConfig{
+		Orch:        &orchestrator.Orchestrator{},
+		Session:     &orchestrator.Session{BaseRepo: t.TempDir()},
+		Plan:        plan,
+		Bus:         bus,
+		MaxParallel: 1,
+	})
+	if err != nil {
+		t.Fatalf("NewPipelineRunner() error = %v", err)
+	}
+
+	// Stop without Start should not panic
+	runner.Stop()
+}
+
+func TestPipelineRunner_MaxParallelDefault(t *testing.T) {
+	bus := event.NewBus()
+	plan := &orchestrator.PlanSpec{
+		ID:             "plan-1",
+		Tasks:          []orchestrator.PlannedTask{{ID: "t1", Title: "task", Description: "d"}},
+		ExecutionOrder: [][]string{{"t1"}},
+	}
+
+	// MaxParallel=0 should default to 3 internally
+	runner, err := NewPipelineRunner(PipelineRunnerConfig{
+		Orch:        &orchestrator.Orchestrator{},
+		Session:     &orchestrator.Session{BaseRepo: t.TempDir()},
+		Plan:        plan,
+		Bus:         bus,
+		MaxParallel: 0,
+	})
+	if err != nil {
+		t.Fatalf("NewPipelineRunner() error = %v", err)
+	}
+	if runner == nil {
+		t.Fatal("runner is nil")
+	}
+}
+
+func TestPipelineRunner_ImplementsExecutionRunner(t *testing.T) {
+	// Compile-time check that PipelineRunner satisfies ExecutionRunner.
+	var _ orchestrator.ExecutionRunner = (*PipelineRunner)(nil)
+}
+
+func TestPipelineRunner_StartCtxCancel(t *testing.T) {
+	bus := event.NewBus()
+	plan := &orchestrator.PlanSpec{
+		ID:             "plan-1",
+		Tasks:          []orchestrator.PlannedTask{{ID: "t1", Title: "task", Description: "d"}},
+		ExecutionOrder: [][]string{{"t1"}},
+	}
+	runner, err := NewPipelineRunner(PipelineRunnerConfig{
+		Orch:        &orchestrator.Orchestrator{},
+		Session:     &orchestrator.Session{BaseRepo: t.TempDir()},
+		Plan:        plan,
+		Bus:         bus,
+		MaxParallel: 1,
+	})
+	if err != nil {
+		t.Fatalf("NewPipelineRunner() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := runner.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	// Cancel context and stop
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		runner.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// success
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop() did not return within 5s")
+	}
+}

--- a/internal/orchestrator/ultraplan.go
+++ b/internal/orchestrator/ultraplan.go
@@ -182,6 +182,9 @@ type UltraPlanConfig struct {
 	// Task verification settings
 	MaxTaskRetries         int  `json:"max_task_retries,omitempty"` // Max retry attempts for tasks with no commits (default: 3)
 	RequireVerifiedCommits bool `json:"require_verified_commits"`   // If true, tasks must produce commits to be marked successful (default: true)
+
+	// Pipeline-based execution (Orchestration 2.0)
+	UsePipeline bool `json:"use_pipeline,omitempty"` // Use Pipeline-based execution instead of legacy ExecutionOrchestrator
 }
 
 // DefaultUltraPlanConfig returns the default configuration
@@ -199,6 +202,7 @@ func DefaultUltraPlanConfig() UltraPlanConfig {
 		BranchPrefix:           "", // Uses config.Branch.Prefix if empty
 		MaxTaskRetries:         3,
 		RequireVerifiedCommits: true,
+		UsePipeline:            true, // Default to Orchestration 2.0 pipeline execution
 	}
 }
 

--- a/internal/orchestrator/workflow_adapters.go
+++ b/internal/orchestrator/workflow_adapters.go
@@ -233,6 +233,14 @@ func NewTripleShotCoordinator(orch *Orchestrator, session *Session, tripleSessio
 	return tripleshot.NewCoordinator(cfg)
 }
 
+// NewTripleShotAdapters returns the orchestrator and session adapters needed to construct
+// a teamwire.TeamCoordinatorConfig from outside the orchestrator package. This avoids
+// exporting the adapter types themselves while still allowing the TUI to create teamwire
+// coordinators without an import cycle.
+func NewTripleShotAdapters(orch *Orchestrator, session *Session) (tripleshot.OrchestratorInterface, tripleshot.SessionInterface) {
+	return &orchestratorAdapter{orch: orch}, &sessionAdapter{session: session}
+}
+
 // adversarialOrchestratorAdapter implements adversarial.OrchestratorInterface
 type adversarialOrchestratorAdapter struct {
 	orch *Orchestrator

--- a/internal/orchestrator/workflows/tripleshot/runner.go
+++ b/internal/orchestrator/workflows/tripleshot/runner.go
@@ -1,0 +1,11 @@
+package tripleshot
+
+// Runner is the common interface satisfied by both *Coordinator (legacy polling)
+// and *teamwire.TeamCoordinator (Orch 2.0 callback-driven). The TUI uses this
+// interface so it can work with either execution path without type assertions.
+type Runner interface {
+	Session() *Session
+	SetCallbacks(cb *CoordinatorCallbacks)
+	GetWinningBranch() string
+	Stop()
+}

--- a/internal/tui/command/handler.go
+++ b/internal/tui/command/handler.go
@@ -39,7 +39,7 @@ type Dependencies interface {
 	IsTripleShotMode() bool
 	IsAdversarialMode() bool
 	GetUltraPlanCoordinator() *orchestrator.Coordinator
-	GetTripleShotCoordinators() []*tripleshot.Coordinator // Returns all active tripleshot coordinators
+	GetTripleShotRunners() []tripleshot.Runner // Returns all active tripleshot runners
 
 	// Logger access
 	GetLogger() *logging.Logger

--- a/internal/tui/command/handler_test.go
+++ b/internal/tui/command/handler_test.go
@@ -68,9 +68,9 @@ func (m *mockDeps) IsAdversarialMode() bool                     { return m.adver
 func (m *mockDeps) GetUltraPlanCoordinator() *orchestrator.Coordinator {
 	return m.ultraCoordinator
 }
-func (m *mockDeps) GetTripleShotCoordinators() []*tripleshot.Coordinator {
+func (m *mockDeps) GetTripleShotRunners() []tripleshot.Runner {
 	if m.tripleShotCoordinator != nil {
-		return []*tripleshot.Coordinator{m.tripleShotCoordinator}
+		return []tripleshot.Runner{m.tripleShotCoordinator}
 	}
 	return nil
 }

--- a/internal/tui/config/config.go
+++ b/internal/tui/config/config.go
@@ -487,6 +487,13 @@ func New() Model {
 					Type:        "bool",
 					Category:    "tripleshot",
 				},
+				{
+					Key:         "tripleshot.use_legacy",
+					Label:       "Use Legacy Coordinator",
+					Description: "Force the legacy polling coordinator instead of teamwire",
+					Type:        "bool",
+					Category:    "tripleshot",
+				},
 			},
 		},
 		{
@@ -1278,6 +1285,7 @@ func (m *Model) resetCurrentToDefault() {
 		// Tripleshot
 		"tripleshot.auto_approve": defaults.Tripleshot.AutoApprove,
 		"tripleshot.adversarial":  defaults.Tripleshot.Adversarial,
+		"tripleshot.use_legacy":   defaults.Tripleshot.UseLegacy,
 		// Adversarial
 		"adversarial.max_iterations":    defaults.Adversarial.MaxIterations,
 		"adversarial.min_passing_score": defaults.Adversarial.MinPassingScore,

--- a/internal/tui/inlineplan.go
+++ b/internal/tui/inlineplan.go
@@ -157,6 +157,8 @@ func (m *Model) initInlineUltraPlanMode(result command.Result) {
 		// Auto-enable grouped sidebar mode
 		m.autoEnableGroupedMode()
 
+		registerPipelineFactory(coordinator, m.orchestrator, m.logger)
+
 		m.ultraPlan = &view.UltraPlanState{
 			Coordinator:           coordinator,
 			ShowPlanView:          false,
@@ -202,6 +204,8 @@ func (m *Model) initInlineUltraPlanMode(result command.Result) {
 			m.errorMessage = fmt.Sprintf("Failed to start planning: %v", err)
 			return
 		}
+
+		registerPipelineFactory(coordinator, m.orchestrator, m.logger)
 
 		m.ultraPlan = &view.UltraPlanState{
 			Coordinator:           coordinator,
@@ -896,6 +900,8 @@ func (m *Model) handleUltraPlanObjectiveSubmit(objective string) {
 		m.errorMessage = fmt.Sprintf("Failed to start planning: %v", err)
 		return
 	}
+
+	registerPipelineFactory(coordinator, m.orchestrator, m.logger)
 
 	m.ultraPlan = &view.UltraPlanState{
 		Coordinator:           coordinator,

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Iron-Ham/claudio/internal/tui/search"
 	"github.com/Iron-Ham/claudio/internal/tui/terminal"
 	"github.com/Iron-Ham/claudio/internal/tui/view"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 // Sidebar layout constants for scroll calculations.
@@ -270,6 +271,10 @@ type Model struct {
 
 	// Triple-shot mode (nil if not in triple-shot mode)
 	tripleShot *TripleShotState
+
+	// teamwireEventCh receives Bubble Tea messages from teamwire callbacks.
+	// Nil when not using the teamwire execution path.
+	teamwireEventCh chan tea.Msg
 
 	// Pipeline orchestration state (nil until first pipeline event)
 	pipeline *view.PipelineState
@@ -1394,12 +1399,12 @@ func (m Model) GetUltraPlanCoordinator() *orchestrator.Coordinator {
 	return m.ultraPlan.Coordinator
 }
 
-// GetTripleShotCoordinators returns all active tripleshot coordinators.
-func (m Model) GetTripleShotCoordinators() []*tripleshot.Coordinator {
+// GetTripleShotRunners returns all active tripleshot runners.
+func (m Model) GetTripleShotRunners() []tripleshot.Runner {
 	if m.tripleShot == nil {
 		return nil
 	}
-	return m.tripleShot.GetAllCoordinators()
+	return m.tripleShot.GetAllRunners()
 }
 
 // GetLogger returns the logger instance.
@@ -1417,9 +1422,9 @@ func (m Model) IsInstanceTripleShotJudge(instanceID string) bool {
 	if m.tripleShot == nil {
 		return false
 	}
-	// Check all coordinators in the map
-	for _, coord := range m.tripleShot.Coordinators {
-		session := coord.Session()
+	// Check all runners in the map
+	for _, runner := range m.tripleShot.Runners {
+		session := runner.Session()
 		if session != nil && session.JudgeID == instanceID {
 			return true
 		}

--- a/internal/tui/msg/commands.go
+++ b/internal/tui/msg/commands.go
@@ -745,6 +745,20 @@ func CheckAdversarialInstanceStuckAsync(
 	}
 }
 
+// ListenTeamwireEvents returns a command that reads one message from the
+// teamwire callback channel. Each handler that receives a teamwire message
+// should return another ListenTeamwireEvents to keep the subscription alive.
+// When the channel is closed, a TeamwireChannelClosedMsg is returned.
+func ListenTeamwireEvents(ch <-chan tea.Msg) tea.Cmd {
+	return func() tea.Msg {
+		msg, ok := <-ch
+		if !ok {
+			return TeamwireChannelClosedMsg{}
+		}
+		return msg
+	}
+}
+
 // RestartAdversarialStuckRoleAsync restarts the stuck role in an adversarial session.
 func RestartAdversarialStuckRoleAsync(
 	coordinator *adversarial.Coordinator,

--- a/internal/tui/msg/types.go
+++ b/internal/tui/msg/types.go
@@ -349,3 +349,49 @@ type BridgeTaskActivityMsg struct {
 	Started    bool // true = task started, false = task completed
 	Success    bool // only meaningful when Started is false
 }
+
+// --- Teamwire callback bridge messages ---
+// These messages are produced by teamwire.TeamCoordinator callbacks and delivered
+// to the Bubble Tea event loop via a buffered channel (see ListenTeamwireEvents).
+
+// TeamwirePhaseChangedMsg signals a phase change in the teamwire coordinator.
+type TeamwirePhaseChangedMsg struct {
+	GroupID string
+	Phase   tripleshot.Phase
+}
+
+// TeamwireAttemptStartedMsg signals that a teamwire attempt has started.
+type TeamwireAttemptStartedMsg struct {
+	GroupID      string
+	AttemptIndex int
+	InstanceID   string
+}
+
+// TeamwireAttemptCompletedMsg signals that a teamwire attempt has completed.
+type TeamwireAttemptCompletedMsg struct {
+	GroupID      string
+	AttemptIndex int
+}
+
+// TeamwireAttemptFailedMsg signals that a teamwire attempt has failed.
+type TeamwireAttemptFailedMsg struct {
+	GroupID      string
+	AttemptIndex int
+	Reason       string
+}
+
+// TeamwireJudgeStartedMsg signals that the teamwire judge has started.
+type TeamwireJudgeStartedMsg struct {
+	GroupID    string
+	InstanceID string
+}
+
+// TeamwireCompletedMsg signals that the teamwire triple-shot has completed.
+type TeamwireCompletedMsg struct {
+	GroupID string
+	Success bool
+	Summary string
+}
+
+// TeamwireChannelClosedMsg signals that the teamwire event channel has been closed.
+type TeamwireChannelClosedMsg struct{}

--- a/internal/tui/pipeline_wire.go
+++ b/internal/tui/pipeline_wire.go
@@ -1,0 +1,28 @@
+package tui
+
+import (
+	"github.com/Iron-Ham/claudio/internal/logging"
+	"github.com/Iron-Ham/claudio/internal/orchestrator"
+	"github.com/Iron-Ham/claudio/internal/orchestrator/bridgewire"
+)
+
+// registerPipelineFactory registers a PipelineRunnerFactory on the given
+// Coordinator. When UsePipeline is enabled in the config, the factory is
+// called lazily on the first StartExecution() call. This function exists in
+// the TUI package because it is the only layer that can import both
+// orchestrator and bridgewire without creating an import cycle.
+func registerPipelineFactory(coordinator *orchestrator.Coordinator, orch *orchestrator.Orchestrator, logger *logging.Logger) {
+	coordinator.SetPipelineFactory(func(deps orchestrator.PipelineRunnerDeps) (orchestrator.ExecutionRunner, error) {
+		recorder := bridgewire.NewSessionRecorder(bridgewire.SessionRecorderDeps{})
+		return bridgewire.NewPipelineRunner(bridgewire.PipelineRunnerConfig{
+			Orch:        deps.Orch,
+			Session:     deps.Session,
+			Verifier:    deps.Verifier,
+			Plan:        deps.Plan,
+			Bus:         orch.EventBus(),
+			Logger:      logger,
+			Recorder:    recorder,
+			MaxParallel: deps.MaxParallel,
+		})
+	})
+}

--- a/internal/tui/view/workflow_status.go
+++ b/internal/tui/view/workflow_status.go
@@ -154,8 +154,8 @@ func (s *WorkflowStatusState) getTripleShotIndicator() *WorkflowIndicator {
 		return nil
 	}
 
-	coordinators := s.TripleShot.GetAllCoordinators()
-	if len(coordinators) == 0 {
+	runners := s.TripleShot.GetAllRunners()
+	if len(runners) == 0 {
 		return nil
 	}
 
@@ -165,8 +165,8 @@ func (s *WorkflowStatusState) getTripleShotIndicator() *WorkflowIndicator {
 	complete := 0
 	failed := 0
 
-	for _, coord := range coordinators {
-		session := coord.Session()
+	for _, runner := range runners {
+		session := runner.Session()
 		if session == nil {
 			continue
 		}
@@ -186,10 +186,10 @@ func (s *WorkflowStatusState) getTripleShotIndicator() *WorkflowIndicator {
 	var label string
 	var style lipgloss.Style
 
-	total := len(coordinators)
+	total := len(runners)
 	if total == 1 {
 		// Single session - show detailed phase
-		session := coordinators[0].Session()
+		session := runners[0].Session()
 		if session == nil {
 			return nil
 		}

--- a/internal/tui/view/workflow_status_test.go
+++ b/internal/tui/view/workflow_status_test.go
@@ -37,8 +37,8 @@ func TestWorkflowStatusState_HasActiveWorkflows(t *testing.T) {
 			name: "tripleshot active returns true",
 			state: &WorkflowStatusState{
 				TripleShot: &TripleShotState{
-					Coordinators: map[string]*tripleshot.Coordinator{
-						"group1": {},
+					Runners: map[string]tripleshot.Runner{
+						"group1": createMockTripleShotCoordinator(),
 					},
 				},
 			},
@@ -59,8 +59,8 @@ func TestWorkflowStatusState_HasActiveWorkflows(t *testing.T) {
 			name: "tripleshot and adversarial active returns true",
 			state: &WorkflowStatusState{
 				TripleShot: &TripleShotState{
-					Coordinators: map[string]*tripleshot.Coordinator{
-						"group1": {},
+					Runners: map[string]tripleshot.Runner{
+						"group1": createMockTripleShotCoordinator(),
 					},
 				},
 				Adversarial: &AdversarialState{
@@ -365,13 +365,13 @@ func TestWorkflowStatusView_Render(t *testing.T) {
 // Helper functions to create mock states for testing
 
 func createMockTripleShotState(count int) *TripleShotState {
-	coordinators := make(map[string]*tripleshot.Coordinator)
+	runners := make(map[string]tripleshot.Runner)
 	for i := 0; i < count; i++ {
 		groupID := string(rune('a' + i))
-		coordinators[groupID] = createMockTripleShotCoordinator()
+		runners[groupID] = createMockTripleShotCoordinator()
 	}
 	return &TripleShotState{
-		Coordinators: coordinators,
+		Runners: runners,
 	}
 }
 
@@ -748,14 +748,14 @@ func TestTripleShotIndicator_MixedPhaseAggregation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			coordinators := make(map[string]*tripleshot.Coordinator)
+			runners := make(map[string]tripleshot.Runner)
 			for i, phase := range tt.phases {
 				groupID := string(rune('a' + i))
-				coordinators[groupID] = createMockTripleShotCoordinatorWithPhase(phase)
+				runners[groupID] = createMockTripleShotCoordinatorWithPhase(phase)
 			}
 			state := &WorkflowStatusState{
 				TripleShot: &TripleShotState{
-					Coordinators: coordinators,
+					Runners: runners,
 				},
 			}
 


### PR DESCRIPTION
## Summary

- **UltraPlan**: Flips `UsePipeline` default to `true`, routing plan execution through the Orch 2.0 pipeline backend (Pipeline → team.Manager → Bridge) instead of the legacy `ExecutionOrchestrator`. Adds `ExecutionRunner` interface with factory-based injection to break import cycles.
- **TripleShot**: Wires `teamwire.TeamCoordinator` as the default execution path, replacing file-based polling with callback-driven execution via a buffered channel bridge into Bubble Tea. Falls back to legacy for adversarial mode or when `tripleshot.use_legacy` config is set.
- **Shared infrastructure**: Adds `tripleshot.Runner` interface for dual-coordinator coexistence, `NewTripleShotAdapters()` factory for cycle-safe adapter creation, `pipeline_wire.go` wiring files for lazy `PipelineRunner` instantiation, and 7 new Bubble Tea message types for teamwire events.
- **Bug fixes from deep review**: Fixed channel close panic (nil-guard), goroutine leak (stop re-subscribing after completion), channel overwrite leak (close old channel), silent `SaveSession()` errors (now logged), generic error messages (improved context), and missing session error details in `PhaseFailed` handler.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes  
- [ ] `gofmt -d .` shows no output
- [ ] `go test -race ./internal/orchestrator/...` passes (coordinator pipeline path tests)
- [ ] `go test -race ./internal/tui/...` passes (view type changes, handler tests)
- [ ] `go test -race ./internal/orchestrator/workflows/tripleshot/teamwire/...` passes
- [ ] Manual: start a session with `UsePipeline: true` → verify pipeline executes
- [ ] Manual: start a tripleshot → verify teamwire callbacks drive the UI
- [ ] Manual: start an adversarial tripleshot → verify legacy fallback
- [ ] Manual: set `tripleshot.use_legacy: true` → verify legacy path