### PR TITLE
Fix TUI freeze when starting teamwire triple-shot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Teamwire TUI Freeze** - Fixed TUI freeze when starting a triple-shot in teamwire mode. `coordinator.Start()` was called synchronously in the Bubble Tea `Update()` handler, blocking the event loop while bridges created git worktrees. Moved startup to an async `tea.Cmd` so the UI remains responsive during initialization.
+
 - **Teamwire Channel Safety** - Fixed potential panic from closing `teamwireEventCh` while callbacks may still write to it (nil-guard before close), goroutine leak from re-subscribing after triple-shot completion, and channel overwrite leak when starting multiple sessions. Surfaced session error details in `PhaseFailed` handler instead of generic "Triple-shot failed" message.
 
 - **Pipeline SaveSession Error Logging** - Replaced silent `_ = SaveSession()` calls in `onPipelineCompleted` and `Cancel()` with logged errors, preventing session state loss from going undetected. Improved pipeline factory error message for user-facing context.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -783,6 +783,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleTeamwireCompleted(msg)
 	case tuimsg.TeamwireChannelClosedMsg:
 		return m.handleTeamwireChannelClosed()
+	case tuimsg.TeamwireStartResultMsg:
+		return m.handleTeamwireStartResult(msg)
 
 	case tuimsg.PlanFileCheckResultMsg:
 		// Handle async plan file check result (single-pass mode)

--- a/internal/tui/msg/types.go
+++ b/internal/tui/msg/types.go
@@ -395,3 +395,11 @@ type TeamwireCompletedMsg struct {
 
 // TeamwireChannelClosedMsg signals that the teamwire event channel has been closed.
 type TeamwireChannelClosedMsg struct{}
+
+// TeamwireStartResultMsg signals whether the teamwire coordinator started
+// successfully. Used to make coordinator startup asynchronous so it does not
+// block the TUI event loop.
+type TeamwireStartResultMsg struct {
+	GroupID string
+	Err     error
+}

--- a/internal/tui/msg/types_test.go
+++ b/internal/tui/msg/types_test.go
@@ -899,3 +899,38 @@ func TestDiffLoadedMsg(t *testing.T) {
 		})
 	}
 }
+
+func TestTeamwireStartResultMsg(t *testing.T) {
+	tests := []struct {
+		name    string
+		groupID string
+		err     error
+	}{
+		{
+			name:    "successful start",
+			groupID: "group-1",
+			err:     nil,
+		},
+		{
+			name:    "failed start",
+			groupID: "group-2",
+			err:     errors.New("bridge start failed"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := TeamwireStartResultMsg{
+				GroupID: tt.groupID,
+				Err:     tt.err,
+			}
+
+			if msg.GroupID != tt.groupID {
+				t.Errorf("GroupID = %q, want %q", msg.GroupID, tt.groupID)
+			}
+			if msg.Err != tt.err {
+				t.Errorf("Err = %v, want %v", msg.Err, tt.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Moved `coordinator.Start()` from synchronous Bubble Tea `Update()` handler into an async `tea.Cmd` to prevent blocking the event loop during I/O-heavy git worktree creation
- Added `TeamwireStartResultMsg` for async error/success signaling back to the TUI
- Added `handleTeamwireStartResult` handler for cleanup on startup failure (calls `Stop()`, removes from runners map, cleans up event channel)

## Test plan
- [x] All 93 existing tests pass with `-race`
- [x] New `TeamwireStartResultMsg` struct test added
- [x] Verified `Stop()` is safe when coordinator never fully started (checked `tc.started` flag guard)
- [x] Verified channel close safety (Stop unsubscribes from event bus before returning, preventing callback races)